### PR TITLE
Deploy ZapMarket

### DIFF
--- a/deploy/00_deploy_zap_market.ts
+++ b/deploy/00_deploy_zap_market.ts
@@ -1,0 +1,37 @@
+// deploy/00_deploy_zoo_token.js
+
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { DeployFunction } from 'hardhat-deploy/types'
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+    const { deployments, getNamedAccounts } = hre
+
+    const { deploy } = deployments
+
+    console.log(deploy)
+
+    const { deployer } = await getNamedAccounts()
+
+    console.log(deployer)
+
+    const useProxy = !hre.network.live
+
+    // Proxy only in non-live network (localhost and hardhat network) enabling
+    // HCR (Hot Contract Replacement) in live network, proxy is disabled and
+    // constructor is invoked
+    await deploy('ZapMarket', {
+        from: deployer,
+        args: [],
+        log: true,
+        // proxy: useProxy && 'postUpgrade',
+    })
+
+    // When live network, record the script as executed to prevent rexecution
+    return !useProxy
+}
+
+export default func
+func.id = 'deploy_zap_market' // ID required to prevent reexecution
+func.tags = ['ZapMarket'];
+func.dependencies = [];
+

--- a/deploy/00_deploy_zap_market.ts
+++ b/deploy/00_deploy_zap_market.ts
@@ -1,37 +1,28 @@
-// deploy/00_deploy_zoo_token.js
-
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
+
 import { DeployFunction } from 'hardhat-deploy/types'
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+
     const { deployments, getNamedAccounts } = hre
 
     const { deploy } = deployments
 
-    console.log(deploy)
-
     const { deployer } = await getNamedAccounts()
-
-    console.log(deployer)
 
     const useProxy = !hre.network.live
 
-    // Proxy only in non-live network (localhost and hardhat network) enabling
-    // HCR (Hot Contract Replacement) in live network, proxy is disabled and
-    // constructor is invoked
     await deploy('ZapMarket', {
         from: deployer,
         args: [],
         log: true,
-        // proxy: useProxy && 'postUpgrade',
     })
 
-    // When live network, record the script as executed to prevent rexecution
     return !useProxy
 }
 
 export default func
-func.id = 'deploy_zap_market' // ID required to prevent reexecution
+func.id = 'deploy_zap_market'
 func.tags = ['ZapMarket'];
 func.dependencies = [];
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -93,6 +93,11 @@ const config = {
     // Obtain one at https://etherscan.io/
     apiKey: BSC_API_KEY
   },
+  namedAccounts: {
+    deployer: {
+      31337: 0
+    }
+  },
   mocha: {
     timeout: 1000000
   }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,12 +1,8 @@
 import { config as dotEnvConfig } from "dotenv";
+
 dotEnvConfig();
 
-import { HardhatUserConfig } from "hardhat/types";
-require("hardhat-gas-reporter")
-
 import "hardhat-gas-reporter"
-
-
 import "@nomiclabs/hardhat-waffle";
 import "@nomiclabs/hardhat-etherscan";
 import "hardhat-typechain";
@@ -63,7 +59,10 @@ const config = {
   },
   networks: {
     localhost: {
-      url: 'http://127.0.0.1:8545/'
+      url: 'http://127.0.0.1:8545/',
+      live: false,
+      saveDeployments: true,
+      tags: ["local"]
     },
     // Will throw an error if the MNEMONIC env variable is non existent
     // Only used for deploying to the BSC testnet
@@ -88,16 +87,19 @@ const config = {
       url: 'http://127.0.0.1:8555' // Coverage launches its own ganache-cli client
     }
   },
+
   etherscan: {
     // Your API key for Etherscan
     // Obtain one at https://etherscan.io/
     apiKey: BSC_API_KEY
   },
+
   namedAccounts: {
     deployer: {
-      31337: 0
+      31337: 0,
     }
   },
+
   mocha: {
     timeout: 1000000
   }


### PR DESCRIPTION
## Summary
Closes #16 
ZapMarket has its own individual deploy script

## Implementation
- Created a deploy folder so the ```npx hardhat deploy``` task knows where to target files
-  Added  ```deploy/00_deploy_zap_market.ts``` to the deplo

## Files
```hardhat.config.ts```
```deploy/00_deploy_zap_market.ts```

## Visual Preview
The ```npx hardhat deploy``` task deploys individual files inside the deploy folder
<img width="364" alt="Screen Shot 2021-08-10 at 5 28 10 PM" src="https://user-images.githubusercontent.com/42893948/128937475-4b78870c-0303-461f-9816-e12ae4dcde86.png">

Deploys the ```00_deploy_zap_market.ts``` file to localhost after  ```npx hardhat deploy```
<img width="793" alt="Screen Shot 2021-08-10 at 5 30 27 PM" src="https://user-images.githubusercontent.com/42893948/128937712-bf17e469-7f19-4cb2-aaaf-0b68947038ed.png">

