### PR TITLE
Bug fixes

### DIFF
--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -295,17 +295,16 @@ contract Zap {
         ZapStorage.Details[5] memory a = zap.currentMiners;
 
         address vaultAddress = zap.addressVars[keccak256('_vault')];
+        require (minerReward != address(0));
         Vault vault = Vault(vaultAddress);
 
         uint256 minerReward = zap.uintVars[keccak256('currentMinerReward')];
 
-        if (minerReward != 0){
-            for (uint256 i = 0; i < 5; i++) {
-                if (a[i].miner != address(0)){
-                    token.approve(address(this), minerReward);
-                    token.transferFrom(address(this), address(vault), minerReward);
-                    vault.deposit(a[i].miner, minerReward);
-                }
+        for (uint256 i = 0; i < 5; i++) {
+            if (a[i].miner != address(0)){
+                token.approve(address(this), minerReward);
+                token.transferFrom(address(this), address(vault), minerReward);
+                vault.deposit(a[i].miner, minerReward);
             }
         }
 
@@ -326,6 +325,7 @@ contract Zap {
         
         // EXPERIMENTAL, needs to be tested
         address vaultAddress = zap.addressVars[keccak256('_vault')];
+        require(vaultAddress != address(0));
         Vault vault = Vault(vaultAddress);
 
         token.approve(address(this), stakeAmount);
@@ -351,6 +351,7 @@ contract Zap {
         zap.withdrawStake();
 
         address vaultAddress = zap.addressVars[keccak256('_vault')];
+        require(vaultAddress != address(0));
         Vault vault = Vault(vaultAddress);
 
         token.transferFrom(
@@ -659,6 +660,7 @@ contract Zap {
      */
     function increaseVaultApproval() public returns (bool) {
         address vaultAddress = zap.addressVars[keccak256('_vault')];
+        require(vaultAddress != address(0));
         Vault vault = Vault(vaultAddress);
         return vault.increaseApproval();
     }

--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -55,7 +55,6 @@ contract Zap {
         address indexed _spender,
         uint256 _value
     ); //ERC20 Approval event
-    event Transfer(address indexed _from, address indexed _to, uint256 _value); //ERC20 Transfer Event
     event OwnershipTransferred(
         address indexed previousOwner,
         address indexed newOwner
@@ -69,8 +68,6 @@ contract Zap {
 
     ZapStorage.ZapStorageStruct zap;
     ZapTokenBSC public token;
-    // Vault public vault;
-    // address public vaultAddress;
 
     address payable public owner;
 
@@ -353,10 +350,13 @@ contract Zap {
     function withdrawStake() external {
         zap.withdrawStake();
 
+        address vaultAddress = zap.addressVars[keccak256('_vault')];
+        Vault vault = Vault(vaultAddress);
+
         token.transferFrom(
-            zap.addressVars[keccak256('_vault')],
+            vaultAddress,
             msg.sender,
-            zap.uintVars[keccak256('stakeAmount')]
+            vault.userBalance(msg.sender)
         );
     }
 
@@ -446,9 +446,8 @@ contract Zap {
         uint256 previousBalance = balanceOf(_from); // actual token balance
         previousBalance = balanceOf(_to); // actual token balance
         require(previousBalance + _amount >= previousBalance); // Check for overflow
-        // transferFrom(_from, _to, _amount); // do the actual transfer to ZapToken
-        token.transferFrom(_from, _to, _amount); // do the actual transfer to ZapToken
-        emit Transfer(_from, _to, _amount);
+        transferFrom(_from, _to, _amount); // do the actual transfer to ZapToken
+        // token.transferFrom(_from, _to, _amount); // do the actual transfer to ZapToken
     }
 
     /**

--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -295,7 +295,7 @@ contract Zap {
         ZapStorage.Details[5] memory a = zap.currentMiners;
 
         address vaultAddress = zap.addressVars[keccak256('_vault')];
-        require (minerReward != address(0));
+        require(vaultAddress != address(0));
         Vault vault = Vault(vaultAddress);
 
         uint256 minerReward = zap.uintVars[keccak256('currentMinerReward')];
@@ -547,7 +547,6 @@ contract Zap {
      */
     function addTip(uint256 _requestId, uint256 _tip) public {
         require(_requestId > 0);
-        require(_tip <= balanceOf(msg.sender));
 
         //If the tip > 0 transfer the tip to this contract
         if (_tip > 0) {

--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -547,6 +547,7 @@ contract Zap {
      */
     function addTip(uint256 _requestId, uint256 _tip) public {
         require(_requestId > 0);
+        require(_tip <= balanceOf(msg.sender));
 
         //If the tip > 0 transfer the tip to this contract
         if (_tip > 0) {

--- a/contracts/zap-miner/libraries/ZapLibrary.sol
+++ b/contracts/zap-miner/libraries/ZapLibrary.sol
@@ -139,14 +139,14 @@ library ZapLibrary {
             self.uintVars[keccak256('currentTotalTips')] /
             5;
 
-        for (i = 0; i < 5; i++) {
-            ZapTransfer.doTransfer(
-                self,
-                address(this),
-                a[i].miner,
-                baseReward + self.uintVars[keccak256('currentTotalTips')] / 5
-            );
-        }
+        // for (i = 0; i < 5; i++) {
+        //     ZapTransfer.doTransfer(
+        //         self,
+        //         address(this),
+        //         a[i].miner,
+        //         baseReward + self.uintVars[keccak256('currentTotalTips')] / 5
+        //     );
+        // }
         emit NewValue(
             _requestId,
             self.uintVars[keccak256('timeOfLastNewValue')],

--- a/contracts/zap-miner/libraries/ZapTransfer.sol
+++ b/contracts/zap-miner/libraries/ZapTransfer.sol
@@ -16,7 +16,6 @@ library ZapTransfer {
         address indexed _spender,
         uint256 _value
     ); //ERC20 Approval event
-    event Transfer(address indexed _from, address indexed _to, uint256 _value); //ERC20 Transfer Event
 
     /*Functions*/
 
@@ -54,7 +53,6 @@ library ZapTransfer {
         require(previousBalance + _amount >= previousBalance); // Check for overflow
         updateBalanceAtNow(self.balances[_to], previousBalance + _amount);
         previousBalance = balanceOfAt(self, _to, block.number);
-        emit Transfer(_from, _to, _amount);
     }
 
     /**
@@ -122,7 +120,6 @@ library ZapTransfer {
             //Removes the stakeAmount from balance if the _user is staked
             if (
                 balanceOfAt(self, _user, block.number).sub(_amount) >= 0
-                // .sub(self.uintVars[keccak256('stakeAmount')])
             ) {
                 return true;
             }

--- a/test/didMineTest.ts
+++ b/test/didMineTest.ts
@@ -173,11 +173,14 @@ describe('Did Mine Test', () => {
         // Attach the ZapMaster instance to Zap
         zap = zap.attach(zapMaster.address);
 
+        let balance = await zapTokenBsc.connect(signers[1]).balanceOf(signers[1].address);
         // Iterates through signers 1 through 5
         for (var i = 1; i <= 5; i++) {
 
             // Connects addresses 1-5 as the signer
             zap = zap.connect(signers[i]);
+
+            
 
             await zapTokenBsc.connect(signers[i]).approve(zapMaster.address, 500000);
 
@@ -364,5 +367,8 @@ describe('Did Mine Test', () => {
         diff =
             parseInt(previousZapMasterBal._hex) - parseInt(currentZapMasterBal._hex);
         expect(diff).to.equal(payOutAmount);
+
+        let bal = await zapTokenBsc.balanceOf(signers[1].address);
+        expect(bal > balance);
     });
 });


### PR DESCRIPTION
### Summary
Removed the duplicate transfer event of the anon token.
- Verified AddTip() does not emit 2 different transfer events.

Added miner rewards to withdraw along with stake withdraw and test
Added requires before Vault instantiations to make sure the vault address was set and test

### Notes
- These temp contracts are corrupted due to requestData property in config.json. Will have to redeploy temp test contracts to verify again.

### Visuals
https://testnet.bscscan.com/tx/0x00b3853c3977b916951a573eb7005dc1fdf69e4fabfa23161780e79c836296c1#eventlog

hardhat MainMinerTest.ts 
![image](https://user-images.githubusercontent.com/18056516/125532225-bc3e9c71-3f08-469a-a7d3-c09c72abf03b.png)

hardhat didMineTest.ts
![image](https://user-images.githubusercontent.com/18056516/125532288-13ba9dc1-876e-4afc-b1cf-28e721501157.png)
