### PR TITLE
Bugfix: Zapmedia Deploy

### DIFF
--- a/.openzeppelin/unknown-31337.json
+++ b/.openzeppelin/unknown-31337.json
@@ -2,19 +2,19 @@
   "manifestVersion": "3.2",
   "admin": {
     "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "txHash": "0x37981ac01b99fff849851ddc5f364a8ace8c0b2bf4227f0e84f144c020cf6560",
+    "txHash": "0xfc997bab2416cabbab0ed4d2bfb452812afcf612373953a343e18242498d71aa",
     "deployTransaction": {
-      "hash": "0x37981ac01b99fff849851ddc5f364a8ace8c0b2bf4227f0e84f144c020cf6560",
+      "hash": "0xfc997bab2416cabbab0ed4d2bfb452812afcf612373953a343e18242498d71aa",
       "type": 0,
       "accessList": null,
-      "blockHash": "0xae6bd0e00d8b6c668dcda5e61c878f7a433093b81c6c46e54717f71fc4fc4a24",
+      "blockHash": "0xcd6a53df5d654d14bbea88918631e96f47652556d435ca0d4cf669a587a8d9b6",
       "blockNumber": 2,
       "transactionIndex": 0,
       "confirmations": 1,
       "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "gasPrice": {
         "type": "BigNumber",
-        "hex": "0x0197d545a7"
+        "hex": "0x01ae63483c"
       },
       "gasLimit": {
         "type": "BigNumber",
@@ -27,8 +27,8 @@
       },
       "nonce": 1,
       "data": "0x608060405234801561001057600080fd5b50600080546001600160a01b031916339081178255604051909182917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350610759806100616000396000f3fe60806040526004361061007b5760003560e01c80639623609d1161004e5780639623609d1461011157806399a88ec414610124578063f2fde38b14610144578063f3b7dead146101645761007b565b8063204e1c7a14610080578063715018a6146100bc5780637eff275e146100d35780638da5cb5b146100f3575b600080fd5b34801561008c57600080fd5b506100a061009b366004610515565b610184565b6040516001600160a01b03909116815260200160405180910390f35b3480156100c857600080fd5b506100d1610215565b005b3480156100df57600080fd5b506100d16100ee366004610554565b610292565b3480156100ff57600080fd5b506000546001600160a01b03166100a0565b6100d161011f36600461058c565b61031c565b34801561013057600080fd5b506100d161013f366004610554565b6103ad565b34801561015057600080fd5b506100d161015f366004610515565b610405565b34801561017057600080fd5b506100a061017f366004610515565b6104ef565b6000806000836001600160a01b03166040516101aa90635c60da1b60e01b815260040190565b600060405180830381855afa9150503d80600081146101e5576040519150601f19603f3d011682016040523d82523d6000602084013e6101ea565b606091505b5091509150816101f957600080fd5b8080602001905181019061020d9190610538565b949350505050565b6000546001600160a01b031633146102485760405162461bcd60e51b815260040161023f906106c0565b60405180910390fd5b600080546040516001600160a01b03909116907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600080546001600160a01b0319169055565b6000546001600160a01b031633146102bc5760405162461bcd60e51b815260040161023f906106c0565b6040516308f2839760e41b81526001600160a01b038281166004830152831690638f283970906024015b600060405180830381600087803b15801561030057600080fd5b505af1158015610314573d6000803e3d6000fd5b505050505050565b6000546001600160a01b031633146103465760405162461bcd60e51b815260040161023f906106c0565b60405163278f794360e11b81526001600160a01b03841690634f1ef286903490610376908690869060040161065d565b6000604051808303818588803b15801561038f57600080fd5b505af11580156103a3573d6000803e3d6000fd5b5050505050505050565b6000546001600160a01b031633146103d75760405162461bcd60e51b815260040161023f906106c0565b604051631b2ce7f360e11b81526001600160a01b038281166004830152831690633659cfe6906024016102e6565b6000546001600160a01b0316331461042f5760405162461bcd60e51b815260040161023f906106c0565b6001600160a01b0381166104945760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b606482015260840161023f565b600080546040516001600160a01b03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a3600080546001600160a01b0319166001600160a01b0392909216919091179055565b6000806000836001600160a01b03166040516101aa906303e1469160e61b815260040190565b600060208284031215610526578081fd5b81356105318161070b565b9392505050565b600060208284031215610549578081fd5b81516105318161070b565b60008060408385031215610566578081fd5b82356105718161070b565b915060208301356105818161070b565b809150509250929050565b6000806000606084860312156105a0578081fd5b83356105ab8161070b565b925060208401356105bb8161070b565b9150604084013567ffffffffffffffff808211156105d7578283fd5b818601915086601f8301126105ea578283fd5b8135818111156105fc576105fc6106f5565b604051601f8201601f19908116603f01168101908382118183101715610624576106246106f5565b8160405282815289602084870101111561063c578586fd5b82602086016020830137856020848301015280955050505050509250925092565b600060018060a01b038416825260206040818401528351806040850152825b818110156106985785810183015185820160600152820161067c565b818111156106a95783606083870101525b50601f01601f191692909201606001949350505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461072057600080fd5b5056fea2646970667358221220d849f96f3086b9f82cdcf665adb8c697ace05638da1c7c16ab2d26293717af6764736f6c63430008020033",
-      "r": "0x89c79c37e83c92965b6401edb2369227e795f13cbcade703b1da64a96ce76a1e",
-      "s": "0x5a3ff142aec3fa6c1b312c7385b165c04c38ab575087a7421e7df5df6cda2a7f",
+      "r": "0x1c501eaff101eb0fd50f3d61cad5b95b69fa8978b15d642a1015beb754b34a14",
+      "s": "0x52f6f024edd064c867079e794e20458a427d10082043eac528701b2460a74fd6",
       "v": 62710,
       "creates": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
       "chainId": 31337
@@ -302,7 +302,262 @@
     },
     {
       "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-      "txHash": "0x85736072d289d73fb421e00376837d5a7843a60ed071e9e517065a3b8b266c0d",
+      "txHash": "0xfbe5b295a5d1b405f8af6cc2a05119da3e0e93aa8a42462fcfc5a6f783fbe1ca",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x71C95911E9a5D330f4D621842EC243EE1343292e",
+      "txHash": "0x826b21b2baec7d503e41eb6c15c9375a77bcafa291bba902ddc56cb5a0a3a43f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x663F3ad617193148711d28f5334eE4Ed07016602",
+      "txHash": "0x97b46e056b437af65a17690a73e348d56ee30d6cf00dbc81bd11419656d600b0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x057ef64E23666F000b34aE31332854aCBd1c8544",
+      "txHash": "0x887a1bb9fcae85bbce3cf59e5431e261e9f357a66d51e454ae703767c8eff877",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xbdEd0D2bf404bdcBa897a74E6657f1f12e5C6fb6",
+      "txHash": "0x2a675f592a7ce0506b9fd18f2d0974cd2d44a5f41b6a29b8a90f2b7d0982ea05",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F",
+      "txHash": "0xe03b93399b206543047eb9594e3540a255c7598e35cafc14f1069b0dc413ac2f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2E983A1Ba5e8b38AAAeC4B440B9dDcFBf72E15d1",
+      "txHash": "0x551769dc9bc9489e1ccacb442e9e2f8f279d4c0c8beb9a7f55af55c60e1f9784",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x261D8c5e9742e6f7f1076Fa1F560894524e19cad",
+      "txHash": "0x30a66f8becb24fd5561b6f5b20f84dc423b4f14dbedfa7f30acab6988a498b23",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2910E325cf29dd912E3476B61ef12F49cb931096",
+      "txHash": "0xfdc9a52dbeb222f7c924b9af1531040ae332cd242f26017811d703c127ce2160",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0116686E2291dbd5e317F47faDBFb43B599786Ef",
+      "txHash": "0x912c88d716450bbb1c1a207c1c59fda8e2eb8cebcd3d8f858c561da4bebb8557",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x13D69Cf7d6CE4218F646B759Dcf334D82c023d8e",
+      "txHash": "0x4b4cb3dd30d6f01763013a485c6c8fa367caa94d55db1dc84f2d1838aba07699",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x72bb9c7ffbE2Ed234e53bc64862DdA6d9fFF333b",
+      "txHash": "0xd1c6599ef5deb0efde309c68b964fb86c7ed4176f0e3895741c5428cccdc2841",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x85C5Dd61585773423e378146D4bEC6f8D149E248",
+      "txHash": "0x4b052ebe91272660d0fb13429759b8500010e6063fed07491c24b899ce325e5e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x63cf2Cd54fE91e3545D1379abf5bfd194545259d",
+      "txHash": "0xf375060b01d0cc31a889802075a77872f10a2875a6a1fbd1075f176fa3102168",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xed17543171C1459714cdC6519b58fFcC29A3C3c9",
+      "txHash": "0xb982b78d582d0b5b52411b365ae6c46b5788b139d0dbe61ca3fdb2d33e7b9e22",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5370F78c6af2Da9cF6642382A3a75F9D5aEc9cc1",
+      "txHash": "0x5c943a037a5397d851acbd4a3f1f78c06fc054d24cca3d15d9a17e7442813ee5",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x20Fbd46DeEd5EEDEB6e5c87eeB31924e9CA312ad",
+      "txHash": "0xd6316ad7b0a97dcd49eb9ae4ef6e33995f622a8b9c4e6a7d43505ac8e122f2ff",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x130A46b6E41DB6E1e18fb9c759F223c459190e90",
+      "txHash": "0x7c94a2021c7805ff40ee57ce8c09c4311951b845ceeaeda5fa5e269369fde732",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1a6a3e7Bb246158dF31d8f924B84D961669Ba4e5",
+      "txHash": "0x4c42e22268f99e2202a15f4bda8335bbe27e78b13e68a92ac4c9f0455ef22836",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa85b028984bC54A2a3D844B070544F59dDDf89DE",
+      "txHash": "0x183058427b7f042aa3bae599602bee5f3ff9365ef9ceb9a534548305b4808967",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x35D2F51DBC8b401B11fA3FE04423E0f5cd9fEDb4",
+      "txHash": "0x72658d64defc344aaf1ec7a817832cab161dc7cc1d1aea84e542799becf0147e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xbe241D1B7b54bF06742cefd45A3440C6562f7603",
+      "txHash": "0x0553c77aa4aba0a0d5c348f0075eedf062399a1b36c2f599a3a9c024d8fa173f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE4F89Fb0dBb45378633c05ACAb071eB998F0A736",
+      "txHash": "0x98660a5782bbd280d198bf2d197724877f9c350aae50c4684d49cabeb2f13ceb",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x3c705dB336C81c7FEFC5746e283aB2c0781A4B7b",
+      "txHash": "0x04f64999cd119893467ca72ff1535c6e2abb52e7e64a022c12fa2a0b0d3df1fb",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x90352F820342f8BE0012848bCB8aBd37877d7ec2",
+      "txHash": "0xecc77fe32c6db1927c1f149aa41318009baa1d47383318d4f655770e979a517d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x87F850cbC2cFfac086F20d0d7307E12d06fA2127",
+      "txHash": "0xc39ebcb8f38a71d40fc5b9d33c48bcec3d95539537bd174bbd139d189d33bbf5",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xEe54514745B056F07040CaCF801f59031D801431",
+      "txHash": "0x33f7bca95570fb5ea79f91deb466a18686ae723dcf5ae255173fac7e821306f4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x73511669fd4dE447feD18BB79bAFeAC93aB7F31f",
+      "txHash": "0x06f7e7512161143a07248b9fefe57b365e726fb0c12c6c502bce4c5075c7c83c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa115891Cae16388b84cb7a521A2032f6b354FE25",
+      "txHash": "0x012054f17512ecbe18dadccbeb77d01168c72157d2fda5b06bab717ea5409e13",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2731e51aFF4615796D44B37a9d2E7970d88E331a",
+      "txHash": "0x1647a0497b0ae71cf34b1db14a9258f89950df57ed9ef91e11276d54fdeb7656",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0e075cB6f980203F8e930a0B527CDbE07F303eAD",
+      "txHash": "0x22e52deadf4f0a7bfe44d4039abbbb0273262444be7ddfd8169bc6830a2df2a2",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x581f62c0901d4dce2553cb6140dBb4CeE533d834",
+      "txHash": "0x01386396acb37af48d6c08b67cda493ff5ee89ed963d3e20ee824ea3aae1f365",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf23B8c9debCdCEa2a40E81c3f6d786987069D40d",
+      "txHash": "0xc6e851ef75aa8dbcd4a4d6e0f4e8a0c3a655be4a8a71fab43667df6543e37f90",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xec552B17995198A0e71E9198D047B5Ec42710359",
+      "txHash": "0xa9ccc34f847e241aebea07baae513f888001e1be8947952b924e9558d4aab996",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x3C8841ddf731d168b0B4FFB633995281DaE8bc3D",
+      "txHash": "0xcd4c63405bc99e3f308ab9b5772605ac3d5e13c0bd14ec0789465a073181314c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1Ef8f58544Ca4d9b1e34E2F9Cd1b37257C618C6D",
+      "txHash": "0xb92ec8264bf79da0b3a5eb9b8e92ad157fff66f28bf769a1eac1bf2019ad8e28",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4ee108458a4D97dAa2f8eF90A73942AC7B3a9209",
+      "txHash": "0x191cb29af7ad2834a7ec6f21ba42c10b1ac6d2954b37154f042df5b9841d755b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9dBCF50e357172D490ee5E428d75129A6224a2e9",
+      "txHash": "0xdba0740bc52c73c393a46577ff8a9b3ccf65e00aa61085ecf95f1e0b09dd7a41",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0543C1020123b4Ed9e95950B6CBb2F1150DF1029",
+      "txHash": "0x01d98ca40a9992847583f8484a4eaf788a045d437745d8959559ce05f59824b3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xC4A743126DCcA4DF85B8f75B6eD113bb69dD65A1",
+      "txHash": "0x346e6fbbc726c5376959c0176ec991222f10104d6d7ead87abf95c77575a5ac3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xA9526DFDd289b2C2ADa83E07c6dd293AA2C5fEe9",
+      "txHash": "0x432249e6e917733416a8bede1c7a9f2c32bb89d800c6afcd3d9938051036d094",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x7F6D5d1bDFB4b281374285510A845cb140d4367b",
+      "txHash": "0x386971b104a5f6dbe1d64ff65e93367e06df8beddb70413e1aba2c349555a992",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x715214AeEf7D4C78b9c329cc4D7375cC08670843",
+      "txHash": "0x7316bdc5dbcc3484dcb607a7a9ee068b9fea3dd1040c40cf5a5f36cccec83132",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf342D22125Eddc24c6c3D716E048388D1415C20d",
+      "txHash": "0x54ee9eb769f7b30410b5285d4d0ab7f342b196dcd437f99194b7642bf3d182ca",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x05275a4799cd1B07D81319390fC62Bc7BDbDf269",
+      "txHash": "0x5b399428786b1847c0d74b802fde46172b7e6767d0be7478028a6b9bd1d0a021",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2575d6D30767149c99589cce743656fA3866ca2e",
+      "txHash": "0xae3f9eb2507186b84bc081d22c14d8c18cab01cb87ce077c5692575a0b5d9a27",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x02d6db176f10C4FdceBDD1B44c1037c1B568bc2E",
+      "txHash": "0x27e20364241658cc89f7449a8782908dc6e675f4a2ddd9f6df9162255c4bed02",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x780ABF86d3a8c070b1e8757A961C126c7D88e460",
+      "txHash": "0xe96094868600b1b7624561dfa566cef1688e4606baa061bc5c0bcc3dbbf6752a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x90b8b4F5B00dCC13c50fC098F2A93368E5a2839a",
+      "txHash": "0xfc4e2feb09b565243ecfe1ab339f05ed704753a2475133ab844f8bf256dca0a1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xD71F8cDe87726587941dCDE67845dd6945eDB3A9",
+      "txHash": "0xc9aeac08b7bdd9d07c01f43afad4ad62ffb15f1f2b76eb8605b04c4149f934b8",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xd637EBC8337d13C4efDD1f90903e10B211FEd52d",
+      "txHash": "0xb790f4bebeca4f6c5db2339166ee02bb2476a16e5e5fb13298daf1ec77027939",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x09DC2cba1450d7E22bf68866E41e24c75BE13723",
+      "txHash": "0x0d4b77fcd26be336d853068f4c3386a47ee9d5231cbc6473743ee9f0ccf7803d",
       "kind": "transparent"
     }
   ],
@@ -476,7 +731,7 @@
     },
     "04c30e822e3c14e270d7fd06be77fecbe54ef6743173d7a5f8467bb5293891c4": {
       "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-      "txHash": "0x8f342591092082456fbf0c0e40a349c6eba20ec642d8c7ad866369da709ac93b",
+      "txHash": "0xe0f58bc7918514637326875088d2fc08ee6e2b53f385345fd697a626347fdefe",
       "layout": {
         "storage": [
           {
@@ -506,19 +761,19 @@
           {
             "contract": "ZapMarket",
             "label": "_tokenBidders",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)9114_storage)))",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)11062_storage)))",
             "src": "contracts/nft/ZapMarket.sol:35"
           },
           {
             "contract": "ZapMarket",
             "label": "_bidShares",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)9129_storage))",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)11077_storage))",
             "src": "contracts/nft/ZapMarket.sol:39"
           },
           {
             "contract": "ZapMarket",
             "label": "_tokenAsks",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)9119_storage))",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)11067_storage))",
             "src": "contracts/nft/ZapMarket.sol:42"
           },
           {
@@ -544,19 +799,19 @@
           "t_array(t_address)dyn_storage": {
             "label": "address[]"
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)9114_storage)))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)11062_storage)))": {
             "label": "mapping(address => mapping(uint256 => mapping(address => struct IMarket.Bid)))"
           },
-          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)9114_storage))": {
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)11062_storage))": {
             "label": "mapping(uint256 => mapping(address => struct IMarket.Bid))"
           },
           "t_uint256": {
             "label": "uint256"
           },
-          "t_mapping(t_address,t_struct(Bid)9114_storage)": {
+          "t_mapping(t_address,t_struct(Bid)11062_storage)": {
             "label": "mapping(address => struct IMarket.Bid)"
           },
-          "t_struct(Bid)9114_storage": {
+          "t_struct(Bid)11062_storage": {
             "label": "struct IMarket.Bid",
             "members": [
               {
@@ -577,11 +832,11 @@
               },
               {
                 "label": "sellOnShare",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               }
             ]
           },
-          "t_struct(D256)5190_storage": {
+          "t_struct(D256)7089_storage": {
             "label": "struct Decimal.D256",
             "members": [
               {
@@ -590,36 +845,36 @@
               }
             ]
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)9129_storage))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)11077_storage))": {
             "label": "mapping(address => mapping(uint256 => struct IMarket.BidShares))"
           },
-          "t_mapping(t_uint256,t_struct(BidShares)9129_storage)": {
+          "t_mapping(t_uint256,t_struct(BidShares)11077_storage)": {
             "label": "mapping(uint256 => struct IMarket.BidShares)"
           },
-          "t_struct(BidShares)9129_storage": {
+          "t_struct(BidShares)11077_storage": {
             "label": "struct IMarket.BidShares",
             "members": [
               {
                 "label": "prevOwner",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               },
               {
                 "label": "creator",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               },
               {
                 "label": "owner",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               }
             ]
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)9119_storage))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)11067_storage))": {
             "label": "mapping(address => mapping(uint256 => struct IMarket.Ask))"
           },
-          "t_mapping(t_uint256,t_struct(Ask)9119_storage)": {
+          "t_mapping(t_uint256,t_struct(Ask)11067_storage)": {
             "label": "mapping(uint256 => struct IMarket.Ask)"
           },
-          "t_struct(Ask)9119_storage": {
+          "t_struct(Ask)11067_storage": {
             "label": "struct IMarket.Ask",
             "members": [
               {
@@ -804,6 +1059,229 @@
           },
           "t_bool": {
             "label": "bool"
+          }
+        }
+      }
+    },
+    "d15852c323da99d9057cb844f9d534cdaabf918997edf3b8fd9243a20d90e670": {
+      "address": "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+      "txHash": "0x25aa19bb65ce0f1a828dbae489c34a0b48a5c7af81e357d19dd56be279c1a5ed",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:21"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:26"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:30"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:35"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:24"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:27"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_owners",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:30"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_balances",
+            "type": "t_mapping(t_address,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:33"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_tokenApprovals",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:36"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_operatorApprovals",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:39"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)44_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:418"
+          },
+          {
+            "contract": "ERC721BurnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol:34"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "_status",
+            "type": "t_uint256",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:37"
+          },
+          {
+            "contract": "ReentrancyGuardUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:67"
+          },
+          {
+            "contract": "Ownable",
+            "label": "owner",
+            "type": "t_address",
+            "src": "contracts/nft/access/Ownable.sol:11"
+          },
+          {
+            "contract": "MediaGetter",
+            "label": "tokens",
+            "type": "t_struct(Tokens)11560_storage",
+            "src": "contracts/nft/MediaGetter.sol:15"
+          },
+          {
+            "contract": "ERC721URIStorageUpgradeable",
+            "label": "_tokenURIs",
+            "type": "t_mapping(t_uint256,t_string_storage)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol:23"
+          },
+          {
+            "contract": "ERC721URIStorageUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol:75"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_ownedTokens",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_uint256))",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:24"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_ownedTokensIndex",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:27"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_allTokens",
+            "type": "t_array(t_uint256)dyn_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:30"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "_allTokensIndex",
+            "type": "t_mapping(t_uint256,t_uint256)",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:33"
+          },
+          {
+            "contract": "ERC721EnumerableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)46_storage",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol:171"
+          }
+        ],
+        "types": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_array(t_uint256)dyn_storage": {
+            "label": "uint256[]"
+          },
+          "t_array(t_uint256)46_storage": {
+            "label": "uint256[46]"
+          },
+          "t_mapping(t_uint256,t_string_storage)": {
+            "label": "mapping(uint256 => string)"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_struct(Tokens)11560_storage": {
+            "label": "struct MediaStorage.Tokens",
+            "members": [
+              {
+                "label": "previousTokenOwners",
+                "type": "t_mapping(t_uint256,t_address)"
+              },
+              {
+                "label": "tokenCreators",
+                "type": "t_mapping(t_uint256,t_address)"
+              },
+              {
+                "label": "tokenContentHashes",
+                "type": "t_mapping(t_uint256,t_bytes32)"
+              },
+              {
+                "label": "tokenMetadataHashes",
+                "type": "t_mapping(t_uint256,t_bytes32)"
+              }
+            ]
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)"
+          },
+          "t_mapping(t_uint256,t_bytes32)": {
+            "label": "mapping(uint256 => bytes32)"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]"
           }
         }
       }

--- a/.openzeppelin/unknown-31337.json
+++ b/.openzeppelin/unknown-31337.json
@@ -1,14 +1,14 @@
 {
   "manifestVersion": "3.2",
   "admin": {
-    "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "txHash": "0xfc997bab2416cabbab0ed4d2bfb452812afcf612373953a343e18242498d71aa",
+    "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+    "txHash": "0x9bc903cc77214bf298f7673a0f16b6a5fd78bf5141aeed50a189dec76b37ca94",
     "deployTransaction": {
-      "hash": "0xfc997bab2416cabbab0ed4d2bfb452812afcf612373953a343e18242498d71aa",
+      "hash": "0x9bc903cc77214bf298f7673a0f16b6a5fd78bf5141aeed50a189dec76b37ca94",
       "type": 0,
       "accessList": null,
-      "blockHash": "0xcd6a53df5d654d14bbea88918631e96f47652556d435ca0d4cf669a587a8d9b6",
-      "blockNumber": 2,
+      "blockHash": "0xad8eb84eeafc782a7f3f2a8d0ec837ba9ad66778ba0c47678bc954c156b10dfd",
+      "blockNumber": 3,
       "transactionIndex": 0,
       "confirmations": 1,
       "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -25,12 +25,12 @@
         "type": "BigNumber",
         "hex": "0x00"
       },
-      "nonce": 1,
+      "nonce": 2,
       "data": "0x608060405234801561001057600080fd5b50600080546001600160a01b031916339081178255604051909182917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350610759806100616000396000f3fe60806040526004361061007b5760003560e01c80639623609d1161004e5780639623609d1461011157806399a88ec414610124578063f2fde38b14610144578063f3b7dead146101645761007b565b8063204e1c7a14610080578063715018a6146100bc5780637eff275e146100d35780638da5cb5b146100f3575b600080fd5b34801561008c57600080fd5b506100a061009b366004610515565b610184565b6040516001600160a01b03909116815260200160405180910390f35b3480156100c857600080fd5b506100d1610215565b005b3480156100df57600080fd5b506100d16100ee366004610554565b610292565b3480156100ff57600080fd5b506000546001600160a01b03166100a0565b6100d161011f36600461058c565b61031c565b34801561013057600080fd5b506100d161013f366004610554565b6103ad565b34801561015057600080fd5b506100d161015f366004610515565b610405565b34801561017057600080fd5b506100a061017f366004610515565b6104ef565b6000806000836001600160a01b03166040516101aa90635c60da1b60e01b815260040190565b600060405180830381855afa9150503d80600081146101e5576040519150601f19603f3d011682016040523d82523d6000602084013e6101ea565b606091505b5091509150816101f957600080fd5b8080602001905181019061020d9190610538565b949350505050565b6000546001600160a01b031633146102485760405162461bcd60e51b815260040161023f906106c0565b60405180910390fd5b600080546040516001600160a01b03909116907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600080546001600160a01b0319169055565b6000546001600160a01b031633146102bc5760405162461bcd60e51b815260040161023f906106c0565b6040516308f2839760e41b81526001600160a01b038281166004830152831690638f283970906024015b600060405180830381600087803b15801561030057600080fd5b505af1158015610314573d6000803e3d6000fd5b505050505050565b6000546001600160a01b031633146103465760405162461bcd60e51b815260040161023f906106c0565b60405163278f794360e11b81526001600160a01b03841690634f1ef286903490610376908690869060040161065d565b6000604051808303818588803b15801561038f57600080fd5b505af11580156103a3573d6000803e3d6000fd5b5050505050505050565b6000546001600160a01b031633146103d75760405162461bcd60e51b815260040161023f906106c0565b604051631b2ce7f360e11b81526001600160a01b038281166004830152831690633659cfe6906024016102e6565b6000546001600160a01b0316331461042f5760405162461bcd60e51b815260040161023f906106c0565b6001600160a01b0381166104945760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b606482015260840161023f565b600080546040516001600160a01b03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a3600080546001600160a01b0319166001600160a01b0392909216919091179055565b6000806000836001600160a01b03166040516101aa906303e1469160e61b815260040190565b600060208284031215610526578081fd5b81356105318161070b565b9392505050565b600060208284031215610549578081fd5b81516105318161070b565b60008060408385031215610566578081fd5b82356105718161070b565b915060208301356105818161070b565b809150509250929050565b6000806000606084860312156105a0578081fd5b83356105ab8161070b565b925060208401356105bb8161070b565b9150604084013567ffffffffffffffff808211156105d7578283fd5b818601915086601f8301126105ea578283fd5b8135818111156105fc576105fc6106f5565b604051601f8201601f19908116603f01168101908382118183101715610624576106246106f5565b8160405282815289602084870101111561063c578586fd5b82602086016020830137856020848301015280955050505050509250925092565b600060018060a01b038416825260206040818401528351806040850152825b818110156106985785810183015185820160600152820161067c565b818111156106a95783606083870101525b50601f01601f191692909201606001949350505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461072057600080fd5b5056fea2646970667358221220d849f96f3086b9f82cdcf665adb8c697ace05638da1c7c16ab2d26293717af6764736f6c63430008020033",
-      "r": "0x1c501eaff101eb0fd50f3d61cad5b95b69fa8978b15d642a1015beb754b34a14",
-      "s": "0x52f6f024edd064c867079e794e20458a427d10082043eac528701b2460a74fd6",
+      "r": "0xd00716dc3ea1eda6a4fe89edb4fd83550211c634c6a0375a442d6b15ebf6cb26",
+      "s": "0x57f4a3ce011a4bb60437fcc8957742763c293205a853c3bb937adcdf289e144e",
       "v": 62710,
-      "creates": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "creates": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
       "chainId": 31337
     }
   },
@@ -126,11 +126,6 @@
       "kind": "transparent"
     },
     {
-      "address": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44",
-      "txHash": "0x96ce3e63807333200bcdded7d0ba272ab02ab1beab7cf990f66e08eba5cc4576",
-      "kind": "transparent"
-    },
-    {
       "address": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
       "txHash": "0x4e64b4618f2d4754aa9ef793eaf9be4d2f3f4c863351511c92e2cb7ead6238a2",
       "kind": "transparent"
@@ -176,143 +171,8 @@
       "kind": "transparent"
     },
     {
-      "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
-      "txHash": "0x0bb84a4ffe9c3679a48e2d92db18231a270a9a66638431ca9745e5074fc82b5e",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-      "txHash": "0xe6126c1b7030ce04a26ab5df18d8a8e840a3a65afb21cc13f0b5fef75fc76dca",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
-      "txHash": "0x0a88c76dd9a9e63e28076556ec80f94bcfd909be49501691019b475fd9e851d5",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
-      "txHash": "0xe0da36e9cc708aa11a0184c56c2f8c1ba0c49586d95d91e21ff654c23e77cd85",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
-      "txHash": "0x788d7677e30dc6e5a0800796a2a7f06ebf0a30b3977f3274076aee89648d144c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x59b670e9fA9D0A427751Af201D676719a970857b",
-      "txHash": "0x0a9de522919cce69bc911b80711836ec58954d6e8c6ebfaaa159d4605cfcd86d",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
-      "txHash": "0xf07158d2326d52f477f95fe8a7c80c4923829da8ea9a1dc53c43e3ca7d7584f7",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
-      "txHash": "0x8385a27148ce7f8a4493ac50e95df5f1a8a0889a60745ed1e880f4543c513f05",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
-      "txHash": "0x90435256cc363ef2fe653894145abaab8e80b493a0c3ead6349ac61e6eb9df45",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9E545E3C0baAB3E08CdfD552C960A1050f373042",
-      "txHash": "0x7ceeede233e17fddd0c331b90ff5c810c880ca99b82ad7df3136d90abc0ddc59",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x851356ae760d987E095750cCeb3bC6014560891C",
-      "txHash": "0x72cc367b6e79d94d99f896e17ec7c4a8c4a19436495ad32e985166c3fdd238c0",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x998abeb3E57409262aE5b751f60747921B33613E",
-      "txHash": "0xe3615ab2edbf3ec815083ea9598f11ae1b2236c21511036811e74b2c4ce2f721",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
-      "txHash": "0x58399403816a84c96d052cbcaea88b7825a5fd312cab6c6b569c412c58639e7a",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9d4454B023096f34B160D6B654540c56A1F81688",
-      "txHash": "0x2b3b4c4d278ffbfe8da03c0cf21a79a221e4314572dab22c04ddc22f0592bd81",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
-      "txHash": "0x0299f9d8abce01ef47c0c4d10ded0268cc45e13433e9ae699a1dde7748275123",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154",
-      "txHash": "0x4aa22c44d3b4df05a9daa1b4aedbc7b19113a0edf23f77ee88a9e9b09b346c6e",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
-      "txHash": "0x795a4df935b77b96aa0770108ba184163596de9f96f69648acade0784ae8e33c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f",
-      "txHash": "0xc6c0541c2003768ac3ef5aa0098619ead90f8b582e4da8135e9b5906602d2eab",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xdbC43Ba45381e02825b14322cDdd15eC4B3164E6",
-      "txHash": "0x87985bca3aeeae8333e9b4a3b874fc827c65416fe15cffa81077d9119ca96ff9",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
-      "txHash": "0x5a182899ada244a344e44c513ba5e10667f0f9f551684ec00455da2ef204fdea",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B",
-      "txHash": "0x9b340fceaecb741b80a9cdcea63fd3cd3653db17919ec6e518b85cbacc40d75c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xC9a43158891282A2B1475592D5719c001986Aaec",
-      "txHash": "0xb8070513a406616644cf23c46abd741e8a9dd2d543134432d17745709a5fef48",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4631BCAbD6dF18D94796344963cB60d44a4136b6",
-      "txHash": "0x4557585aebfaea50c1ec4f913c23b1cd45d7b47a7099de0c88af0a87e25ac8cd",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3",
-      "txHash": "0x9950594d50fce735b5e7abe310c153553a3da8019ce1033b7efeadce3ab578a1",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xD5ac451B0c50B9476107823Af206eD814a2e2580",
-      "txHash": "0xb9cd0e0aa7a3d242ee59547aa9a62f273bc8fd255ecd4e7f484e9c6492b174d7",
-      "kind": "transparent"
-    },
-    {
       "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
       "txHash": "0xfbe5b295a5d1b405f8af6cc2a05119da3e0e93aa8a42462fcfc5a6f783fbe1ca",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x71C95911E9a5D330f4D621842EC243EE1343292e",
-      "txHash": "0x826b21b2baec7d503e41eb6c15c9375a77bcafa291bba902ddc56cb5a0a3a43f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x663F3ad617193148711d28f5334eE4Ed07016602",
-      "txHash": "0x97b46e056b437af65a17690a73e348d56ee30d6cf00dbc81bd11419656d600b0",
       "kind": "transparent"
     },
     {
@@ -323,16 +183,6 @@
     {
       "address": "0xbdEd0D2bf404bdcBa897a74E6657f1f12e5C6fb6",
       "txHash": "0x2a675f592a7ce0506b9fd18f2d0974cd2d44a5f41b6a29b8a90f2b7d0982ea05",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F",
-      "txHash": "0xe03b93399b206543047eb9594e3540a255c7598e35cafc14f1069b0dc413ac2f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2E983A1Ba5e8b38AAAeC4B440B9dDcFBf72E15d1",
-      "txHash": "0x551769dc9bc9489e1ccacb442e9e2f8f279d4c0c8beb9a7f55af55c60e1f9784",
       "kind": "transparent"
     },
     {
@@ -351,28 +201,13 @@
       "kind": "transparent"
     },
     {
-      "address": "0x13D69Cf7d6CE4218F646B759Dcf334D82c023d8e",
-      "txHash": "0x4b4cb3dd30d6f01763013a485c6c8fa367caa94d55db1dc84f2d1838aba07699",
-      "kind": "transparent"
-    },
-    {
       "address": "0x72bb9c7ffbE2Ed234e53bc64862DdA6d9fFF333b",
       "txHash": "0xd1c6599ef5deb0efde309c68b964fb86c7ed4176f0e3895741c5428cccdc2841",
       "kind": "transparent"
     },
     {
-      "address": "0x85C5Dd61585773423e378146D4bEC6f8D149E248",
-      "txHash": "0x4b052ebe91272660d0fb13429759b8500010e6063fed07491c24b899ce325e5e",
-      "kind": "transparent"
-    },
-    {
       "address": "0x63cf2Cd54fE91e3545D1379abf5bfd194545259d",
       "txHash": "0xf375060b01d0cc31a889802075a77872f10a2875a6a1fbd1075f176fa3102168",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xed17543171C1459714cdC6519b58fFcC29A3C3c9",
-      "txHash": "0xb982b78d582d0b5b52411b365ae6c46b5788b139d0dbe61ca3fdb2d33e7b9e22",
       "kind": "transparent"
     },
     {
@@ -393,26 +228,6 @@
     {
       "address": "0x1a6a3e7Bb246158dF31d8f924B84D961669Ba4e5",
       "txHash": "0x4c42e22268f99e2202a15f4bda8335bbe27e78b13e68a92ac4c9f0455ef22836",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa85b028984bC54A2a3D844B070544F59dDDf89DE",
-      "txHash": "0x183058427b7f042aa3bae599602bee5f3ff9365ef9ceb9a534548305b4808967",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x35D2F51DBC8b401B11fA3FE04423E0f5cd9fEDb4",
-      "txHash": "0x72658d64defc344aaf1ec7a817832cab161dc7cc1d1aea84e542799becf0147e",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xbe241D1B7b54bF06742cefd45A3440C6562f7603",
-      "txHash": "0x0553c77aa4aba0a0d5c348f0075eedf062399a1b36c2f599a3a9c024d8fa173f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE4F89Fb0dBb45378633c05ACAb071eB998F0A736",
-      "txHash": "0x98660a5782bbd280d198bf2d197724877f9c350aae50c4684d49cabeb2f13ceb",
       "kind": "transparent"
     },
     {
@@ -558,6 +373,526 @@
     {
       "address": "0x09DC2cba1450d7E22bf68866E41e24c75BE13723",
       "txHash": "0x0d4b77fcd26be336d853068f4c3386a47ee9d5231cbc6473743ee9f0ccf7803d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
+      "txHash": "0xce73bd2647ea5e3b9c4eb6a5522dca35b12b121555332e11c6d8d926e2691466",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+      "txHash": "0x237733e57d7fcfea3f1eb0de91317c2c6c3482965d671a7c5ad64e34e7d1e6f0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44",
+      "txHash": "0xec7348f974f7495c3e28bcc266834813d94312c01eb68244bacd4bfa0689ad6c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
+      "txHash": "0x06e0806ae8e86b52cc10ce3fd4ab0bff112ed5c062552c6c20b906ef8981e870",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+      "txHash": "0xf3fc179d5a802c9a91040a467e33b5333152330f0955248f3da98ad205bcb12f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x71C95911E9a5D330f4D621842EC243EE1343292e",
+      "txHash": "0xf48a3a28adc140369f38a297ce6774a93a811057a624d10ebef042d13093bd56",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x663F3ad617193148711d28f5334eE4Ed07016602",
+      "txHash": "0xe06da778da7d71da99b956c0e3cdd3bd10d72d39f6c6fac82d5473153f49c552",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2E983A1Ba5e8b38AAAeC4B440B9dDcFBf72E15d1",
+      "txHash": "0x6d9a18a72467fc6c1aabe87db42897bef91efef5592cf2fc37eb2b8b0ff556a0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+      "txHash": "0x09696a9ba555d69e7d467b395f3c674c6e399f76e03862444a010aa06114906f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F",
+      "txHash": "0xff545614b1818ac3e158b377e4b69edc9f209cecf8b46ddc67a51be6bc577637",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x8438Ad1C834623CfF278AB6829a248E37C2D7E3f",
+      "txHash": "0xac5786ea409c9cd55c12ee4bf03cd9cdf0c08bc6e46cda0b49025f3e58e1d1b1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xBC9129Dc0487fc2E169941C75aABC539f208fb01",
+      "txHash": "0x01c128a005e87284f3d075e4cb77250a86882f20a86929a3e5383740fc2c63ec",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
+      "txHash": "0x788bbde3e4d8ff758620daaa6fc0959083f14c95c4a6637799a705f1a29da3a7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x712516e61C8B383dF4A63CFe83d7701Bce54B03e",
+      "txHash": "0x5699b745a88d69a5bfbe976c24b3ec5207596c39331ed0d41eb199a7bd42012e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6e989C01a3e3A94C973A62280a72EC335598490e",
+      "txHash": "0x57ea94d3e2e01179bf3d7083c95ce5cb6beefd0d86bffac8154cfeef7bb7fec4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xF6168876932289D073567f347121A267095f3DD6",
+      "txHash": "0x13680b5a31d6a3e3838fe1076735fd8e04a8bde7e36ec9b35d77125ff1f59158",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+      "txHash": "0x90cf75d03f33db18a819d82d20a94d0ca82c4c508128be3e22753b512f18b310",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xbCF26943C0197d2eE0E5D05c716Be60cc2761508",
+      "txHash": "0xbd379a78b194e4b10545b2d6d0479516b3d70419338356fd9131f0439e3330ba",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x94B75AA39bEC4cB15e7B9593C315aF203B7B847f",
+      "txHash": "0xf017ba90dd9a5ebedbbaa0ea0d33438ccdd3f605a0922dcd46aae6abccfcd2a1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x13D69Cf7d6CE4218F646B759Dcf334D82c023d8e",
+      "txHash": "0xb6e252bde9c418e96a02f43171b187855f960408e87f0e4f79cee6e738327d77",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+      "txHash": "0x5bf248a5b1046fd01392ee18e805ab1f0fab1f030a61f15e9bbdb8600f5d411f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1275D096B9DBf2347bD2a131Fb6BDaB0B4882487",
+      "txHash": "0x2a6270717ba9a5702913e117058b93b2942839d92ba7b03d9b2702031c3c9564",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE7C2a73131dd48D8AC46dCD7Ab80C8cbeE5b410A",
+      "txHash": "0xa638a250ce1410c552d19c72eac483afa8567f6cbd0ededfad0ab201ecdd1777",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6cffa31dd31cF649fb24AC7cEfE87579324bD89c",
+      "txHash": "0xa1548a3ef5ee145ba77fa0ddbc2dd40034009f4274267a4fe149b78889e11864",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x59b670e9fA9D0A427751Af201D676719a970857b",
+      "txHash": "0xf4112542f219b445eb4181e29838ac9dc384fdcd78177726128bd924cc27a4c0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x05Aa229Aec102f78CE0E852A812a388F076Aa555",
+      "txHash": "0x206b2e30c950ceaa06bb0340ea90e229ceed46bb6adb35f9b9861fe6c23182c1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0124189Fc71496f8660dB5189F296055ED757632",
+      "txHash": "0x982f4b08ed2c70644efa63b8f40df0e1d29d5e33160dafc237869c1947b2aa6c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4F41b941940005aE25D5ecB0F01BaDbc7065E2dD",
+      "txHash": "0x2771792b78e5b5927b49e491fe9485c59718d488c15391248faa61cd9e10de60",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
+      "txHash": "0xdfb20485f39431d56362404ac60d594bd98ae12f9de7f947ff8a2b7217f7ddd7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0f5D1ef48f12b6f691401bfe88c2037c690a6afe",
+      "txHash": "0x5dd676b0f26ebd4e2c1a956b2988d6bb5a0be10a57abfc8446df1311bbc9861a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x558785b76e29e5b9f8Bf428936480B49d71F3d76",
+      "txHash": "0xffb93223aa1eba8a34dff78c8aaac09d0b6090e50bd4c8da3e14d6ef3dabbcde",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x71550ac84Ba7599220eAEf5C756b847cB4486606",
+      "txHash": "0x3f47e3e71b11316df76accf58cccee3968a190d2b21e8c42c2d1c559b0e05a34",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
+      "txHash": "0xade18e38cc2c494de67b1d71697814e1542b56ea71739bf6adf4758c7c8bd1d5",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2dE080e97B0caE9825375D31f5D0eD5751fDf16D",
+      "txHash": "0x5abcc5071f6a1b60268df15f6fab2c594f00018474732aff3598ab6ce60da540",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x050499eBdbBBc1216011dE07A48b5182c983Ae74",
+      "txHash": "0xf50a80a0789bfcd88a893fe32dc1bb6c2a21b6f4d8680c58d86cddcb4bc318c9",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5F1e91d509cFEB544809B0749284DEB25C3a113a",
+      "txHash": "0xc286a65b4c0c8df356e3471cc5d144fccdcd7ef071d4e7c7878dbae8c6eeab0a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
+      "txHash": "0x629c1b924e4b567611491fc7f3a147b109de9566bbfb1b2bfe46dd54f8a0a1ff",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x381445710b5e73d34aF196c53A3D5cDa58EDBf7A",
+      "txHash": "0xdf43fb23696ad17ff1cb459a043174cffa37bb4928e2e9cfdf40e5cb055ec6b7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x029A31eDd4C791C99387B318cbc352EA4D3f64bf",
+      "txHash": "0xf88b45b7dcd772a2f7e0a34dfb6c19044fc20bee49549e8e851f8e864edddff4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf764adBB39386BC744d533649D1EE3c86b0D6fD1",
+      "txHash": "0xaa27b25b642744ceb6d2365fbc839f60439879df30dd586023611c7d0f9f3f5b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9E545E3C0baAB3E08CdfD552C960A1050f373042",
+      "txHash": "0xedb0c53c65e610b45220cb8cdf29f87cd77b373ccd82ec3e4614063a08aad9e4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5C7c905B505f0Cf40Ab6600d05e677F717916F6B",
+      "txHash": "0xf05e6ee043d8793756a325c7720bd42e97a0fbe34e42e83f2517c85448ba2e4b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xA9639c9bA80dcF06e858C6495a72e4661C059Fe3",
+      "txHash": "0xd2065fd90450d9d2d632bd12ce754009fad2fc5bc1747cf1afee6acc553a36e0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9726Fc549AcaA0791d8c170843a031ec1D2f8a68",
+      "txHash": "0x26ceef48f9f4196f302fcac3755d675d3a2ea8f590345d5d5fb170b12c134e07",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x851356ae760d987E095750cCeb3bC6014560891C",
+      "txHash": "0x3e13e95c1878cd1cd87e846382f3c1f7c4305d398c2eb8e317d61671f3b3ac11",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x85C5Dd61585773423e378146D4bEC6f8D149E248",
+      "txHash": "0xfad18404026489ee63cda9d17bdc20a43648dbcced9d1d8400d71375d5cf0c9b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x95AF2694e3359a8DF8294E7A3ad66E68F7066dB9",
+      "txHash": "0x5ab90e24c4dbcc37f843cb47002f65b8efcc428c8696dd15a16256cea1678322",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2348f027Dc1C4884a457cfA92472Bd5Ed67E3a70",
+      "txHash": "0x49602e2e7cf8f2a7dd5caa16a3be9c2be4545e9fc6923a7893cb2612ddd6a903",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x998abeb3E57409262aE5b751f60747921B33613E",
+      "txHash": "0x793ca489d5fc38c480129759c6b9864ba40b8569e10837a72e88c6617fe9bd9d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2fc631e4B3018258759C52AF169200213e84ABab",
+      "txHash": "0xfe533b11a5306c24abdcdef00bceecbb6c4630b151672baf6d445df6128c714a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0b80e3f7b9038Cc182b1F647F907eD8DB00aC0Ff",
+      "txHash": "0x29ce1bee3b12bb26b070f772ac90c29ee114167e87f29b0aea370fcef9d2697f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x130C277872F3F03EFF2fEd0C1a03B67D3036FA64",
+      "txHash": "0xc2f0c1a29130bee9962c2913060d8077b889e7e45f6344153b53deaa008343e3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
+      "txHash": "0x840ca9b8ce04370ad5498eb2f1eabd6516f3276e15bfc6a1512f3129dfd8a266",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1e2F4432bFeF9E9Ad39DA6d272F4aFf33629c770",
+      "txHash": "0xd3338ee5eeff0e3f95fed72734d9915683e26d5c5256b992b99a84ff29f24539",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1B5F7Bdc3eDB8D4273a6EA10489a6E19d16DC60C",
+      "txHash": "0x19834398da9a9c7e47d3388e03906ff8b83010bf7aac6e13a1d58a401cd12786",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x65007C1351d9fBb88d49533c843cb1ef589557FE",
+      "txHash": "0x4d5a2eabc767b0b6f1efc3456ac3237964c5476371f51a0956ac213674cddb2d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9d4454B023096f34B160D6B654540c56A1F81688",
+      "txHash": "0xc114367c0a4c923eb8b986d2a11f28464de40ff3ddab72ea62cccec9691a8f94",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xed17543171C1459714cdC6519b58fFcC29A3C3c9",
+      "txHash": "0x21265a81d1cfe6d5b2c54bdf2126b76238746c2ee647a3458bc2139b843843b1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x774f5C00707DaB6A1E41636AE4803aD620A0f53E",
+      "txHash": "0xfe63528ce3a20bb60d22a57f5d94004c9c6b125169f18ef092f89b6150387460",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xcDd73a57d8d27124040D02E52E3748E1C0117e88",
+      "txHash": "0x437a67268551245eba87841843c407de2f045328ab2dd0d85ca7ed17b88a5c51",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+      "txHash": "0x2ec67f12180d948f4b4b921a057787b76529c9100bfa431e04f6a8eeb80cf9b8",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xcEC91d876E8f003110D43381359b1bAd124e7F2b",
+      "txHash": "0x221303d9c1e518904e20abab77e388c53db83b999c19d181291f77d39eabadee",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x981a7614afb87Cd0F56328f72660f3FbFa2EF30e",
+      "txHash": "0xd2b5869c46f3fc3d96a28f81b12b831328f109229c98a83ed9a779b312693ad3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x121525a50836042846362fAAB126168b998D1cF2",
+      "txHash": "0xd1b69eb6ae3902a1b04813d4bbb9245c8a662605f579ae8674644ddf64bb4a85",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154",
+      "txHash": "0x5cae2d0af98cca5f2cc658f1d10dfbaba8be990106af782080ac9597b2e0c52f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xF818A7C2AFC45cF4B9DDC48933C9A1edD624e46f",
+      "txHash": "0xf59c95ced2af6a67ca82ebf342cdc74c7a8700bae81476278e60f54aa95e1e51",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xBE95c3f554e9Fc85ec51bE69a3D807A0D55BCF2C",
+      "txHash": "0x1580297f652b98d1127a9b7dbae2a29eb15092e96374544164172a1355d6f8d9",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xEaA95FF42CE9b59D539805b7220a63E426566830",
+      "txHash": "0xbc58e1918349dc3bbd0e1d783c9dca0eaa033a7740664505430e7da1e23934b6",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
+      "txHash": "0x090f80eef65c7c06ad3a2065823c533fb787ff07f3cbf203e11b777b697c0be3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE5BD5bDC03371fB239956dbbF40bD185D6c2ea28",
+      "txHash": "0xd9db66705040c09fd797e766abf2850e7b1f3a62a733118a1d677823bd972c9b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x085a1Ec0d51f4541d81a442a0Df4c9E9C70D7D1e",
+      "txHash": "0xe03ad0148b1a792441744753296bb8ac904b7dfcb68ae23048ccaedc182eff2f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6A803B8F038554AF34AC73F1C099bd340dcC7026",
+      "txHash": "0x6fec0b2a56879ff5e1015c1dc8e2bd91015699cfa7f514f7f1947e921d1a951c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f",
+      "txHash": "0x00fe14cd42c277d923ee17843a92a33bb4cc0724a9c2c568011bf445508dbe2f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x7290f72B5C67052DDE8e6E179F7803c493e90d3f",
+      "txHash": "0xce40930faafc490da95bf3a27685491f0117fbb565cb495989a99c71e88ec66b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1C0AEba12EEb939c87884d207d695A5D938E496c",
+      "txHash": "0x6d629b68907d9712ce3aeae282838b053f16879a23dc464717d1cbb03ae72ba0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9DF5f35792A9cc08CDDC250279a4ce6126BE0476",
+      "txHash": "0x802f27168d0b5e808bb7b1ddc0afa19377b0d4f1f67da0f047c9a8f4e61c5883",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xdbC43Ba45381e02825b14322cDdd15eC4B3164E6",
+      "txHash": "0x5d5f9e8d0644b0be7e1123f17af2cc0fda1abcfdb9cea398f2c31913e467d850",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x093e8F4d8f267d2CeEc9eB889E2054710d187beD",
+      "txHash": "0x166b6a50b7907e025002b349547a025397604d464126c6c8b0d9ef0f81de0c1c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xDbBFC50202D116773A35673Af5b0e6c3CE0802C0",
+      "txHash": "0xdf8f5b5bb8f7a5a107e1ae2a58adac4f385d6fad05515ecc57febb488bebdde6",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf4668673B9378795e13EB43061844A5953949659",
+      "txHash": "0x7a421c3f8a984eb0a3a36afe542f8e1f43351e16fba57dcbad8e0f17f45b072c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
+      "txHash": "0xed84b0590e4a78b26ae9130bb42b4240cadfc764e651ce90ad9bb1f3eb37f6ad",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa85b028984bC54A2a3D844B070544F59dDDf89DE",
+      "txHash": "0x8b48b3f07372f39ff4fe54b5cf75b6f7fbc89b9d5e727993e633e9981f8802bf",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xd18cE8F45b7d21234eC502646e17Df647a7349A6",
+      "txHash": "0x328194a1d5d930d36c6781bff4dc33435e8f60b4ceb641fc8282022a28647c51",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xA8952908e8E5404a0719e07f6B073b400A4DDE55",
+      "txHash": "0xecef2d1e6c7bcd696032c8fc0e6f499793507d3b32c10bd97b38b9376241880b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B",
+      "txHash": "0x9c544469aaac81f9dfc78e2a88fadb6a3be5c538faced288cddfc35197cded3d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x35D2F51DBC8b401B11fA3FE04423E0f5cd9fEDb4",
+      "txHash": "0x1e7834f44155f46d7783d99d766718c416b0c3d60431bc2142b8a5f6a6ea557b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6654dCEf5F156EbFC7F7d115a9952083Fd650697",
+      "txHash": "0x96106fb7ad404641b313f5c1b57c7a450b012c08a24d44543282a3db51a0b2fe",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE09B6da11bE36396Ca8dc568880747c928c7B9DA",
+      "txHash": "0xe980d3031edd19b2abf5e07c8cd50d88e891bb539cd5860b1a8374d0138985f4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xC9a43158891282A2B1475592D5719c001986Aaec",
+      "txHash": "0x0b93c7e7cc8bc4c90855e0e3ece033a1226422661abd1307629bfaf12e094bff",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xbe241D1B7b54bF06742cefd45A3440C6562f7603",
+      "txHash": "0x2ab41b6e6df14293f948684a0332abed2b8f65e7b77ca6aa56c0d0c5e3783d70",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x758675ee1D9C6e24034355f8C5A89fceDBe99730",
+      "txHash": "0xb428ceaa08e7f4537d8b6519cd9bf68738c3175b6d73b1619d21137021675f34",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa9CA52Ef69b5360FEb1FD5478a870D8442662355",
+      "txHash": "0xfc351aead92bc21f99a7daeb888d0ea8ff6c2baf77d6e1247d733f80dbe7a3c8",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4631BCAbD6dF18D94796344963cB60d44a4136b6",
+      "txHash": "0x91ebb7d0c41c2ab6dcdc7f386f56dc4d50e06151c38663cc4099de725ef94701",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE4F89Fb0dBb45378633c05ACAb071eB998F0A736",
+      "txHash": "0x75453d998ebb31ea46030cad7375034ca9e22ac7af66adc3870b3d53fb42a9ba",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE77552Eb433Da759A19cee23793335e0f37D6e2B",
+      "txHash": "0x666035a66bd9f88b393d7b824f19719532a9970e8acccfd9bcd6fb67638b2a70",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE25CB03E85EC26E077935997a01cD3371baa457b",
+      "txHash": "0xafdc1366bafd2ecea8d0e0266d33b9f91deb8ae36625c563f7080082a5e994e1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3",
+      "txHash": "0x1b422fefd39cbaf2683e6003833ec8e25a0c6b2dd0d932aec40281965471d4e7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1dBDba33dfA381bCC89FCe74DFF69Aa96B53b503",
+      "txHash": "0xf73b122385a500e3c30e85827fce8358e92c5beb03e3a0f0e0fb21d012d0b55a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2dab84757226C2B00386Fe39CFa55eB3FAF2c2dE",
+      "txHash": "0xb6e48d8154dea79537b9ecab8a251ab7c7e2b309ed843fd56c2937f42ecf1f12",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xAfB44a95ebaBe34Cb991A3f3d6b9f89FaA28711E",
+      "txHash": "0xa2200a192286a71773ad8e0ab64b2114880c2e3390c8e655d5c40bfedb116768",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xD5ac451B0c50B9476107823Af206eD814a2e2580",
+      "txHash": "0x7351ab5e58e9a693381fce17aed6db54a36aafcf307f802aa855159f10bfcd66",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9Fe28b717aDE38BA99E32c45BE3Ee4291f2E338B",
+      "txHash": "0x7326dc43b1e4c733cbce4d9bfeccc6ad884a02e4c92ccc2896502d46749acb04",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x080E497C3EedC9E3D5D8225D2Ff62639bDdeb62E",
+      "txHash": "0x291ccda49fa2a6b38d5a6d107941dbe60199647ec30ae3da9b17ae4e881b592b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x09EC9819B6c3777c5C28C9Eebf5fb62cd0DbA479",
+      "txHash": "0x76393561087ad01f2e0e3de49a0838ee27e63e5a4a9ce4aa43582da48b0d078f",
       "kind": "transparent"
     }
   ],
@@ -730,8 +1065,8 @@
       }
     },
     "04c30e822e3c14e270d7fd06be77fecbe54ef6743173d7a5f8467bb5293891c4": {
-      "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-      "txHash": "0xe0f58bc7918514637326875088d2fc08ee6e2b53f385345fd697a626347fdefe",
+      "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+      "txHash": "0xeabbd99d92ef78feb88d461f9868b15f738affc7d839376be6d6460027248803",
       "layout": {
         "storage": [
           {
@@ -898,7 +1233,7 @@
     },
     "9a1fd00aa22d923bf09a54a571e542075394a2b74a56e2a438b432e4af7264a5": {
       "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
-      "txHash": "0x30ec15e45c5b4d29059ee07778c0100e4e7e9fe2cbaf7d40a86206c5f0515bd5",
+      "txHash": "0x9b98e29c98ca3f8c88064e2d9f0311c9ffc47ca7eecb6fa01d64a64375be692a",
       "layout": {
         "storage": [
           {
@@ -928,19 +1263,19 @@
           {
             "contract": "ZapMarketV2",
             "label": "_tokenBidders",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)9114_storage)))",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)11062_storage)))",
             "src": "contracts/nft/upgradeTests/ZapMarketV2.sol:35"
           },
           {
             "contract": "ZapMarketV2",
             "label": "_bidShares",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)9129_storage))",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)11077_storage))",
             "src": "contracts/nft/upgradeTests/ZapMarketV2.sol:39"
           },
           {
             "contract": "ZapMarketV2",
             "label": "_tokenAsks",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)9119_storage))",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)11067_storage))",
             "src": "contracts/nft/upgradeTests/ZapMarketV2.sol:42"
           },
           {
@@ -966,19 +1301,19 @@
           "t_array(t_address)dyn_storage": {
             "label": "address[]"
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)9114_storage)))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)11062_storage)))": {
             "label": "mapping(address => mapping(uint256 => mapping(address => struct IMarket.Bid)))"
           },
-          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)9114_storage))": {
+          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)11062_storage))": {
             "label": "mapping(uint256 => mapping(address => struct IMarket.Bid))"
           },
           "t_uint256": {
             "label": "uint256"
           },
-          "t_mapping(t_address,t_struct(Bid)9114_storage)": {
+          "t_mapping(t_address,t_struct(Bid)11062_storage)": {
             "label": "mapping(address => struct IMarket.Bid)"
           },
-          "t_struct(Bid)9114_storage": {
+          "t_struct(Bid)11062_storage": {
             "label": "struct IMarket.Bid",
             "members": [
               {
@@ -999,11 +1334,11 @@
               },
               {
                 "label": "sellOnShare",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               }
             ]
           },
-          "t_struct(D256)5190_storage": {
+          "t_struct(D256)7089_storage": {
             "label": "struct Decimal.D256",
             "members": [
               {
@@ -1012,36 +1347,36 @@
               }
             ]
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)9129_storage))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)11077_storage))": {
             "label": "mapping(address => mapping(uint256 => struct IMarket.BidShares))"
           },
-          "t_mapping(t_uint256,t_struct(BidShares)9129_storage)": {
+          "t_mapping(t_uint256,t_struct(BidShares)11077_storage)": {
             "label": "mapping(uint256 => struct IMarket.BidShares)"
           },
-          "t_struct(BidShares)9129_storage": {
+          "t_struct(BidShares)11077_storage": {
             "label": "struct IMarket.BidShares",
             "members": [
               {
                 "label": "prevOwner",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               },
               {
                 "label": "creator",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               },
               {
                 "label": "owner",
-                "type": "t_struct(D256)5190_storage"
+                "type": "t_struct(D256)7089_storage"
               }
             ]
           },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)9119_storage))": {
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)11067_storage))": {
             "label": "mapping(address => mapping(uint256 => struct IMarket.Ask))"
           },
-          "t_mapping(t_uint256,t_struct(Ask)9119_storage)": {
+          "t_mapping(t_uint256,t_struct(Ask)11067_storage)": {
             "label": "mapping(uint256 => struct IMarket.Ask)"
           },
-          "t_struct(Ask)9119_storage": {
+          "t_struct(Ask)11067_storage": {
             "label": "struct IMarket.Ask",
             "members": [
               {

--- a/.openzeppelin/unknown-31337.json
+++ b/.openzeppelin/unknown-31337.json
@@ -1,14 +1,14 @@
 {
   "manifestVersion": "3.2",
   "admin": {
-    "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-    "txHash": "0x9bc903cc77214bf298f7673a0f16b6a5fd78bf5141aeed50a189dec76b37ca94",
+    "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "txHash": "0xfc997bab2416cabbab0ed4d2bfb452812afcf612373953a343e18242498d71aa",
     "deployTransaction": {
-      "hash": "0x9bc903cc77214bf298f7673a0f16b6a5fd78bf5141aeed50a189dec76b37ca94",
+      "hash": "0xfc997bab2416cabbab0ed4d2bfb452812afcf612373953a343e18242498d71aa",
       "type": 0,
       "accessList": null,
-      "blockHash": "0xad8eb84eeafc782a7f3f2a8d0ec837ba9ad66778ba0c47678bc954c156b10dfd",
-      "blockNumber": 3,
+      "blockHash": "0x630dba48354f3d7232e461d6a225c94c2461118a1adb6934a947aa2a780dabf9",
+      "blockNumber": 2,
       "transactionIndex": 0,
       "confirmations": 1,
       "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -25,21 +25,16 @@
         "type": "BigNumber",
         "hex": "0x00"
       },
-      "nonce": 2,
+      "nonce": 1,
       "data": "0x608060405234801561001057600080fd5b50600080546001600160a01b031916339081178255604051909182917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350610759806100616000396000f3fe60806040526004361061007b5760003560e01c80639623609d1161004e5780639623609d1461011157806399a88ec414610124578063f2fde38b14610144578063f3b7dead146101645761007b565b8063204e1c7a14610080578063715018a6146100bc5780637eff275e146100d35780638da5cb5b146100f3575b600080fd5b34801561008c57600080fd5b506100a061009b366004610515565b610184565b6040516001600160a01b03909116815260200160405180910390f35b3480156100c857600080fd5b506100d1610215565b005b3480156100df57600080fd5b506100d16100ee366004610554565b610292565b3480156100ff57600080fd5b506000546001600160a01b03166100a0565b6100d161011f36600461058c565b61031c565b34801561013057600080fd5b506100d161013f366004610554565b6103ad565b34801561015057600080fd5b506100d161015f366004610515565b610405565b34801561017057600080fd5b506100a061017f366004610515565b6104ef565b6000806000836001600160a01b03166040516101aa90635c60da1b60e01b815260040190565b600060405180830381855afa9150503d80600081146101e5576040519150601f19603f3d011682016040523d82523d6000602084013e6101ea565b606091505b5091509150816101f957600080fd5b8080602001905181019061020d9190610538565b949350505050565b6000546001600160a01b031633146102485760405162461bcd60e51b815260040161023f906106c0565b60405180910390fd5b600080546040516001600160a01b03909116907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600080546001600160a01b0319169055565b6000546001600160a01b031633146102bc5760405162461bcd60e51b815260040161023f906106c0565b6040516308f2839760e41b81526001600160a01b038281166004830152831690638f283970906024015b600060405180830381600087803b15801561030057600080fd5b505af1158015610314573d6000803e3d6000fd5b505050505050565b6000546001600160a01b031633146103465760405162461bcd60e51b815260040161023f906106c0565b60405163278f794360e11b81526001600160a01b03841690634f1ef286903490610376908690869060040161065d565b6000604051808303818588803b15801561038f57600080fd5b505af11580156103a3573d6000803e3d6000fd5b5050505050505050565b6000546001600160a01b031633146103d75760405162461bcd60e51b815260040161023f906106c0565b604051631b2ce7f360e11b81526001600160a01b038281166004830152831690633659cfe6906024016102e6565b6000546001600160a01b0316331461042f5760405162461bcd60e51b815260040161023f906106c0565b6001600160a01b0381166104945760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b606482015260840161023f565b600080546040516001600160a01b03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a3600080546001600160a01b0319166001600160a01b0392909216919091179055565b6000806000836001600160a01b03166040516101aa906303e1469160e61b815260040190565b600060208284031215610526578081fd5b81356105318161070b565b9392505050565b600060208284031215610549578081fd5b81516105318161070b565b60008060408385031215610566578081fd5b82356105718161070b565b915060208301356105818161070b565b809150509250929050565b6000806000606084860312156105a0578081fd5b83356105ab8161070b565b925060208401356105bb8161070b565b9150604084013567ffffffffffffffff808211156105d7578283fd5b818601915086601f8301126105ea578283fd5b8135818111156105fc576105fc6106f5565b604051601f8201601f19908116603f01168101908382118183101715610624576106246106f5565b8160405282815289602084870101111561063c578586fd5b82602086016020830137856020848301015280955050505050509250925092565b600060018060a01b038416825260206040818401528351806040850152825b818110156106985785810183015185820160600152820161067c565b818111156106a95783606083870101525b50601f01601f191692909201606001949350505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461072057600080fd5b5056fea2646970667358221220d849f96f3086b9f82cdcf665adb8c697ace05638da1c7c16ab2d26293717af6764736f6c63430008020033",
-      "r": "0xd00716dc3ea1eda6a4fe89edb4fd83550211c634c6a0375a442d6b15ebf6cb26",
-      "s": "0x57f4a3ce011a4bb60437fcc8957742763c293205a853c3bb937adcdf289e144e",
+      "r": "0x1c501eaff101eb0fd50f3d61cad5b95b69fa8978b15d642a1015beb754b34a14",
+      "s": "0x52f6f024edd064c867079e794e20458a427d10082043eac528701b2460a74fd6",
       "v": 62710,
-      "creates": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+      "creates": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
       "chainId": 31337
     }
   },
   "proxies": [
-    {
-      "address": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
-      "txHash": "0x2076ab77dcab9943e1f84462bb209313cf80e8de37bfe2b923f58c66d8004f7a",
-      "kind": "transparent"
-    },
     {
       "address": "0xc5a5C42992dECbae36851359345FE25997F5C42d",
       "txHash": "0x549bb86adca9b3ad901bb6c941f0bf01395726b6c6600148f41cef5dfaeb507b",
@@ -88,16 +83,6 @@
     {
       "address": "0xfbC22278A96299D91d41C453234d97b4F5Eb9B2d",
       "txHash": "0x41a1a0106e8b764b84b39dadc7b1bb98e1137721e37b381b8cb86d74d3cb1c95",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
-      "txHash": "0x62f61db4fbd8c087fa3a9d63153d2cc3fbe92d256e9f05ebdee66df660d2574f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
-      "txHash": "0xf1588865f18a3682b8121d61f403e3653e21aa0d4f9217959deda69f1e466fdc",
       "kind": "transparent"
     },
     {
@@ -171,8 +156,513 @@
       "kind": "transparent"
     },
     {
+      "address": "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
+      "txHash": "0x06e0806ae8e86b52cc10ce3fd4ab0bff112ed5c062552c6c20b906ef8981e870",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
+      "txHash": "0xe62e2c172b783c57d558c0f59b30558f24f6ce4f7a9b70f872a3162794421212",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+      "txHash": "0xb60b290c1a451b5fb5d4327d86c115b1b8eb11a96bea2794e8f71a7910ad3ba5",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+      "txHash": "0xe14f46d0b2cf3ebbcc4a4a9a8fbff6d59abe7b1aa69bd8220e458674581e9ace",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+      "txHash": "0x33eda2d05e3316f1b4688e45fff88b5c40b043772b0364530374e8d8145c74f1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+      "txHash": "0x6c4bf3a362d7aa9d015604cc450a22e1a24b1819b95487076ceda0d8bde218ca",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1",
+      "txHash": "0xc8722c19bd408023ea8a3de0c85080245525add240c288e09298dd1c9483f221",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+      "txHash": "0x1d9c232b6b6a125147b4e6ec370f606462ae29f5b4a205bdb2b9511a59f78216",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
+      "txHash": "0x29c3e42f0de7f280029cde380ff5b7e2fde4dccaf5597afd28145b681bcb06eb",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44",
+      "txHash": "0xa63db93c2f3d062126363ab3edcb59d8f0ae2bdb7ca93e5868a34c7081fafdbd",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+      "txHash": "0xf3fc179d5a802c9a91040a467e33b5333152330f0955248f3da98ad205bcb12f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+      "txHash": "0x09696a9ba555d69e7d467b395f3c674c6e399f76e03862444a010aa06114906f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x8438Ad1C834623CfF278AB6829a248E37C2D7E3f",
+      "txHash": "0xac5786ea409c9cd55c12ee4bf03cd9cdf0c08bc6e46cda0b49025f3e58e1d1b1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xBC9129Dc0487fc2E169941C75aABC539f208fb01",
+      "txHash": "0x01c128a005e87284f3d075e4cb77250a86882f20a86929a3e5383740fc2c63ec",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
+      "txHash": "0x788bbde3e4d8ff758620daaa6fc0959083f14c95c4a6637799a705f1a29da3a7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x712516e61C8B383dF4A63CFe83d7701Bce54B03e",
+      "txHash": "0x5699b745a88d69a5bfbe976c24b3ec5207596c39331ed0d41eb199a7bd42012e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6e989C01a3e3A94C973A62280a72EC335598490e",
+      "txHash": "0x57ea94d3e2e01179bf3d7083c95ce5cb6beefd0d86bffac8154cfeef7bb7fec4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xF6168876932289D073567f347121A267095f3DD6",
+      "txHash": "0x13680b5a31d6a3e3838fe1076735fd8e04a8bde7e36ec9b35d77125ff1f59158",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+      "txHash": "0x90cf75d03f33db18a819d82d20a94d0ca82c4c508128be3e22753b512f18b310",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xbCF26943C0197d2eE0E5D05c716Be60cc2761508",
+      "txHash": "0xbd379a78b194e4b10545b2d6d0479516b3d70419338356fd9131f0439e3330ba",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x94B75AA39bEC4cB15e7B9593C315aF203B7B847f",
+      "txHash": "0xf017ba90dd9a5ebedbbaa0ea0d33438ccdd3f605a0922dcd46aae6abccfcd2a1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+      "txHash": "0x5bf248a5b1046fd01392ee18e805ab1f0fab1f030a61f15e9bbdb8600f5d411f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1275D096B9DBf2347bD2a131Fb6BDaB0B4882487",
+      "txHash": "0x2a6270717ba9a5702913e117058b93b2942839d92ba7b03d9b2702031c3c9564",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE7C2a73131dd48D8AC46dCD7Ab80C8cbeE5b410A",
+      "txHash": "0xa638a250ce1410c552d19c72eac483afa8567f6cbd0ededfad0ab201ecdd1777",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6cffa31dd31cF649fb24AC7cEfE87579324bD89c",
+      "txHash": "0xa1548a3ef5ee145ba77fa0ddbc2dd40034009f4274267a4fe149b78889e11864",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x59b670e9fA9D0A427751Af201D676719a970857b",
+      "txHash": "0xf4112542f219b445eb4181e29838ac9dc384fdcd78177726128bd924cc27a4c0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x05Aa229Aec102f78CE0E852A812a388F076Aa555",
+      "txHash": "0x206b2e30c950ceaa06bb0340ea90e229ceed46bb6adb35f9b9861fe6c23182c1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0124189Fc71496f8660dB5189F296055ED757632",
+      "txHash": "0x982f4b08ed2c70644efa63b8f40df0e1d29d5e33160dafc237869c1947b2aa6c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4F41b941940005aE25D5ecB0F01BaDbc7065E2dD",
+      "txHash": "0x2771792b78e5b5927b49e491fe9485c59718d488c15391248faa61cd9e10de60",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
+      "txHash": "0xdfb20485f39431d56362404ac60d594bd98ae12f9de7f947ff8a2b7217f7ddd7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0f5D1ef48f12b6f691401bfe88c2037c690a6afe",
+      "txHash": "0x5dd676b0f26ebd4e2c1a956b2988d6bb5a0be10a57abfc8446df1311bbc9861a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x558785b76e29e5b9f8Bf428936480B49d71F3d76",
+      "txHash": "0xffb93223aa1eba8a34dff78c8aaac09d0b6090e50bd4c8da3e14d6ef3dabbcde",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x71550ac84Ba7599220eAEf5C756b847cB4486606",
+      "txHash": "0x3f47e3e71b11316df76accf58cccee3968a190d2b21e8c42c2d1c559b0e05a34",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
+      "txHash": "0xade18e38cc2c494de67b1d71697814e1542b56ea71739bf6adf4758c7c8bd1d5",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2dE080e97B0caE9825375D31f5D0eD5751fDf16D",
+      "txHash": "0x5abcc5071f6a1b60268df15f6fab2c594f00018474732aff3598ab6ce60da540",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x050499eBdbBBc1216011dE07A48b5182c983Ae74",
+      "txHash": "0xf50a80a0789bfcd88a893fe32dc1bb6c2a21b6f4d8680c58d86cddcb4bc318c9",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5F1e91d509cFEB544809B0749284DEB25C3a113a",
+      "txHash": "0xc286a65b4c0c8df356e3471cc5d144fccdcd7ef071d4e7c7878dbae8c6eeab0a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
+      "txHash": "0x629c1b924e4b567611491fc7f3a147b109de9566bbfb1b2bfe46dd54f8a0a1ff",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x381445710b5e73d34aF196c53A3D5cDa58EDBf7A",
+      "txHash": "0xdf43fb23696ad17ff1cb459a043174cffa37bb4928e2e9cfdf40e5cb055ec6b7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x029A31eDd4C791C99387B318cbc352EA4D3f64bf",
+      "txHash": "0xf88b45b7dcd772a2f7e0a34dfb6c19044fc20bee49549e8e851f8e864edddff4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf764adBB39386BC744d533649D1EE3c86b0D6fD1",
+      "txHash": "0xaa27b25b642744ceb6d2365fbc839f60439879df30dd586023611c7d0f9f3f5b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9E545E3C0baAB3E08CdfD552C960A1050f373042",
+      "txHash": "0xedb0c53c65e610b45220cb8cdf29f87cd77b373ccd82ec3e4614063a08aad9e4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5C7c905B505f0Cf40Ab6600d05e677F717916F6B",
+      "txHash": "0xf05e6ee043d8793756a325c7720bd42e97a0fbe34e42e83f2517c85448ba2e4b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xA9639c9bA80dcF06e858C6495a72e4661C059Fe3",
+      "txHash": "0xd2065fd90450d9d2d632bd12ce754009fad2fc5bc1747cf1afee6acc553a36e0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9726Fc549AcaA0791d8c170843a031ec1D2f8a68",
+      "txHash": "0x26ceef48f9f4196f302fcac3755d675d3a2ea8f590345d5d5fb170b12c134e07",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x851356ae760d987E095750cCeb3bC6014560891C",
+      "txHash": "0x3e13e95c1878cd1cd87e846382f3c1f7c4305d398c2eb8e317d61671f3b3ac11",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x95AF2694e3359a8DF8294E7A3ad66E68F7066dB9",
+      "txHash": "0x5ab90e24c4dbcc37f843cb47002f65b8efcc428c8696dd15a16256cea1678322",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2348f027Dc1C4884a457cfA92472Bd5Ed67E3a70",
+      "txHash": "0x49602e2e7cf8f2a7dd5caa16a3be9c2be4545e9fc6923a7893cb2612ddd6a903",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x998abeb3E57409262aE5b751f60747921B33613E",
+      "txHash": "0x793ca489d5fc38c480129759c6b9864ba40b8569e10837a72e88c6617fe9bd9d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2fc631e4B3018258759C52AF169200213e84ABab",
+      "txHash": "0xfe533b11a5306c24abdcdef00bceecbb6c4630b151672baf6d445df6128c714a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0b80e3f7b9038Cc182b1F647F907eD8DB00aC0Ff",
+      "txHash": "0x29ce1bee3b12bb26b070f772ac90c29ee114167e87f29b0aea370fcef9d2697f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x130C277872F3F03EFF2fEd0C1a03B67D3036FA64",
+      "txHash": "0xc2f0c1a29130bee9962c2913060d8077b889e7e45f6344153b53deaa008343e3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
+      "txHash": "0x840ca9b8ce04370ad5498eb2f1eabd6516f3276e15bfc6a1512f3129dfd8a266",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1e2F4432bFeF9E9Ad39DA6d272F4aFf33629c770",
+      "txHash": "0xd3338ee5eeff0e3f95fed72734d9915683e26d5c5256b992b99a84ff29f24539",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1B5F7Bdc3eDB8D4273a6EA10489a6E19d16DC60C",
+      "txHash": "0x19834398da9a9c7e47d3388e03906ff8b83010bf7aac6e13a1d58a401cd12786",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x65007C1351d9fBb88d49533c843cb1ef589557FE",
+      "txHash": "0x4d5a2eabc767b0b6f1efc3456ac3237964c5476371f51a0956ac213674cddb2d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9d4454B023096f34B160D6B654540c56A1F81688",
+      "txHash": "0xc114367c0a4c923eb8b986d2a11f28464de40ff3ddab72ea62cccec9691a8f94",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x774f5C00707DaB6A1E41636AE4803aD620A0f53E",
+      "txHash": "0xfe63528ce3a20bb60d22a57f5d94004c9c6b125169f18ef092f89b6150387460",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xcDd73a57d8d27124040D02E52E3748E1C0117e88",
+      "txHash": "0x437a67268551245eba87841843c407de2f045328ab2dd0d85ca7ed17b88a5c51",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+      "txHash": "0x2ec67f12180d948f4b4b921a057787b76529c9100bfa431e04f6a8eeb80cf9b8",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xcEC91d876E8f003110D43381359b1bAd124e7F2b",
+      "txHash": "0x221303d9c1e518904e20abab77e388c53db83b999c19d181291f77d39eabadee",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x981a7614afb87Cd0F56328f72660f3FbFa2EF30e",
+      "txHash": "0xd2b5869c46f3fc3d96a28f81b12b831328f109229c98a83ed9a779b312693ad3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x121525a50836042846362fAAB126168b998D1cF2",
+      "txHash": "0xd1b69eb6ae3902a1b04813d4bbb9245c8a662605f579ae8674644ddf64bb4a85",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154",
+      "txHash": "0x5cae2d0af98cca5f2cc658f1d10dfbaba8be990106af782080ac9597b2e0c52f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xF818A7C2AFC45cF4B9DDC48933C9A1edD624e46f",
+      "txHash": "0xf59c95ced2af6a67ca82ebf342cdc74c7a8700bae81476278e60f54aa95e1e51",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xBE95c3f554e9Fc85ec51bE69a3D807A0D55BCF2C",
+      "txHash": "0x1580297f652b98d1127a9b7dbae2a29eb15092e96374544164172a1355d6f8d9",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xEaA95FF42CE9b59D539805b7220a63E426566830",
+      "txHash": "0xbc58e1918349dc3bbd0e1d783c9dca0eaa033a7740664505430e7da1e23934b6",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
+      "txHash": "0x090f80eef65c7c06ad3a2065823c533fb787ff07f3cbf203e11b777b697c0be3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE5BD5bDC03371fB239956dbbF40bD185D6c2ea28",
+      "txHash": "0xd9db66705040c09fd797e766abf2850e7b1f3a62a733118a1d677823bd972c9b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x085a1Ec0d51f4541d81a442a0Df4c9E9C70D7D1e",
+      "txHash": "0xe03ad0148b1a792441744753296bb8ac904b7dfcb68ae23048ccaedc182eff2f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6A803B8F038554AF34AC73F1C099bd340dcC7026",
+      "txHash": "0x6fec0b2a56879ff5e1015c1dc8e2bd91015699cfa7f514f7f1947e921d1a951c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f",
+      "txHash": "0x00fe14cd42c277d923ee17843a92a33bb4cc0724a9c2c568011bf445508dbe2f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x7290f72B5C67052DDE8e6E179F7803c493e90d3f",
+      "txHash": "0xce40930faafc490da95bf3a27685491f0117fbb565cb495989a99c71e88ec66b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1C0AEba12EEb939c87884d207d695A5D938E496c",
+      "txHash": "0x6d629b68907d9712ce3aeae282838b053f16879a23dc464717d1cbb03ae72ba0",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9DF5f35792A9cc08CDDC250279a4ce6126BE0476",
+      "txHash": "0x802f27168d0b5e808bb7b1ddc0afa19377b0d4f1f67da0f047c9a8f4e61c5883",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xdbC43Ba45381e02825b14322cDdd15eC4B3164E6",
+      "txHash": "0x5d5f9e8d0644b0be7e1123f17af2cc0fda1abcfdb9cea398f2c31913e467d850",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x093e8F4d8f267d2CeEc9eB889E2054710d187beD",
+      "txHash": "0x166b6a50b7907e025002b349547a025397604d464126c6c8b0d9ef0f81de0c1c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xDbBFC50202D116773A35673Af5b0e6c3CE0802C0",
+      "txHash": "0xdf8f5b5bb8f7a5a107e1ae2a58adac4f385d6fad05515ecc57febb488bebdde6",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf4668673B9378795e13EB43061844A5953949659",
+      "txHash": "0x7a421c3f8a984eb0a3a36afe542f8e1f43351e16fba57dcbad8e0f17f45b072c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
+      "txHash": "0xed84b0590e4a78b26ae9130bb42b4240cadfc764e651ce90ad9bb1f3eb37f6ad",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xd18cE8F45b7d21234eC502646e17Df647a7349A6",
+      "txHash": "0x328194a1d5d930d36c6781bff4dc33435e8f60b4ceb641fc8282022a28647c51",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xA8952908e8E5404a0719e07f6B073b400A4DDE55",
+      "txHash": "0xecef2d1e6c7bcd696032c8fc0e6f499793507d3b32c10bd97b38b9376241880b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B",
+      "txHash": "0x9c544469aaac81f9dfc78e2a88fadb6a3be5c538faced288cddfc35197cded3d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6654dCEf5F156EbFC7F7d115a9952083Fd650697",
+      "txHash": "0x96106fb7ad404641b313f5c1b57c7a450b012c08a24d44543282a3db51a0b2fe",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE09B6da11bE36396Ca8dc568880747c928c7B9DA",
+      "txHash": "0xe980d3031edd19b2abf5e07c8cd50d88e891bb539cd5860b1a8374d0138985f4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xC9a43158891282A2B1475592D5719c001986Aaec",
+      "txHash": "0x0b93c7e7cc8bc4c90855e0e3ece033a1226422661abd1307629bfaf12e094bff",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x758675ee1D9C6e24034355f8C5A89fceDBe99730",
+      "txHash": "0xb428ceaa08e7f4537d8b6519cd9bf68738c3175b6d73b1619d21137021675f34",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa9CA52Ef69b5360FEb1FD5478a870D8442662355",
+      "txHash": "0xfc351aead92bc21f99a7daeb888d0ea8ff6c2baf77d6e1247d733f80dbe7a3c8",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4631BCAbD6dF18D94796344963cB60d44a4136b6",
+      "txHash": "0x91ebb7d0c41c2ab6dcdc7f386f56dc4d50e06151c38663cc4099de725ef94701",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE77552Eb433Da759A19cee23793335e0f37D6e2B",
+      "txHash": "0x666035a66bd9f88b393d7b824f19719532a9970e8acccfd9bcd6fb67638b2a70",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE25CB03E85EC26E077935997a01cD3371baa457b",
+      "txHash": "0xafdc1366bafd2ecea8d0e0266d33b9f91deb8ae36625c563f7080082a5e994e1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3",
+      "txHash": "0x1b422fefd39cbaf2683e6003833ec8e25a0c6b2dd0d932aec40281965471d4e7",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x1dBDba33dfA381bCC89FCe74DFF69Aa96B53b503",
+      "txHash": "0xf73b122385a500e3c30e85827fce8358e92c5beb03e3a0f0e0fb21d012d0b55a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2dab84757226C2B00386Fe39CFa55eB3FAF2c2dE",
+      "txHash": "0xb6e48d8154dea79537b9ecab8a251ab7c7e2b309ed843fd56c2937f42ecf1f12",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xAfB44a95ebaBe34Cb991A3f3d6b9f89FaA28711E",
+      "txHash": "0xa2200a192286a71773ad8e0ab64b2114880c2e3390c8e655d5c40bfedb116768",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xD5ac451B0c50B9476107823Af206eD814a2e2580",
+      "txHash": "0x7351ab5e58e9a693381fce17aed6db54a36aafcf307f802aa855159f10bfcd66",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9Fe28b717aDE38BA99E32c45BE3Ee4291f2E338B",
+      "txHash": "0x7326dc43b1e4c733cbce4d9bfeccc6ad884a02e4c92ccc2896502d46749acb04",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x080E497C3EedC9E3D5D8225D2Ff62639bDdeb62E",
+      "txHash": "0x291ccda49fa2a6b38d5a6d107941dbe60199647ec30ae3da9b17ae4e881b592b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x09EC9819B6c3777c5C28C9Eebf5fb62cd0DbA479",
+      "txHash": "0x76393561087ad01f2e0e3de49a0838ee27e63e5a4a9ce4aa43582da48b0d078f",
+      "kind": "transparent"
+    },
+    {
       "address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
       "txHash": "0xfbe5b295a5d1b405f8af6cc2a05119da3e0e93aa8a42462fcfc5a6f783fbe1ca",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x71C95911E9a5D330f4D621842EC243EE1343292e",
+      "txHash": "0x826b21b2baec7d503e41eb6c15c9375a77bcafa291bba902ddc56cb5a0a3a43f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x663F3ad617193148711d28f5334eE4Ed07016602",
+      "txHash": "0x97b46e056b437af65a17690a73e348d56ee30d6cf00dbc81bd11419656d600b0",
       "kind": "transparent"
     },
     {
@@ -183,6 +673,16 @@
     {
       "address": "0xbdEd0D2bf404bdcBa897a74E6657f1f12e5C6fb6",
       "txHash": "0x2a675f592a7ce0506b9fd18f2d0974cd2d44a5f41b6a29b8a90f2b7d0982ea05",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F",
+      "txHash": "0xe03b93399b206543047eb9594e3540a255c7598e35cafc14f1069b0dc413ac2f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x2E983A1Ba5e8b38AAAeC4B440B9dDcFBf72E15d1",
+      "txHash": "0x551769dc9bc9489e1ccacb442e9e2f8f279d4c0c8beb9a7f55af55c60e1f9784",
       "kind": "transparent"
     },
     {
@@ -201,13 +701,28 @@
       "kind": "transparent"
     },
     {
+      "address": "0x13D69Cf7d6CE4218F646B759Dcf334D82c023d8e",
+      "txHash": "0x4b4cb3dd30d6f01763013a485c6c8fa367caa94d55db1dc84f2d1838aba07699",
+      "kind": "transparent"
+    },
+    {
       "address": "0x72bb9c7ffbE2Ed234e53bc64862DdA6d9fFF333b",
       "txHash": "0xd1c6599ef5deb0efde309c68b964fb86c7ed4176f0e3895741c5428cccdc2841",
       "kind": "transparent"
     },
     {
+      "address": "0x85C5Dd61585773423e378146D4bEC6f8D149E248",
+      "txHash": "0x4b052ebe91272660d0fb13429759b8500010e6063fed07491c24b899ce325e5e",
+      "kind": "transparent"
+    },
+    {
       "address": "0x63cf2Cd54fE91e3545D1379abf5bfd194545259d",
       "txHash": "0xf375060b01d0cc31a889802075a77872f10a2875a6a1fbd1075f176fa3102168",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xed17543171C1459714cdC6519b58fFcC29A3C3c9",
+      "txHash": "0xb982b78d582d0b5b52411b365ae6c46b5788b139d0dbe61ca3fdb2d33e7b9e22",
       "kind": "transparent"
     },
     {
@@ -228,6 +743,26 @@
     {
       "address": "0x1a6a3e7Bb246158dF31d8f924B84D961669Ba4e5",
       "txHash": "0x4c42e22268f99e2202a15f4bda8335bbe27e78b13e68a92ac4c9f0455ef22836",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa85b028984bC54A2a3D844B070544F59dDDf89DE",
+      "txHash": "0x183058427b7f042aa3bae599602bee5f3ff9365ef9ceb9a534548305b4808967",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x35D2F51DBC8b401B11fA3FE04423E0f5cd9fEDb4",
+      "txHash": "0x72658d64defc344aaf1ec7a817832cab161dc7cc1d1aea84e542799becf0147e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xbe241D1B7b54bF06742cefd45A3440C6562f7603",
+      "txHash": "0x0553c77aa4aba0a0d5c348f0075eedf062399a1b36c2f599a3a9c024d8fa173f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE4F89Fb0dBb45378633c05ACAb071eB998F0A736",
+      "txHash": "0x98660a5782bbd280d198bf2d197724877f9c350aae50c4684d49cabeb2f13ceb",
       "kind": "transparent"
     },
     {
@@ -374,699 +909,12 @@
       "address": "0x09DC2cba1450d7E22bf68866E41e24c75BE13723",
       "txHash": "0x0d4b77fcd26be336d853068f4c3386a47ee9d5231cbc6473743ee9f0ccf7803d",
       "kind": "transparent"
-    },
-    {
-      "address": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
-      "txHash": "0xce73bd2647ea5e3b9c4eb6a5522dca35b12b121555332e11c6d8d926e2691466",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
-      "txHash": "0x237733e57d7fcfea3f1eb0de91317c2c6c3482965d671a7c5ad64e34e7d1e6f0",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44",
-      "txHash": "0xec7348f974f7495c3e28bcc266834813d94312c01eb68244bacd4bfa0689ad6c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
-      "txHash": "0x06e0806ae8e86b52cc10ce3fd4ab0bff112ed5c062552c6c20b906ef8981e870",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
-      "txHash": "0xf3fc179d5a802c9a91040a467e33b5333152330f0955248f3da98ad205bcb12f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x71C95911E9a5D330f4D621842EC243EE1343292e",
-      "txHash": "0xf48a3a28adc140369f38a297ce6774a93a811057a624d10ebef042d13093bd56",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x663F3ad617193148711d28f5334eE4Ed07016602",
-      "txHash": "0xe06da778da7d71da99b956c0e3cdd3bd10d72d39f6c6fac82d5473153f49c552",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2E983A1Ba5e8b38AAAeC4B440B9dDcFBf72E15d1",
-      "txHash": "0x6d9a18a72467fc6c1aabe87db42897bef91efef5592cf2fc37eb2b8b0ff556a0",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
-      "txHash": "0x09696a9ba555d69e7d467b395f3c674c6e399f76e03862444a010aa06114906f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F",
-      "txHash": "0xff545614b1818ac3e158b377e4b69edc9f209cecf8b46ddc67a51be6bc577637",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x8438Ad1C834623CfF278AB6829a248E37C2D7E3f",
-      "txHash": "0xac5786ea409c9cd55c12ee4bf03cd9cdf0c08bc6e46cda0b49025f3e58e1d1b1",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xBC9129Dc0487fc2E169941C75aABC539f208fb01",
-      "txHash": "0x01c128a005e87284f3d075e4cb77250a86882f20a86929a3e5383740fc2c63ec",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
-      "txHash": "0x788bbde3e4d8ff758620daaa6fc0959083f14c95c4a6637799a705f1a29da3a7",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x712516e61C8B383dF4A63CFe83d7701Bce54B03e",
-      "txHash": "0x5699b745a88d69a5bfbe976c24b3ec5207596c39331ed0d41eb199a7bd42012e",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x6e989C01a3e3A94C973A62280a72EC335598490e",
-      "txHash": "0x57ea94d3e2e01179bf3d7083c95ce5cb6beefd0d86bffac8154cfeef7bb7fec4",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xF6168876932289D073567f347121A267095f3DD6",
-      "txHash": "0x13680b5a31d6a3e3838fe1076735fd8e04a8bde7e36ec9b35d77125ff1f59158",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
-      "txHash": "0x90cf75d03f33db18a819d82d20a94d0ca82c4c508128be3e22753b512f18b310",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xbCF26943C0197d2eE0E5D05c716Be60cc2761508",
-      "txHash": "0xbd379a78b194e4b10545b2d6d0479516b3d70419338356fd9131f0439e3330ba",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x94B75AA39bEC4cB15e7B9593C315aF203B7B847f",
-      "txHash": "0xf017ba90dd9a5ebedbbaa0ea0d33438ccdd3f605a0922dcd46aae6abccfcd2a1",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x13D69Cf7d6CE4218F646B759Dcf334D82c023d8e",
-      "txHash": "0xb6e252bde9c418e96a02f43171b187855f960408e87f0e4f79cee6e738327d77",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
-      "txHash": "0x5bf248a5b1046fd01392ee18e805ab1f0fab1f030a61f15e9bbdb8600f5d411f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1275D096B9DBf2347bD2a131Fb6BDaB0B4882487",
-      "txHash": "0x2a6270717ba9a5702913e117058b93b2942839d92ba7b03d9b2702031c3c9564",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE7C2a73131dd48D8AC46dCD7Ab80C8cbeE5b410A",
-      "txHash": "0xa638a250ce1410c552d19c72eac483afa8567f6cbd0ededfad0ab201ecdd1777",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x6cffa31dd31cF649fb24AC7cEfE87579324bD89c",
-      "txHash": "0xa1548a3ef5ee145ba77fa0ddbc2dd40034009f4274267a4fe149b78889e11864",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x59b670e9fA9D0A427751Af201D676719a970857b",
-      "txHash": "0xf4112542f219b445eb4181e29838ac9dc384fdcd78177726128bd924cc27a4c0",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x05Aa229Aec102f78CE0E852A812a388F076Aa555",
-      "txHash": "0x206b2e30c950ceaa06bb0340ea90e229ceed46bb6adb35f9b9861fe6c23182c1",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x0124189Fc71496f8660dB5189F296055ED757632",
-      "txHash": "0x982f4b08ed2c70644efa63b8f40df0e1d29d5e33160dafc237869c1947b2aa6c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4F41b941940005aE25D5ecB0F01BaDbc7065E2dD",
-      "txHash": "0x2771792b78e5b5927b49e491fe9485c59718d488c15391248faa61cd9e10de60",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
-      "txHash": "0xdfb20485f39431d56362404ac60d594bd98ae12f9de7f947ff8a2b7217f7ddd7",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x0f5D1ef48f12b6f691401bfe88c2037c690a6afe",
-      "txHash": "0x5dd676b0f26ebd4e2c1a956b2988d6bb5a0be10a57abfc8446df1311bbc9861a",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x558785b76e29e5b9f8Bf428936480B49d71F3d76",
-      "txHash": "0xffb93223aa1eba8a34dff78c8aaac09d0b6090e50bd4c8da3e14d6ef3dabbcde",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x71550ac84Ba7599220eAEf5C756b847cB4486606",
-      "txHash": "0x3f47e3e71b11316df76accf58cccee3968a190d2b21e8c42c2d1c559b0e05a34",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
-      "txHash": "0xade18e38cc2c494de67b1d71697814e1542b56ea71739bf6adf4758c7c8bd1d5",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2dE080e97B0caE9825375D31f5D0eD5751fDf16D",
-      "txHash": "0x5abcc5071f6a1b60268df15f6fab2c594f00018474732aff3598ab6ce60da540",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x050499eBdbBBc1216011dE07A48b5182c983Ae74",
-      "txHash": "0xf50a80a0789bfcd88a893fe32dc1bb6c2a21b6f4d8680c58d86cddcb4bc318c9",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x5F1e91d509cFEB544809B0749284DEB25C3a113a",
-      "txHash": "0xc286a65b4c0c8df356e3471cc5d144fccdcd7ef071d4e7c7878dbae8c6eeab0a",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
-      "txHash": "0x629c1b924e4b567611491fc7f3a147b109de9566bbfb1b2bfe46dd54f8a0a1ff",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x381445710b5e73d34aF196c53A3D5cDa58EDBf7A",
-      "txHash": "0xdf43fb23696ad17ff1cb459a043174cffa37bb4928e2e9cfdf40e5cb055ec6b7",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x029A31eDd4C791C99387B318cbc352EA4D3f64bf",
-      "txHash": "0xf88b45b7dcd772a2f7e0a34dfb6c19044fc20bee49549e8e851f8e864edddff4",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xf764adBB39386BC744d533649D1EE3c86b0D6fD1",
-      "txHash": "0xaa27b25b642744ceb6d2365fbc839f60439879df30dd586023611c7d0f9f3f5b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9E545E3C0baAB3E08CdfD552C960A1050f373042",
-      "txHash": "0xedb0c53c65e610b45220cb8cdf29f87cd77b373ccd82ec3e4614063a08aad9e4",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x5C7c905B505f0Cf40Ab6600d05e677F717916F6B",
-      "txHash": "0xf05e6ee043d8793756a325c7720bd42e97a0fbe34e42e83f2517c85448ba2e4b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xA9639c9bA80dcF06e858C6495a72e4661C059Fe3",
-      "txHash": "0xd2065fd90450d9d2d632bd12ce754009fad2fc5bc1747cf1afee6acc553a36e0",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9726Fc549AcaA0791d8c170843a031ec1D2f8a68",
-      "txHash": "0x26ceef48f9f4196f302fcac3755d675d3a2ea8f590345d5d5fb170b12c134e07",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x851356ae760d987E095750cCeb3bC6014560891C",
-      "txHash": "0x3e13e95c1878cd1cd87e846382f3c1f7c4305d398c2eb8e317d61671f3b3ac11",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x85C5Dd61585773423e378146D4bEC6f8D149E248",
-      "txHash": "0xfad18404026489ee63cda9d17bdc20a43648dbcced9d1d8400d71375d5cf0c9b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x95AF2694e3359a8DF8294E7A3ad66E68F7066dB9",
-      "txHash": "0x5ab90e24c4dbcc37f843cb47002f65b8efcc428c8696dd15a16256cea1678322",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2348f027Dc1C4884a457cfA92472Bd5Ed67E3a70",
-      "txHash": "0x49602e2e7cf8f2a7dd5caa16a3be9c2be4545e9fc6923a7893cb2612ddd6a903",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x998abeb3E57409262aE5b751f60747921B33613E",
-      "txHash": "0x793ca489d5fc38c480129759c6b9864ba40b8569e10837a72e88c6617fe9bd9d",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2fc631e4B3018258759C52AF169200213e84ABab",
-      "txHash": "0xfe533b11a5306c24abdcdef00bceecbb6c4630b151672baf6d445df6128c714a",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x0b80e3f7b9038Cc182b1F647F907eD8DB00aC0Ff",
-      "txHash": "0x29ce1bee3b12bb26b070f772ac90c29ee114167e87f29b0aea370fcef9d2697f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x130C277872F3F03EFF2fEd0C1a03B67D3036FA64",
-      "txHash": "0xc2f0c1a29130bee9962c2913060d8077b889e7e45f6344153b53deaa008343e3",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
-      "txHash": "0x840ca9b8ce04370ad5498eb2f1eabd6516f3276e15bfc6a1512f3129dfd8a266",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1e2F4432bFeF9E9Ad39DA6d272F4aFf33629c770",
-      "txHash": "0xd3338ee5eeff0e3f95fed72734d9915683e26d5c5256b992b99a84ff29f24539",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1B5F7Bdc3eDB8D4273a6EA10489a6E19d16DC60C",
-      "txHash": "0x19834398da9a9c7e47d3388e03906ff8b83010bf7aac6e13a1d58a401cd12786",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x65007C1351d9fBb88d49533c843cb1ef589557FE",
-      "txHash": "0x4d5a2eabc767b0b6f1efc3456ac3237964c5476371f51a0956ac213674cddb2d",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9d4454B023096f34B160D6B654540c56A1F81688",
-      "txHash": "0xc114367c0a4c923eb8b986d2a11f28464de40ff3ddab72ea62cccec9691a8f94",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xed17543171C1459714cdC6519b58fFcC29A3C3c9",
-      "txHash": "0x21265a81d1cfe6d5b2c54bdf2126b76238746c2ee647a3458bc2139b843843b1",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x774f5C00707DaB6A1E41636AE4803aD620A0f53E",
-      "txHash": "0xfe63528ce3a20bb60d22a57f5d94004c9c6b125169f18ef092f89b6150387460",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xcDd73a57d8d27124040D02E52E3748E1C0117e88",
-      "txHash": "0x437a67268551245eba87841843c407de2f045328ab2dd0d85ca7ed17b88a5c51",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
-      "txHash": "0x2ec67f12180d948f4b4b921a057787b76529c9100bfa431e04f6a8eeb80cf9b8",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xcEC91d876E8f003110D43381359b1bAd124e7F2b",
-      "txHash": "0x221303d9c1e518904e20abab77e388c53db83b999c19d181291f77d39eabadee",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x981a7614afb87Cd0F56328f72660f3FbFa2EF30e",
-      "txHash": "0xd2b5869c46f3fc3d96a28f81b12b831328f109229c98a83ed9a779b312693ad3",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x121525a50836042846362fAAB126168b998D1cF2",
-      "txHash": "0xd1b69eb6ae3902a1b04813d4bbb9245c8a662605f579ae8674644ddf64bb4a85",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154",
-      "txHash": "0x5cae2d0af98cca5f2cc658f1d10dfbaba8be990106af782080ac9597b2e0c52f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xF818A7C2AFC45cF4B9DDC48933C9A1edD624e46f",
-      "txHash": "0xf59c95ced2af6a67ca82ebf342cdc74c7a8700bae81476278e60f54aa95e1e51",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xBE95c3f554e9Fc85ec51bE69a3D807A0D55BCF2C",
-      "txHash": "0x1580297f652b98d1127a9b7dbae2a29eb15092e96374544164172a1355d6f8d9",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xEaA95FF42CE9b59D539805b7220a63E426566830",
-      "txHash": "0xbc58e1918349dc3bbd0e1d783c9dca0eaa033a7740664505430e7da1e23934b6",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
-      "txHash": "0x090f80eef65c7c06ad3a2065823c533fb787ff07f3cbf203e11b777b697c0be3",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE5BD5bDC03371fB239956dbbF40bD185D6c2ea28",
-      "txHash": "0xd9db66705040c09fd797e766abf2850e7b1f3a62a733118a1d677823bd972c9b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x085a1Ec0d51f4541d81a442a0Df4c9E9C70D7D1e",
-      "txHash": "0xe03ad0148b1a792441744753296bb8ac904b7dfcb68ae23048ccaedc182eff2f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x6A803B8F038554AF34AC73F1C099bd340dcC7026",
-      "txHash": "0x6fec0b2a56879ff5e1015c1dc8e2bd91015699cfa7f514f7f1947e921d1a951c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f",
-      "txHash": "0x00fe14cd42c277d923ee17843a92a33bb4cc0724a9c2c568011bf445508dbe2f",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x7290f72B5C67052DDE8e6E179F7803c493e90d3f",
-      "txHash": "0xce40930faafc490da95bf3a27685491f0117fbb565cb495989a99c71e88ec66b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1C0AEba12EEb939c87884d207d695A5D938E496c",
-      "txHash": "0x6d629b68907d9712ce3aeae282838b053f16879a23dc464717d1cbb03ae72ba0",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9DF5f35792A9cc08CDDC250279a4ce6126BE0476",
-      "txHash": "0x802f27168d0b5e808bb7b1ddc0afa19377b0d4f1f67da0f047c9a8f4e61c5883",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xdbC43Ba45381e02825b14322cDdd15eC4B3164E6",
-      "txHash": "0x5d5f9e8d0644b0be7e1123f17af2cc0fda1abcfdb9cea398f2c31913e467d850",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x093e8F4d8f267d2CeEc9eB889E2054710d187beD",
-      "txHash": "0x166b6a50b7907e025002b349547a025397604d464126c6c8b0d9ef0f81de0c1c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xDbBFC50202D116773A35673Af5b0e6c3CE0802C0",
-      "txHash": "0xdf8f5b5bb8f7a5a107e1ae2a58adac4f385d6fad05515ecc57febb488bebdde6",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xf4668673B9378795e13EB43061844A5953949659",
-      "txHash": "0x7a421c3f8a984eb0a3a36afe542f8e1f43351e16fba57dcbad8e0f17f45b072c",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
-      "txHash": "0xed84b0590e4a78b26ae9130bb42b4240cadfc764e651ce90ad9bb1f3eb37f6ad",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa85b028984bC54A2a3D844B070544F59dDDf89DE",
-      "txHash": "0x8b48b3f07372f39ff4fe54b5cf75b6f7fbc89b9d5e727993e633e9981f8802bf",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xd18cE8F45b7d21234eC502646e17Df647a7349A6",
-      "txHash": "0x328194a1d5d930d36c6781bff4dc33435e8f60b4ceb641fc8282022a28647c51",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xA8952908e8E5404a0719e07f6B073b400A4DDE55",
-      "txHash": "0xecef2d1e6c7bcd696032c8fc0e6f499793507d3b32c10bd97b38b9376241880b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B",
-      "txHash": "0x9c544469aaac81f9dfc78e2a88fadb6a3be5c538faced288cddfc35197cded3d",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x35D2F51DBC8b401B11fA3FE04423E0f5cd9fEDb4",
-      "txHash": "0x1e7834f44155f46d7783d99d766718c416b0c3d60431bc2142b8a5f6a6ea557b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x6654dCEf5F156EbFC7F7d115a9952083Fd650697",
-      "txHash": "0x96106fb7ad404641b313f5c1b57c7a450b012c08a24d44543282a3db51a0b2fe",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE09B6da11bE36396Ca8dc568880747c928c7B9DA",
-      "txHash": "0xe980d3031edd19b2abf5e07c8cd50d88e891bb539cd5860b1a8374d0138985f4",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xC9a43158891282A2B1475592D5719c001986Aaec",
-      "txHash": "0x0b93c7e7cc8bc4c90855e0e3ece033a1226422661abd1307629bfaf12e094bff",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xbe241D1B7b54bF06742cefd45A3440C6562f7603",
-      "txHash": "0x2ab41b6e6df14293f948684a0332abed2b8f65e7b77ca6aa56c0d0c5e3783d70",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x758675ee1D9C6e24034355f8C5A89fceDBe99730",
-      "txHash": "0xb428ceaa08e7f4537d8b6519cd9bf68738c3175b6d73b1619d21137021675f34",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xa9CA52Ef69b5360FEb1FD5478a870D8442662355",
-      "txHash": "0xfc351aead92bc21f99a7daeb888d0ea8ff6c2baf77d6e1247d733f80dbe7a3c8",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x4631BCAbD6dF18D94796344963cB60d44a4136b6",
-      "txHash": "0x91ebb7d0c41c2ab6dcdc7f386f56dc4d50e06151c38663cc4099de725ef94701",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE4F89Fb0dBb45378633c05ACAb071eB998F0A736",
-      "txHash": "0x75453d998ebb31ea46030cad7375034ca9e22ac7af66adc3870b3d53fb42a9ba",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE77552Eb433Da759A19cee23793335e0f37D6e2B",
-      "txHash": "0x666035a66bd9f88b393d7b824f19719532a9970e8acccfd9bcd6fb67638b2a70",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xE25CB03E85EC26E077935997a01cD3371baa457b",
-      "txHash": "0xafdc1366bafd2ecea8d0e0266d33b9f91deb8ae36625c563f7080082a5e994e1",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x720472c8ce72c2A2D711333e064ABD3E6BbEAdd3",
-      "txHash": "0x1b422fefd39cbaf2683e6003833ec8e25a0c6b2dd0d932aec40281965471d4e7",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x1dBDba33dfA381bCC89FCe74DFF69Aa96B53b503",
-      "txHash": "0xf73b122385a500e3c30e85827fce8358e92c5beb03e3a0f0e0fb21d012d0b55a",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x2dab84757226C2B00386Fe39CFa55eB3FAF2c2dE",
-      "txHash": "0xb6e48d8154dea79537b9ecab8a251ab7c7e2b309ed843fd56c2937f42ecf1f12",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xAfB44a95ebaBe34Cb991A3f3d6b9f89FaA28711E",
-      "txHash": "0xa2200a192286a71773ad8e0ab64b2114880c2e3390c8e655d5c40bfedb116768",
-      "kind": "transparent"
-    },
-    {
-      "address": "0xD5ac451B0c50B9476107823Af206eD814a2e2580",
-      "txHash": "0x7351ab5e58e9a693381fce17aed6db54a36aafcf307f802aa855159f10bfcd66",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x9Fe28b717aDE38BA99E32c45BE3Ee4291f2E338B",
-      "txHash": "0x7326dc43b1e4c733cbce4d9bfeccc6ad884a02e4c92ccc2896502d46749acb04",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x080E497C3EedC9E3D5D8225D2Ff62639bDdeb62E",
-      "txHash": "0x291ccda49fa2a6b38d5a6d107941dbe60199647ec30ae3da9b17ae4e881b592b",
-      "kind": "transparent"
-    },
-    {
-      "address": "0x09EC9819B6c3777c5C28C9Eebf5fb62cd0DbA479",
-      "txHash": "0x76393561087ad01f2e0e3de49a0838ee27e63e5a4a9ce4aa43582da48b0d078f",
-      "kind": "transparent"
     }
   ],
   "impls": {
-    "02e044d5971e5bb3cefa503f1b2d5ec84b96b9ef7ef3b0283980442036a1acee": {
-      "address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
-      "txHash": "0xcf842c28a11be49185a94ba105ed08c455b7062d4becd35a5cc000a42a3173e8",
-      "layout": {
-        "storage": [
-          {
-            "contract": "Initializable",
-            "label": "_initialized",
-            "type": "t_bool",
-            "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:21"
-          },
-          {
-            "contract": "Initializable",
-            "label": "_initializing",
-            "type": "t_bool",
-            "src": "@openzeppelin/contracts/proxy/utils/Initializable.sol:26"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "mediaContracts",
-            "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
-            "src": "contracts/nft/ZapMarketV2.sol:31"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "_owner",
-            "type": "t_address",
-            "src": "contracts/nft/ZapMarketV2.sol:34"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "_tokenBidders",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)6986_storage)))",
-            "src": "contracts/nft/ZapMarketV2.sol:37"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "_bidShares",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)7001_storage))",
-            "src": "contracts/nft/ZapMarketV2.sol:41"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "_tokenAsks",
-            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)6991_storage))",
-            "src": "contracts/nft/ZapMarketV2.sol:47"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "isConfigured",
-            "type": "t_mapping(t_address,t_bool)",
-            "src": "contracts/nft/ZapMarketV2.sol:50"
-          },
-          {
-            "contract": "ZapMarketV2",
-            "label": "initialized",
-            "type": "t_bool",
-            "src": "contracts/nft/ZapMarketV2.sol:52"
-          }
-        ],
-        "types": {
-          "t_mapping(t_address,t_array(t_address)dyn_storage)": {
-            "label": "mapping(address => address[])"
-          },
-          "t_address": {
-            "label": "address"
-          },
-          "t_array(t_address)dyn_storage": {
-            "label": "address[]"
-          },
-          "t_mapping(t_address,t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)6986_storage)))": {
-            "label": "mapping(address => mapping(uint256 => mapping(address => struct IMarket.Bid)))"
-          },
-          "t_mapping(t_uint256,t_mapping(t_address,t_struct(Bid)6986_storage))": {
-            "label": "mapping(uint256 => mapping(address => struct IMarket.Bid))"
-          },
-          "t_uint256": {
-            "label": "uint256"
-          },
-          "t_mapping(t_address,t_struct(Bid)6986_storage)": {
-            "label": "mapping(address => struct IMarket.Bid)"
-          },
-          "t_struct(Bid)6986_storage": {
-            "label": "struct IMarket.Bid",
-            "members": [
-              {
-                "label": "amount",
-                "type": "t_uint256"
-              },
-              {
-                "label": "currency",
-                "type": "t_address"
-              },
-              {
-                "label": "bidder",
-                "type": "t_address"
-              },
-              {
-                "label": "recipient",
-                "type": "t_address"
-              },
-              {
-                "label": "sellOnShare",
-                "type": "t_struct(D256)3526_storage"
-              }
-            ]
-          },
-          "t_struct(D256)3526_storage": {
-            "label": "struct Decimal.D256",
-            "members": [
-              {
-                "label": "value",
-                "type": "t_uint256"
-              }
-            ]
-          },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(BidShares)7001_storage))": {
-            "label": "mapping(address => mapping(uint256 => struct IMarket.BidShares))"
-          },
-          "t_mapping(t_uint256,t_struct(BidShares)7001_storage)": {
-            "label": "mapping(uint256 => struct IMarket.BidShares)"
-          },
-          "t_struct(BidShares)7001_storage": {
-            "label": "struct IMarket.BidShares",
-            "members": [
-              {
-                "label": "prevOwner",
-                "type": "t_struct(D256)3526_storage"
-              },
-              {
-                "label": "creator",
-                "type": "t_struct(D256)3526_storage"
-              },
-              {
-                "label": "owner",
-                "type": "t_struct(D256)3526_storage"
-              }
-            ]
-          },
-          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Ask)6991_storage))": {
-            "label": "mapping(address => mapping(uint256 => struct IMarket.Ask))"
-          },
-          "t_mapping(t_uint256,t_struct(Ask)6991_storage)": {
-            "label": "mapping(uint256 => struct IMarket.Ask)"
-          },
-          "t_struct(Ask)6991_storage": {
-            "label": "struct IMarket.Ask",
-            "members": [
-              {
-                "label": "amount",
-                "type": "t_uint256"
-              },
-              {
-                "label": "currency",
-                "type": "t_address"
-              }
-            ]
-          },
-          "t_mapping(t_address,t_bool)": {
-            "label": "mapping(address => bool)"
-          },
-          "t_bool": {
-            "label": "bool"
-          }
-        }
-      }
-    },
     "04c30e822e3c14e270d7fd06be77fecbe54ef6743173d7a5f8467bb5293891c4": {
-      "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-      "txHash": "0xeabbd99d92ef78feb88d461f9868b15f738affc7d839376be6d6460027248803",
+      "address": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+      "txHash": "0xe0f58bc7918514637326875088d2fc08ee6e2b53f385345fd697a626347fdefe",
       "layout": {
         "storage": [
           {

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -7,14 +7,18 @@ async function main() {
 
     const tokenAddress = (await hre.deployments.get('ZapTokenBSC')).address;
 
-    const ZapMarket = await ethers.getContractFactory('ZapMarket', signers[0]);
-    const zapMarket = await upgrades.deployProxy(ZapMarket, { initializer: 'initialize' });
-    await zapMarket.deployed();
-    console.log('ZapMarket deployed to:', zapMarket.address);
+    const ZapMarketImplementation = await ethers.getContractFactory('ZapMarket', signers[0]);
+    const zapMarketImplementation = await ZapMarketImplementation.deploy();
+    await zapMarketImplementation.deployed();
+
+    const ZapMarketProxy = await ethers.getContractFactory('ZapMarket', signers[0]);
+    const zapMarketProxy = await upgrades.deployProxy(ZapMarketProxy, { initializer: 'initialize' });
+    await zapMarketProxy.deployed();
+    console.log('ZapMarket Proxy deployed to:', zapMarketProxy.address);
 
     // ZapMedia may be changed in the future to be upgradeable
     const ZapMedia = await ethers.getContractFactory('ZapMedia', signers[0]);
-    const zapMedia = await ZapMedia.deploy('ZapMedia', 'ZAPBSC', zapMarket.address);
+    const zapMedia = await ZapMedia.deploy('ZapMedia', 'ZAPBSC', zapMarketImplementation.address, true);
     await zapMedia.deployed();
     console.log('ZapMedia deployed to:', zapMedia.address);
 

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -7,40 +7,23 @@ async function main() {
 
     const tokenAddress = (await hre.deployments.get('ZapTokenBSC')).address;
 
-    const ZapMarketImplementation = await ethers.getContractFactory('ZapMarket', signers[0]);
-    const zapMarketImplementation = await ZapMarketImplementation.deploy();
-    await zapMarketImplementation.deployed();
-    console.log('ZapMarket Implementation deployed to:', zapMarketImplementation.address);
-
     const ZapMarketProxy = await ethers.getContractFactory('ZapMarket', signers[0]);
     const zapMarketProxy = await upgrades.deployProxy(ZapMarketProxy, { initializer: 'initialize' });
     await zapMarketProxy.deployed();
     console.log('ZapMarket Proxy deployed to:', zapMarketProxy.address);
 
+    const ZapMediaProxy = await ethers.getContractFactory('ZapMedia', signers[0]);
+    const zapMediaProxy = await upgrades.deployProxy(
+        ZapMediaProxy,
+        ["ZapMedia", "ZAPBSC", zapMarketProxy.address, true],
+    );
+    await zapMediaProxy.deployed();
+    console.log('ZapMedia Proxy deployed to:', zapMediaProxy.address);
 
-    const ZapMedia = await ethers.getContractFactory('ZapMedia', signers[0])
-
-    const zapMedia = await ZapMedia.deploy()
-
-    await zapMedia.deployed()
-
-    console.log(zapMedia.address)
-    console.log(await zapMedia.symbol())
-
-    // const test = await ethers.getContractFactory('ZapMarketV2', signers[0])
-
-    // const x = await upgrades.upgradeProxy(zapMarketProxy.address, test)
-
-
-    // console.log(await x.getConfigStatus(zapMediaImplementation.address));
-
-    // await zapMediaImplementation.deployed();
-    // console.log('ZapMedia Implementation deployed to:', zapMediaImplementation.address);
-
-    // // AuctionHouse may be changed in the future to be upgradeable
-    // // AucionHouse will change to handle more than one Media contract
+    // AuctionHouse may be changed in the future to be upgradeable
+    // AucionHouse will change to handle more than one Media contract
     // const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
-    // const auctionHouse = await AuctionHouse.deploy(zapMedia.address, tokenAddress);
+    // const auctionHouse = await AuctionHouse.deploy(zapMediaProxy.address, tokenAddress);
     // await auctionHouse.deployed();
     // console.log('AuctionHouse deployed to:', auctionHouse.address);
 

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -10,24 +10,39 @@ async function main() {
     const ZapMarketImplementation = await ethers.getContractFactory('ZapMarket', signers[0]);
     const zapMarketImplementation = await ZapMarketImplementation.deploy();
     await zapMarketImplementation.deployed();
+    console.log('ZapMarket Implementation deployed to:', zapMarketImplementation.address);
 
     const ZapMarketProxy = await ethers.getContractFactory('ZapMarket', signers[0]);
     const zapMarketProxy = await upgrades.deployProxy(ZapMarketProxy, { initializer: 'initialize' });
     await zapMarketProxy.deployed();
     console.log('ZapMarket Proxy deployed to:', zapMarketProxy.address);
 
-    // ZapMedia may be changed in the future to be upgradeable
-    const ZapMedia = await ethers.getContractFactory('ZapMedia', signers[0]);
-    const zapMedia = await ZapMedia.deploy('ZapMedia', 'ZAPBSC', zapMarketImplementation.address, true);
-    await zapMedia.deployed();
-    console.log('ZapMedia deployed to:', zapMedia.address);
 
-    // AuctionHouse may be changed in the future to be upgradeable
-    // AucionHouse will change to handle more than one Media contract
-    const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
-    const auctionHouse = await AuctionHouse.deploy(zapMedia.address, tokenAddress);
-    await auctionHouse.deployed();
-    console.log('AuctionHouse deployed to:', auctionHouse.address);
+    const ZapMedia = await ethers.getContractFactory('ZapMedia', signers[0])
+
+    const zapMedia = await ZapMedia.deploy()
+
+    await zapMedia.deployed()
+
+    console.log(zapMedia.address)
+    console.log(await zapMedia.symbol())
+
+    // const test = await ethers.getContractFactory('ZapMarketV2', signers[0])
+
+    // const x = await upgrades.upgradeProxy(zapMarketProxy.address, test)
+
+
+    // console.log(await x.getConfigStatus(zapMediaImplementation.address));
+
+    // await zapMediaImplementation.deployed();
+    // console.log('ZapMedia Implementation deployed to:', zapMediaImplementation.address);
+
+    // // AuctionHouse may be changed in the future to be upgradeable
+    // // AucionHouse will change to handle more than one Media contract
+    // const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
+    // const auctionHouse = await AuctionHouse.deploy(zapMedia.address, tokenAddress);
+    // await auctionHouse.deployed();
+    // console.log('AuctionHouse deployed to:', auctionHouse.address);
 
 }
 

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -116,21 +116,15 @@ describe("ZapMarket Test", () => {
             zapMarket = await upgrades.deployProxy(zapMarketFactory, { initializer: 'initialize' }) as ZapMarket;
 
             const mediaFactory = await ethers.getContractFactory("ZapMedia", signers[1]);
-
-            zapMedia1 = (await mediaFactory.deploy("TEST MEDIA 1", "TM1", zapMarket.address, false)) as ZapMedia
-
+            zapMedia1 = (await upgrades.deployProxy(mediaFactory, ["TEST MEDIA 1", "TM1", zapMarket.address, false])) as ZapMedia;
             await zapMedia1.deployed();
 
             const mediaFactory2 = await ethers.getContractFactory("ZapMedia", signers[2]);
-
-            zapMedia2 = (await mediaFactory2.deploy("TEST MEDIA 2", "TM2", zapMarket.address, false)) as ZapMedia
-
+            zapMedia2 = (await upgrades.deployProxy(mediaFactory2, ["TEST MEDIA 2", "TM2", zapMarket.address, false])) as ZapMedia;
             await zapMedia2.deployed();
 
             const mediaFactory3 = await ethers.getContractFactory("ZapMedia", signers[2]);
-
-            zapMedia3 = (await mediaFactory3.deploy("TEST MEDIA 3", "TM3", zapMarket.address, false)) as ZapMedia
-
+            zapMedia3 = (await upgrades.deployProxy(mediaFactory3, ["Test MEDIA 3", "TM3", zapMarket.address, false])) as ZapMedia;
             await zapMedia3.deployed();
 
             ask1.currency = zapTokenBsc.address
@@ -264,16 +258,16 @@ describe("ZapMarket Test", () => {
             zapMarket = await upgrades.deployProxy(zapMarketFactory, { initializer: 'initialize' }) as ZapMarket;
 
             const mediaFactory = await ethers.getContractFactory("ZapMedia", signers[1]);
-
-            zapMedia1 = (await mediaFactory.deploy("TEST MEDIA 1", "TM1", zapMarket.address, false)) as ZapMedia
-
+            zapMedia1 = (await upgrades.deployProxy(mediaFactory, ["TEST MEDIA 1", "TM1", zapMarket.address, false])) as ZapMedia;
             await zapMedia1.deployed();
 
             const mediaFactory2 = await ethers.getContractFactory("ZapMedia", signers[2]);
-
-            zapMedia2 = (await mediaFactory2.deploy("TEST MEDIA 2", "TM2", zapMarket.address, false)) as ZapMedia
-
+            zapMedia2 = (await upgrades.deployProxy(mediaFactory2, ["TEST MEDIA 2", "TM2", zapMarket.address, false])) as ZapMedia;
             await zapMedia2.deployed();
+
+            const mediaFactory3 = await ethers.getContractFactory("ZapMedia", signers[2]);
+            zapMedia3 = (await upgrades.deployProxy(mediaFactory3, ["Test MEDIA 3", "TM3", zapMarket.address, false])) as ZapMedia;
+            await zapMedia3.deployed();
 
             const zapTokenFactory = await ethers.getContractFactory(
                 'ZapTokenBSC',
@@ -474,16 +468,16 @@ describe("ZapMarket Test", () => {
             zapMarket = await upgrades.deployProxy(zapMarketFactory, { initializer: 'initialize' }) as ZapMarket;
 
             const mediaFactory = await ethers.getContractFactory("ZapMedia", signers[1]);
-
-            zapMedia1 = (await mediaFactory.deploy("TEST MEDIA 1", "TM1", zapMarket.address, false)) as ZapMedia
-
+            zapMedia1 = (await upgrades.deployProxy(mediaFactory, ["TEST MEDIA 1", "TM1", zapMarket.address, false])) as ZapMedia;
             await zapMedia1.deployed();
 
             const mediaFactory2 = await ethers.getContractFactory("ZapMedia", signers[2]);
-
-            zapMedia2 = (await mediaFactory2.deploy("TEST MEDIA 2", "TM2", zapMarket.address, false)) as ZapMedia
-
+            zapMedia2 = (await upgrades.deployProxy(mediaFactory2, ["TEST MEDIA 2", "TM2", zapMarket.address, false])) as ZapMedia;
             await zapMedia2.deployed();
+
+            const mediaFactory3 = await ethers.getContractFactory("ZapMedia", signers[2]);
+            zapMedia3 = (await upgrades.deployProxy(mediaFactory3, ["Test MEDIA 3", "TM3", zapMarket.address, false])) as ZapMedia;
+            await zapMedia3.deployed();
 
             ask1.currency = zapTokenBsc.address
             ask2.currency = zapTokenBsc.address
@@ -673,16 +667,16 @@ describe("ZapMarket Test", () => {
             zapMarket = await upgrades.deployProxy(zapMarketFactory, { initializer: 'initialize' }) as ZapMarket;
 
             const mediaFactory = await ethers.getContractFactory("ZapMedia", signers[1]);
-
-            zapMedia1 = (await mediaFactory.deploy("TEST MEDIA 1", "TM1", zapMarket.address, false)) as ZapMedia
-
+            zapMedia1 = (await upgrades.deployProxy(mediaFactory, ["TEST MEDIA 1", "TM1", zapMarket.address, false])) as ZapMedia;
             await zapMedia1.deployed();
 
             const mediaFactory2 = await ethers.getContractFactory("ZapMedia", signers[2]);
-
-            zapMedia2 = (await mediaFactory2.deploy("TEST MEDIA 2", "TM2", zapMarket.address, false)) as ZapMedia
-
+            zapMedia2 = (await upgrades.deployProxy(mediaFactory2, ["TEST MEDIA 2", "TM2", zapMarket.address, false])) as ZapMedia;
             await zapMedia2.deployed();
+
+            const mediaFactory3 = await ethers.getContractFactory("ZapMedia", signers[2]);
+            zapMedia3 = (await upgrades.deployProxy(mediaFactory3, ["Test MEDIA 3", "TM3", zapMarket.address, false])) as ZapMedia;
+            await zapMedia3.deployed();
 
             const zapTokenFactory = await ethers.getContractFactory(
                 'ZapTokenBSC',

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -12,12 +12,13 @@ import { ZapTokenBSC } from '../typechain/ZapTokenBSC';
 import { signPermit, signMintWithSig } from './utils';
 
 import { ZapMedia } from '../typechain/ZapMedia';
+import { ZapMarket } from "../typechain/ZapMarket";
 
 chai.use(solidity);
 
 describe("ZapMedia Test", async () => {
 
-    let zapMarket: any;
+    let zapMarket: ZapMarket;
     let zapMedia1: ZapMedia;
     let zapMedia2: ZapMedia;
     let zapMedia3: ZapMedia;
@@ -59,18 +60,18 @@ describe("ZapMedia Test", async () => {
     let mediaData: any;
     let randomString: any;
 
-    before ( async () => {
+    before(async () => {
         signers = await ethers.getSigners();
 
-        const marketFixture = await deployments.fixture(['ZapMarket']);
-        zapMarket = await ethers.getContractAt("ZapMarket", marketFixture.ZapMarket.address);
+        const zapMarketFactory = await ethers.getContractFactory('ZapMarket');
+        zapMarket = await upgrades.deployProxy(zapMarketFactory, { initializer: 'initialize' }) as ZapMarket;
     })
 
     describe("Configure", () => {
 
         beforeEach(async () => {
 
-            tokenURI =  String('media contract 1 - token 1 uri');
+            tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
             metadataHex = ethers.utils.formatBytes32String('{}');
@@ -171,20 +172,20 @@ describe("ZapMedia Test", async () => {
 
     describe('#mint', () => {
         beforeEach(async () => {
-            tokenURI =  String('media contract 1 - token 1 uri');
+            tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
             metadataHex = ethers.utils.formatBytes32String('{}');
             metadataHash = ethers.utils.sha256(metadataHex);
             metadataHashBytes = ethers.utils.arrayify(metadataHash);
-        
+
             randomString = Date.now().toString();
             contentHex = ethers.utils.formatBytes32String(randomString);
             contentHash = ethers.utils.sha256(contentHex);
             contentHashBytes = ethers.utils.arrayify(contentHash);
 
             zeroContentHashBytes = ethers.utils.arrayify(ethers.constants.HashZero);
-        
+
             mediaData = {
                 tokenURI,
                 metadataURI,
@@ -216,7 +217,7 @@ describe("ZapMedia Test", async () => {
             const savedTokenURI = await zapMedia2.tokenURI(0);
             const savedMetadataURI = await zapMedia2.tokenMetadataURI(0);
             const currentSupply = await zapMedia2.totalSupply();
-      
+
             expect(ownerOf).eq(signers[3].address);
             expect(creator).eq(signers[3].address);
             expect(prevOwner).eq(signers[3].address);
@@ -263,7 +264,7 @@ describe("ZapMedia Test", async () => {
             const metadataContentHash = await zapMedia1.getTokenMetadataHashes(0);
             const savedTokenURI = await zapMedia1.tokenURI(0);
             const savedMetadataURI = await zapMedia1.tokenMetadataURI(0);
-      
+
             expect(ownerOf).eq(signers[1].address);
             expect(creator).eq(signers[1].address);
             expect(prevOwner).eq(signers[1].address);
@@ -273,46 +274,46 @@ describe("ZapMedia Test", async () => {
             expect(savedMetadataURI).eq(metadataURI);
         });
 
-        it('should revert if an empty content hash is specified', async () => {      
+        it('should revert if an empty content hash is specified', async () => {
             await expect(
                 zapMedia1.mint(
-                    {...mediaData, contentHash: zeroContentHashBytes}, bidShares
+                    { ...mediaData, contentHash: zeroContentHashBytes }, bidShares
                 )
             ).revertedWith('Media: content hash must be non-zero');
         });
-    
+
         it('should revert if the content hash already exists for a created token', async () => {
             await zapMedia2.mint(mediaData, bidShares);
-        
+
             await expect(
                 zapMedia2.mint(mediaData, bidShares)
             ).revertedWith('Media: a token has already been created with this content hash');
         });
-      
+
         it('should revert if the metadataHash is empty', async () => {
             const secondContentHex = ethers.utils.formatBytes32String('invert2');
             const secondContentHash = await ethers.utils.sha256(secondContentHex);
 
             await expect(
                 zapMedia1.mint(
-                    {...mediaData, contentHash: secondContentHash, metadataHash: zeroContentHashBytes},
+                    { ...mediaData, contentHash: secondContentHash, metadataHash: zeroContentHashBytes },
                     bidShares
                 )
             ).revertedWith('Media: metadata hash must be non-zero');
         });
-    
+
         it('should revert if the tokenURI is empty', async () => {
             await expect(
-                zapMedia1.mint({...mediaData, tokenURI: ''}, bidShares)
+                zapMedia1.mint({ ...mediaData, tokenURI: '' }, bidShares)
             ).revertedWith('Media: specified uri must be non-empty');
         });
-    
+
         it('should revert if the metadataURI is empty', async () => {
             await expect(
-                zapMedia1.mint({...mediaData, metadataURI: ''}, bidShares)
+                zapMedia1.mint({ ...mediaData, metadataURI: '' }, bidShares)
             ).revertedWith('Media: specified uri must be non-empty');
         });
-    
+
         // it('should not be able to mint a token with bid shares summing to less than 100', async () => {
         //     await expect(
         //         zapMedia1.mint(mediaData, {...bidShares, creator: {
@@ -343,7 +344,7 @@ describe("ZapMedia Test", async () => {
             const recoveredMetadataHash = await zapMedia1.getTokenMetadataHashes(1);
             const recoveredCreatorBidShare = (await zapMarket.bidSharesForToken(zapMedia1.address, 1)).creator.value;
             const afterNonce = await zapMedia1.getSigNonces(signers[1].address);
-      
+
             expect(recovered).to.eq(signers[1].address);
             expect(recoveredTokenURI).to.eq(tokenURI);
             expect(recoveredMetadataURI).to.eq(metadataURI);
@@ -392,7 +393,7 @@ describe("ZapMedia Test", async () => {
             const recoveredMetadataHash = await zapMedia2.getTokenMetadataHashes(0);
             const recoveredCreatorBidShare = (await zapMarket.bidSharesForToken(zapMedia2.address, 0)).creator.value;
             const afterNonce = await zapMedia2.getSigNonces(signers[1].address);
-      
+
             expect(recovered).to.eq(signers[1].address);
             expect(recoveredTokenURI).to.eq(tokenURI);
             expect(recoveredMetadataURI).to.eq(metadataURI);
@@ -410,7 +411,7 @@ describe("ZapMedia Test", async () => {
                 metadataHashBytes,
                 version
             );
-        
+
             await expect(
                 zapMedia1.mintWithSig(signers[2].address, mediaData, bidShares, sig)
             ).revertedWith('Media: Signature invalid');
@@ -420,7 +421,7 @@ describe("ZapMedia Test", async () => {
             const badContent = 'bad bad bad';
             const badContentHex = ethers.utils.formatBytes32String(badContent);
             const badContentHashBytes = ethers.utils.arrayify(badContentHex);
-      
+
             const sig = await signMintWithSig(
                 zapMedia1,
                 signers,
@@ -428,7 +429,7 @@ describe("ZapMedia Test", async () => {
                 metadataHashBytes,
                 version
             );
-        
+
             await expect(
                 zapMedia1.mintWithSig(signers[1].address, mediaData, bidShares, sig)
             ).revertedWith('Media: Signature invalid');
@@ -446,7 +447,7 @@ describe("ZapMedia Test", async () => {
                 badMetadataHashBytes,
                 version
             );
-      
+
             await expect(
                 zapMedia1.mintWithSig(signers[1].address, mediaData, bidShares, sig)
             ).revertedWith('Media: Signature invalid');
@@ -460,7 +461,7 @@ describe("ZapMedia Test", async () => {
                 metadataHashBytes,
                 version
             );
-        
+
             await expect(
                 zapMedia1.mintWithSig(
                     signers[1].address,
@@ -489,29 +490,29 @@ describe("ZapMedia Test", async () => {
                 metadataHashBytes,
                 version
             );
-        
+
             await expect(
                 zapMedia1.mintWithSig(signers[1].address, mediaData, bidShares, { ...sig, deadline: '1' })
             ).revertedWith('Media: mintWithSig expired');
         });
     });
 
-    describe('#setAsk', () => {    
+    describe('#setAsk', () => {
         beforeEach(async () => {
-            tokenURI =  String('media contract 1 - token 1 uri');
+            tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
             metadataHex = ethers.utils.formatBytes32String('{}');
             metadataHash = ethers.utils.sha256(metadataHex);
             metadataHashBytes = ethers.utils.arrayify(metadataHash);
-        
+
             randomString = Date.now().toString();
             contentHex = ethers.utils.formatBytes32String(randomString);
             contentHash = ethers.utils.sha256(contentHex);
             contentHashBytes = ethers.utils.arrayify(contentHash);
 
             zeroContentHashBytes = ethers.utils.arrayify(ethers.constants.HashZero);
-        
+
             mediaData = {
                 tokenURI,
                 metadataURI,
@@ -527,13 +528,13 @@ describe("ZapMedia Test", async () => {
                 await zapMedia3.setAsk(0, ask)
             );
         });
-    
+
         it('should reject if the ask is 0', async () => {
             await expect(
                 zapMedia3.setAsk(0, { ...ask, amount: 0 })
             ).revertedWith('Market: Ask invalid for share splitting');
         });
-    
+
         it('should reject if the ask amount is invalid and cannot be split', async () => {
             await expect(
                 zapMedia3.setAsk(0, { ...ask, amount: 101 })
@@ -568,20 +569,20 @@ describe("ZapMedia Test", async () => {
                 }
             };
 
-            tokenURI =  String('media contract 1 - token 1 uri');
+            tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
             metadataHex = ethers.utils.formatBytes32String('{}');
             metadataHash = ethers.utils.sha256(metadataHex);
             metadataHashBytes = ethers.utils.arrayify(metadataHash);
-        
+
             randomString = Date.now().toString();
             contentHex = ethers.utils.formatBytes32String(randomString);
             contentHash = ethers.utils.sha256(contentHex);
             contentHashBytes = ethers.utils.arrayify(contentHash);
 
             zeroContentHashBytes = ethers.utils.arrayify(ethers.constants.HashZero);
-        
+
             mediaData = {
                 tokenURI,
                 metadataURI,
@@ -617,7 +618,7 @@ describe("ZapMedia Test", async () => {
 
             await zapTokenBsc.connect(signers[4]).approve(zapMarket.address, 100000);
 
-            expect(await zapMedia3.connect(signers[4]).setBid(0, {...bid1, bidder: signers[4].address, recipient: signers[4].address}));
+            expect(await zapMedia3.connect(signers[4]).setBid(0, { ...bid1, bidder: signers[4].address, recipient: signers[4].address }));
 
             const balance = await zapTokenBsc.balanceOf(signers[4].address);
             expect(balance.toNumber()).eq(100000 - 100);
@@ -646,11 +647,11 @@ describe("ZapMedia Test", async () => {
             await setupAuction(zapMedia11, signers[11]);
 
             await zapMedia11.connect(signers[3]).setAsk(0, ask);
-      
+
             expect(await zapMedia11.ownerOf(0)).to.equal(signers[3].address);
 
             const beforeBalance = await zapTokenBsc.balanceOf(signers[4].address);
-            await zapMedia11.connect(signers[4]).setBid(0, {...bid1, amount: 200, bidder: signers[4].address, recipient: signers[5].address});
+            await zapMedia11.connect(signers[4]).setBid(0, { ...bid1, amount: 200, bidder: signers[4].address, recipient: signers[5].address });
             const afterBalance = await zapTokenBsc.balanceOf(signers[4].address);
 
             expect(afterBalance - 100).eq(beforeBalance - 200);
@@ -684,14 +685,14 @@ describe("ZapMedia Test", async () => {
         contentHex = ethers.utils.formatBytes32String(randomString);
         contentHash = ethers.utils.sha256(contentHex);
         contentHashBytes = ethers.utils.arrayify(contentHash);
-        await ownerContract.mint({...mediaData, contentHash: contentHashBytes}, bidShares);
-    
-        await ownerContract.connect(signers[2]).setBid(0, {...bid1, bidder: signers[2].address, recipient: signers[2].address});
-        await ownerContract.connect(ownerWallet).acceptBid(0, {...bid1, bidder: signers[2].address, recipient: signers[2].address});
-        await ownerContract.connect(signers[3]).setBid(0, {...bid1, bidder: signers[3].address, recipient: signers[3].address});
-        await ownerContract.connect(signers[2]).acceptBid(0, {...bid1, bidder: signers[3].address, recipient: signers[3].address});
-        await ownerContract.connect(signers[4]).setBid(0, {...bid1, bidder: signers[4].address, recipient: signers[4].address});
-        await ownerContract.connect(signers[5]).setBid(0, {...bid1, bidder: signers[5].address, recipient: signers[5].address});        
+        await ownerContract.mint({ ...mediaData, contentHash: contentHashBytes }, bidShares);
+
+        await ownerContract.connect(signers[2]).setBid(0, { ...bid1, bidder: signers[2].address, recipient: signers[2].address });
+        await ownerContract.connect(ownerWallet).acceptBid(0, { ...bid1, bidder: signers[2].address, recipient: signers[2].address });
+        await ownerContract.connect(signers[3]).setBid(0, { ...bid1, bidder: signers[3].address, recipient: signers[3].address });
+        await ownerContract.connect(signers[2]).acceptBid(0, { ...bid1, bidder: signers[3].address, recipient: signers[3].address });
+        await ownerContract.connect(signers[4]).setBid(0, { ...bid1, bidder: signers[4].address, recipient: signers[4].address });
+        await ownerContract.connect(signers[5]).setBid(0, { ...bid1, bidder: signers[5].address, recipient: signers[5].address });
     }
 
     describe('#removeBid', () => {
@@ -707,13 +708,13 @@ describe("ZapMedia Test", async () => {
                 'Market: cannot remove bid amount of 0'
             );
         });
-    
+
         it('should revert if the tokenId has not yet ben created', async () => {
             await expect(zapMedia1.connect(signers[4]).removeBid(100)).revertedWith(
                 'Media: token with that id does not exist'
             );
         });
-    
+
         it('should remove a bid and refund the bidder', async () => {
             const beforeBalance = await zapTokenBsc.balanceOf(signers[4].address);
             expect(await zapMedia1.connect(signers[4]).removeBid(0));
@@ -721,14 +722,14 @@ describe("ZapMedia Test", async () => {
             console.log(afterBalance.toNumber(), beforeBalance.toNumber());
             expect(afterBalance.toNumber()).eq(beforeBalance.toNumber() + 100);
         });
-    
+
         it('should not be able to remove a bid twice', async () => {
             await zapMedia1.connect(signers[4]).removeBid(0);
-        
+
             await expect(zapMedia1.connect(signers[4]).removeBid(0))
-            .revertedWith('Market: cannot remove bid amount of 0');
+                .revertedWith('Market: cannot remove bid amount of 0');
         });
-    
+
         it('should remove a bid, even if the token is burned', async () => {
             const mediaFactory1 = await ethers.getContractFactory("ZapMedia", signers[1]);
             const zapMedia1 = (await upgrades.deployProxy(mediaFactory1, ["Test MEDIA 1", "T1", zapMarket.address, false]));
@@ -739,7 +740,7 @@ describe("ZapMedia Test", async () => {
             await zapMedia1.burn(0);
             const beforeBalance = await zapTokenBsc.balanceOf(signers[4].address);
             expect(await zapMedia1.connect(signers[4]).removeBid(0));
-            const afterBalance = await zapTokenBsc.balanceOf(signers[4].address); 
+            const afterBalance = await zapTokenBsc.balanceOf(signers[4].address);
             expect(afterBalance.toNumber()).eq(beforeBalance.toNumber() + 100);
         });
     });
@@ -763,7 +764,7 @@ describe("ZapMedia Test", async () => {
             await zapMedia1.deployed();
             await setupAuction(zapMedia1, signers[1]);
         });
-    
+
         it('should accept a bid', async () => {
             const bid = {
                 ...bid1,
@@ -775,7 +776,7 @@ describe("ZapMedia Test", async () => {
             };
 
             await zapMedia1.connect(signers[4]).setBid(0, bid);
-        
+
             const beforeOwnerBalance = (await zapTokenBsc.balanceOf(signers[3].address)).toNumber();
             const beforePrevOwnerBalance = (await zapTokenBsc.balanceOf(signers[2].address)).toNumber();
             const beforeCreatorBalance = (await zapTokenBsc.balanceOf(signers[1].address)).toNumber();
@@ -785,7 +786,7 @@ describe("ZapMedia Test", async () => {
             const afterPrevOwnerBalance = (await zapTokenBsc.balanceOf(signers[2].address)).toNumber();
             const afterCreatorBalance = (await zapTokenBsc.balanceOf(signers[1].address)).toNumber();
             const bidShares = await zapMarket.bidSharesForToken(zapMedia1.address, 0);
-        
+
             expect(afterOwnerBalance).eq(beforeOwnerBalance + 80);
             expect(afterPrevOwnerBalance).eq(beforePrevOwnerBalance + 10);
             expect(afterCreatorBalance).eq(beforeCreatorBalance + 10);
@@ -796,7 +797,7 @@ describe("ZapMedia Test", async () => {
         });
 
         it('should emit a bid finalized event if the bid is accepted', async () => {
-            const bid = {...bid1, bidder: signers[4].address};
+            const bid = { ...bid1, bidder: signers[4].address };
             await zapMedia1.connect(signers[4]).setBid(0, bid);
             await zapMedia1.connect(signers[3]).acceptBid(0, bid);
 
@@ -810,9 +811,9 @@ describe("ZapMedia Test", async () => {
             expect(logDescription.args.bid.sellOnShare.value).to.eq(bid.sellOnShare.value);
             expect(logDescription.args.bid.bidder).to.eq(bid.bidder);
         });
-    
+
         it('should emit a bid shares updated event if the bid is accepted', async () => {
-            const bid = {...bid1, bidder: signers[4].address};
+            const bid = { ...bid1, bidder: signers[4].address };
             await zapMedia1.connect(signers[4]).setBid(0, bid);
             await zapMedia1.connect(signers[3]).acceptBid(0, bid);
 
@@ -832,7 +833,7 @@ describe("ZapMedia Test", async () => {
                 BigInt(10000000000000000000)
             );
         });
-      
+
         it('should revert if not called by the owner', async () => {
             const mediaFactory1 = await ethers.getContractFactory("ZapMedia", signers[1]);
             const zapMedia1 = (await upgrades.deployProxy(mediaFactory1, ["Test MEDIA 1", "T1", zapMarket.address, false]));
@@ -840,10 +841,10 @@ describe("ZapMedia Test", async () => {
             await setupAuction(zapMedia1, signers[1]);
 
             await expect(
-                zapMedia1.connect(signers[5]).acceptBid(0, {...bid1, bidder: signers[4].address})
+                zapMedia1.connect(signers[5]).acceptBid(0, { ...bid1, bidder: signers[4].address })
             ).revertedWith('Media: Only approved or owner');
         });
-      
+
         it('should revert if a non-existent bid is accepted', async () => {
             const mediaFactory1 = await ethers.getContractFactory("ZapMedia", signers[1]);
             const zapMedia1 = (await upgrades.deployProxy(mediaFactory1, ["Test MEDIA 1", "T1", zapMarket.address, false]));
@@ -851,10 +852,10 @@ describe("ZapMedia Test", async () => {
             await setupAuction(zapMedia1, signers[1]);
 
             await expect(
-                zapMedia1.connect(signers[3]).acceptBid(0, {...bid1, bidder: '0x0000000000000000000000000000000000000000'})
+                zapMedia1.connect(signers[3]).acceptBid(0, { ...bid1, bidder: '0x0000000000000000000000000000000000000000' })
             ).revertedWith('Market: cannot accept bid of 0');
         });
-      
+
         it('should revert if an invalid bid is accepted', async () => {
             const mediaFactory1 = await ethers.getContractFactory("ZapMedia", signers[1]);
             const zapMedia1 = (await upgrades.deployProxy(mediaFactory1, ["Test MEDIA 1", "T1", zapMarket.address, false]));
@@ -867,7 +868,7 @@ describe("ZapMedia Test", async () => {
                 amount: 99,
             };
             await zapMedia1.connect(signers[4]).setBid(0, bid);
-        
+
             await expect(zapMedia1.connect(signers[3]).acceptBid(0, bid)).revertedWith(
                 'Market: Bid invalid for share splitting'
             );
@@ -889,7 +890,7 @@ describe("ZapMedia Test", async () => {
             expect(await askB.currency).eq('0x0000000000000000000000000000000000000000');
         });
     });
-    
+
     describe('#burn', () => {
         beforeEach(async () => {
             const mediaFactory1 = await ethers.getContractFactory("ZapMedia", signers[1]);
@@ -897,7 +898,7 @@ describe("ZapMedia Test", async () => {
             await zapMedia1.deployed();
             await zapMedia1.mint(mediaData, bidShares);
         });
-    
+
         it('should revert when the caller is the owner, but not creator', async () => {
             await zapMedia1.connect(signers[1]).transferFrom(
                 signers[1].address,
@@ -907,7 +908,7 @@ describe("ZapMedia Test", async () => {
 
             await expect(zapMedia1.connect(signers[3]).burn(0)).revertedWith('Media: owner is not creator of media');
         });
-    
+
         it('should revert when the caller is approved, but the owner is not the creator', async () => {
             await zapMedia1.connect(signers[1]).transferFrom(
                 signers[1].address,
@@ -916,57 +917,57 @@ describe("ZapMedia Test", async () => {
             );
 
             await zapMedia1.connect(signers[3]).approve(signers[5].address, 0);
- 
+
             await expect(zapMedia1.connect(signers[5]).burn(0)).revertedWith(
                 'Media: owner is not creator of media'
             );
         });
-    
+
         it('should revert when the caller is not the owner or a creator', async () => {
-          await expect(zapMedia1.connect(signers[5]).burn(0)).revertedWith('Media: Only approved or owner');
+            await expect(zapMedia1.connect(signers[5]).burn(0)).revertedWith('Media: Only approved or owner');
         });
-    
+
         it('should revert if the token id does not exist', async () => {
-          await expect(zapMedia1.connect(signers[1]).burn(100)).revertedWith('Media: nonexistent token');
+            await expect(zapMedia1.connect(signers[1]).burn(100)).revertedWith('Media: nonexistent token');
         });
-    
+
         it('should clear approvals, set remove owner, but maintain tokenURI and contentHash when the owner is creator and caller', async () => {
             expect(await zapMedia1.connect(signers[1]).approve(signers[5].address, 0));
-        
+
             expect(await zapMedia1.connect(signers[1]).burn(0));
-        
+
             await expect(zapMedia1.connect(signers[1]).ownerOf(0)).revertedWith(
                 'ERC721: owner query for nonexistent token'
             );
-        
+
             const totalSupply = await zapMedia1.connect(signers[1]).totalSupply();
             expect(totalSupply.toNumber()).eq(0);
-        
+
             await expect(zapMedia1.connect(signers[1]).getApproved(0)).revertedWith(
                 'ERC721: approved query for nonexistent token'
             );
-        
+
             await expect(zapMedia1.connect(signers[1]).tokenURI(0)).revertedWith(
                 'ERC721URIStorage: URI query for nonexistent token'
             );
         });
-    
+
         it('should clear approvals, set remove owner, but maintain tokenURI and contentHash when the owner is creator and caller is approved', async () => {
             expect(await zapMedia1.connect(signers[1]).approve(signers[5].address, 0));
-        
+
             expect(await zapMedia1.connect(signers[5]).burn(0));
-        
+
             await expect(zapMedia1.connect(signers[1]).ownerOf(0)).revertedWith(
                 'ERC721: owner query for nonexistent token'
             );
-        
+
             const totalSupply = await zapMedia1.connect(signers[1]).totalSupply();
             expect(totalSupply.toNumber()).eq(0);
-        
+
             await expect(zapMedia1.connect(signers[1]).getApproved(0)).revertedWith(
                 'ERC721: approved query for nonexistent token'
             );
-        
+
             await expect(zapMedia1.connect(signers[1]).tokenURI(0)).revertedWith(
                 'ERC721URIStorage: URI query for nonexistent token'
             );
@@ -1041,7 +1042,7 @@ describe("ZapMedia Test", async () => {
             expect(tokenURI).eq('blah blah');
         });
     });
-    
+
     describe('#updateMetadataURI', async () => {
         beforeEach(async () => {
             const mediaFactory1 = await ethers.getContractFactory("ZapMedia", signers[1]);
@@ -1145,7 +1146,7 @@ describe("ZapMedia Test", async () => {
             expect(await zapMedia1.connect(signers[5]).getApproved(0)).eq(ethers.constants.AddressZero);
         });
     });
-    
+
     describe('#supportsInterface', async () => {
         it('should return true to supporting new metadata interface', async () => {
             const interfaceId = ethers.utils.arrayify('0x2315d6f4');
@@ -1167,25 +1168,25 @@ describe("ZapMedia Test", async () => {
             await zapMedia1.deployed();
             await setupAuction(zapMedia1, signers[1]);
         });
-    
+
         it('should revert if the caller is the owner', async () => {
             await expect(zapMedia1.connect(signers[3]).revokeApproval(0)).revertedWith(
                 'Media: caller not approved address'
             );
         });
-    
+
         it('should revert if the caller is the creator', async () => {
             await expect(zapMedia1.connect(signers[1]).revokeApproval(0)).revertedWith(
                 'Media: caller not approved address'
             );
         });
-    
+
         it('should revert if the caller is neither owner, creator, or approver', async () => {
             await expect(zapMedia1.connect(signers[5]).revokeApproval(0)).revertedWith(
                 'Media: caller not approved address'
             );
         });
-    
+
         it('should revoke the approval for token id if caller is approved address', async () => {
             await zapMedia1.connect(signers[3]).approve(signers[5].address, 0);
             expect(await zapMedia1.connect(signers[5]).revokeApproval(0));


### PR DESCRIPTION
## Summary
Closes #51 

## Implementation
- PR #52 made the ZapMedia contract upgradeable and configured the NFT deploy script to accommodate for that
- Added the correct amount of arguments to the ZapMedia contract for deployment
- Updated the ZapMedia & ZapMarket tests to ensure they are passing

## Files
```scripts/deploy_nft_contracts.ts```
```test/ZapMarketTest.ts```
```test/ZapMediaTest.ts```

## Visual Preview
Upgradeable Contracts are able to be deployed
<img width="548" alt="Screen Shot 2021-09-08 at 12 49 21 PM" src="https://user-images.githubusercontent.com/42893948/132551167-44d043e8-4a24-45cd-97fe-f5b8f368cca7.png">

ZapMarket Tests are passing
<img width="936" alt="Screen Shot 2021-09-08 at 12 50 53 PM" src="https://user-images.githubusercontent.com/42893948/132551415-a17343a4-f900-4c87-9f7e-79063949fb29.png">

ZapMedia Tests are passing
<img width="449" alt="Screen Shot 2021-09-08 at 12 52 04 PM" src="https://user-images.githubusercontent.com/42893948/132551590-b2a018a9-fb3e-429a-a55c-4a820deb1487.png">






