### PR TITLE
Ensuring Eth isn't locked to AuctionHouse if ERC20 token is used instead.

### DIFF
--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -470,6 +470,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
 
             IWETH(wethAddress).deposit{value: amount}();
         } else {
+            require(msg.value == 0, "AuctionHouse: Ether is not required for this transaction");
             // We must check the balance that was actually transferred to the auction,
             // as some tokens impose a transfer fee and would not actually transfer the
             // full amount to the market, resulting in potentally locked funds

--- a/contracts/nft/test/BadBidder.sol
+++ b/contracts/nft/test/BadBidder.sol
@@ -18,7 +18,7 @@ contract BadBidder {
 
     function placeBid(uint256 auctionId, uint256 amount, address mediaContract, address tokenAddress) external payable {
         IERC20(tokenAddress).approve(auction, amount);
-        IAuctionHouse(auction).createBid{value: amount}(auctionId, amount, mediaContract);
+        IAuctionHouse(auction).createBid(auctionId, amount, mediaContract);
     }
 
     receive() external payable {}

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -80,13 +80,13 @@ describe("AuctionHouse", () => {
     await zapTokenBsc.mint(bidder.address, BigNumber.from("10000000000000000000"));
   });
 
-  async function deploy(signer: SignerWithAddress): Promise<AuctionHouse> {
+  async function deploy(signer: SignerWithAddress, currency: string): Promise<AuctionHouse> {
     let auctionHouse: AuctionHouse;
     let AuctionHouse: AuctionHouse__factory;
 
     AuctionHouse = await ethers.getContractFactory("AuctionHouse", signer) as AuctionHouse__factory;
 
-    auctionHouse = await upgrades.deployProxy(AuctionHouse, [zapTokenBsc.address], { initializer: 'initialize' }) as AuctionHouse;
+    auctionHouse = await upgrades.deployProxy(AuctionHouse, [currency], { initializer: 'initialize' }) as AuctionHouse;
 
 
     return auctionHouse as AuctionHouse;
@@ -167,7 +167,7 @@ describe("AuctionHouse", () => {
 
       signers = await ethers.getSigners();
 
-      auctionHouse = await deploy(signers[1]);
+      auctionHouse = await deploy(signers[1], zapTokenBsc.address);
 
       await mint(media1);
 
@@ -347,7 +347,7 @@ describe("AuctionHouse", () => {
 
     beforeEach(async () => {
       [deity, admin, curator, bidder] = await ethers.getSigners();
-      auctionHouse = (await deploy(deity)).connect(curator) as AuctionHouse;
+      auctionHouse = (await deploy(deity, zapTokenBsc.address)).connect(curator) as AuctionHouse;
       await mint(media1);
       await approveAuction(media1, auctionHouse);
       await createAuction(
@@ -377,7 +377,7 @@ describe("AuctionHouse", () => {
 
       await auctionHouse
         .connect(bidder)
-        .createBid(0, ONE_ETH, media1.address, { value: ONE_ETH });
+        .createBid(0, ONE_ETH, media1.address);
 
       await expect(
         auctionHouse.setAuctionApproval(0, false)
@@ -415,7 +415,7 @@ describe("AuctionHouse", () => {
 
     beforeEach(async () => {
       [deity, admin, creator, curator, bidder] = await ethers.getSigners();
-      auctionHouse = (await deploy(admin)).connect(curator) as AuctionHouse;
+      auctionHouse = (await deploy(admin, zapTokenBsc.address)).connect(curator) as AuctionHouse;
       await mint(media1.connect(creator));
       await approveAuction(
         media1.connect(creator),
@@ -452,7 +452,7 @@ describe("AuctionHouse", () => {
       await auctionHouse.setAuctionApproval(0, true);
       await auctionHouse
         .connect(bidder)
-        .createBid(0, TWO_ETH, media1.address, { value: TWO_ETH });
+        .createBid(0, TWO_ETH, media1.address);
       await expect(
         auctionHouse.setAuctionReservePrice(0, ONE_ETH)
       ).revertedWith(`Auction has already started`);
@@ -494,7 +494,7 @@ describe("AuctionHouse", () => {
     beforeEach(async () => {
       [admin, curator, bidderA, bidderB] = await ethers.getSigners();
 
-      auctionHouse = (await (await deploy(admin)).connect(bidderA)) as AuctionHouse;
+      auctionHouse = (await (await deploy(admin, zapTokenBsc.address)).connect(bidderA)) as AuctionHouse;
 
       await mint(media1);
 
@@ -530,7 +530,7 @@ describe("AuctionHouse", () => {
     it("should revert if the specified auction is not approved", async () => {
       await auctionHouse.connect(curator).setAuctionApproval(0, false);
       await expect(
-        auctionHouse.createBid(0, ONE_ETH, media1.address, { value: ONE_ETH })
+        auctionHouse.createBid(0, ONE_ETH, media1.address)
       ).revertedWith(`Auction must be approved by curator`);
     });
 
@@ -543,18 +543,14 @@ describe("AuctionHouse", () => {
     it("should revert if the bid is invalid for share splitting", async () => {
 
       await expect(
-        auctionHouse.createBid(0, ONE_ETH.add(1), media1.address, {
-          value: ONE_ETH.add(1),
-        })
+        auctionHouse.createBid(0, ONE_ETH.add(1), media1.address)
       ).revertedWith(`Bid invalid for share splitting`);
     });
 
     it.skip("should revert if msg.value does not equal specified amount", async () => {
       // This test will never pass since we are not using WETH for bids
       await expect(
-        auctionHouse.createBid(0, ONE_ETH, media1.address, {
-          value: ONE_ETH.mul(2),
-        })
+        auctionHouse.createBid(0, ONE_ETH, media1.address)
       ).revertedWith(
         `Sent ETH Value does not match specified bid amount`
       );
@@ -566,30 +562,37 @@ describe("AuctionHouse", () => {
 
         await ethers.provider.send("evm_setNextBlockTimestamp", [9617249934]);
 
-        await auctionHouse.createBid(0, ONE_ETH, media1.address, {
-          value: ONE_ETH,
-        });
+        await auctionHouse.createBid(0, ONE_ETH, media1.address);
 
         expect((await auctionHouse.auctions(0)).firstBidTime).to.eq(9617249934);
       });
 
       it("should store the transferred ZAP", async () => {
 
-        await auctionHouse.createBid(0, ONE_ETH, media1.address, {
-          value: ONE_ETH,
-        });
+        await auctionHouse.createBid(0, ONE_ETH, media1.address);
 
         expect(await zapTokenBsc.balanceOf(auctionHouse.address)).to.eq(ONE_ETH);
 
+      });
+
+      it("should not transfer any Ether since a currency (ZAP) was set", async () => {
+        const ethBalanceBefore = await ethers.provider.getBalance(bidderA.address);
+
+        await expect(auctionHouse.connect(bidderA).createBid(
+          0, ONE_ETH, media1.address, { value: ONE_ETH })
+          ).to.be.revertedWith("AuctionHouse: Ether is not required for this transaction");
+
+        expect(
+          await ethers.provider.getBalance(bidderA.address),
+          "ethBalanceBefore minus gas, but should be gt ethBalanceBefore minus One Eth."
+          ).to.be.gt(ethBalanceBefore.sub(ONE_ETH));
       });
 
       it("should not update the auction's duration", async () => {
 
         const beforeDuration = (await auctionHouse.auctions(0)).duration;
 
-        await auctionHouse.createBid(0, ONE_ETH, media1.address, {
-          value: ONE_ETH,
-        });
+        await auctionHouse.createBid(0, ONE_ETH, media1.address);
 
         const afterDuration = (await auctionHouse.auctions(0)).duration;
 
@@ -599,9 +602,7 @@ describe("AuctionHouse", () => {
 
       it("should store the bidder's information", async () => {
 
-        await auctionHouse.createBid(0, ONE_ETH, media1.address, {
-          value: ONE_ETH,
-        });
+        await auctionHouse.createBid(0, ONE_ETH, media1.address);
 
         const currAuction = await auctionHouse.auctions(0);
 
@@ -614,9 +615,7 @@ describe("AuctionHouse", () => {
 
         const block = await ethers.provider.getBlockNumber();
 
-        await auctionHouse.createBid(0, ONE_ETH, media1.address, {
-          value: ONE_ETH,
-        });
+        await auctionHouse.createBid(0, ONE_ETH, media1.address);
 
         const events = await auctionHouse.queryFilter(
           auctionHouse.filters.AuctionBid(
@@ -650,15 +649,13 @@ describe("AuctionHouse", () => {
         auctionHouse = auctionHouse.connect(bidderB) as AuctionHouse;
         await auctionHouse
           .connect(bidderA)
-          .createBid(0, ONE_ETH, media1.address, { value: ONE_ETH });
+          .createBid(0, ONE_ETH, media1.address);
       });
 
       it("should revert if the bid is smaller than the last bid + minBid", async () => {
 
         await expect(
-          auctionHouse.createBid(0, ONE_ETH.add(1), media1.address, {
-            value: ONE_ETH.add(1),
-          })
+          auctionHouse.createBid(0, ONE_ETH.add(1), media1.address)
         ).revertedWith(
           `Must send more than last bid by minBidIncrementPercentage amount`
         );
@@ -670,9 +667,7 @@ describe("AuctionHouse", () => {
 
         const beforeBidAmount = (await auctionHouse.auctions(0)).amount;
 
-        await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-          value: TWO_ETH,
-        });
+        await auctionHouse.createBid(0, TWO_ETH, media1.address);
 
         const afterBalance = await zapTokenBsc.balanceOf(bidderA.address);
 
@@ -690,9 +685,7 @@ describe("AuctionHouse", () => {
 
         const firstBidTime = (await auctionHouse.auctions(0)).firstBidTime;
 
-        await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-          value: TWO_ETH,
-        });
+        await auctionHouse.createBid(0, TWO_ETH, media1.address);
 
         expect((await auctionHouse.auctions(0)).firstBidTime).to.eq(
           firstBidTime
@@ -702,18 +695,14 @@ describe("AuctionHouse", () => {
 
       it("should transfer the bid to the contract and store it as Zap", async () => {
 
-        await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-          value: TWO_ETH,
-        });
+        await auctionHouse.createBid(0, TWO_ETH, media1.address);
 
         expect(await zapTokenBsc.balanceOf(auctionHouse.address)).to.eq(TWO_ETH);
       });
 
       it("should update the stored bid information", async () => {
 
-        await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-          value: TWO_ETH,
-        });
+        await auctionHouse.createBid(0, TWO_ETH, media1.address);
 
         const currAuction = await auctionHouse.auctions(0);
 
@@ -725,9 +714,7 @@ describe("AuctionHouse", () => {
 
         const beforeDuration = (await auctionHouse.auctions(0)).duration;
 
-        await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-          value: TWO_ETH,
-        });
+        await auctionHouse.createBid(0, TWO_ETH, media1.address);
 
         const afterDuration = (await auctionHouse.auctions(0)).duration;
 
@@ -736,9 +723,7 @@ describe("AuctionHouse", () => {
 
       it("should emit an AuctionBid event", async () => {
         const block = await ethers.provider.getBlockNumber();
-        await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-          value: TWO_ETH,
-        });
+        await auctionHouse.createBid(0, TWO_ETH, media1.address);
         const events = await auctionHouse.queryFilter(
           auctionHouse.filters.AuctionBid(
             null,
@@ -773,9 +758,7 @@ describe("AuctionHouse", () => {
         });
         it("should extend the duration of the bid if inside of the time buffer", async () => {
           const beforeDuration = (await auctionHouse.auctions(0)).duration;
-          await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-            value: TWO_ETH,
-          });
+          await auctionHouse.createBid(0, TWO_ETH, media1.address);
 
           const currAuction = await auctionHouse.auctions(0);
           expect(currAuction.duration).to.eq(
@@ -784,9 +767,7 @@ describe("AuctionHouse", () => {
         });
         it("should emit an AuctionBid event", async () => {
           const block = await ethers.provider.getBlockNumber();
-          await auctionHouse.createBid(0, TWO_ETH, media1.address, {
-            value: TWO_ETH,
-          });
+          await auctionHouse.createBid(0, TWO_ETH, media1.address);
           const events = await auctionHouse.queryFilter(
             auctionHouse.filters.AuctionBid(
               null,
@@ -840,7 +821,7 @@ describe("AuctionHouse", () => {
 
     beforeEach(async () => {
       [admin, creator, curator, bidder] = await ethers.getSigners();
-      auctionHouse = (await deploy(admin)).connect(creator) as AuctionHouse;
+      auctionHouse = (await deploy(admin, zapTokenBsc.address)).connect(creator) as AuctionHouse;
       await mint(media1.connect(creator));
       await approveAuction(media1.connect(creator), auctionHouse);
       // await auctionHouse.setTokenDetails(0, media1.address);
@@ -871,7 +852,7 @@ describe("AuctionHouse", () => {
       await zapTokenBsc.connect(bidder).approve(auctionHouse.address, ONE_ETH);
       await auctionHouse
         .connect(bidder)
-        .createBid(0, ONE_ETH, media1.address, { value: ONE_ETH });
+        .createBid(0, ONE_ETH, media1.address);
       await expect(auctionHouse.cancelAuction(0)).revertedWith(
         `Can't cancel an auction once it's begun`
       );
@@ -939,7 +920,7 @@ describe("AuctionHouse", () => {
 
     beforeEach(async () => {
       [admin, creator, curator, bidder, other] = await ethers.getSigners();
-      auctionHouse = (await deploy(creator)) as AuctionHouse;
+      auctionHouse = (await deploy(creator, zapTokenBsc.address)) as AuctionHouse;
       await mint(media1.connect(creator));
       await approveAuction(media1.connect(creator), auctionHouse);
 
@@ -969,9 +950,7 @@ describe("AuctionHouse", () => {
     });
 
     it("should revert if the auction has not completed", async () => {
-      await auctionHouse.connect(bidder).createBid(0, ONE_ETH, media1.address, {
-        value: ONE_ETH,
-      });
+      await auctionHouse.connect(bidder).createBid(0, ONE_ETH, media1.address);
 
       await expect(auctionHouse.endAuction(0, media1.address)).revertedWith(
         `Auction hasn't completed`
@@ -981,7 +960,7 @@ describe("AuctionHouse", () => {
     it("should cancel the auction if the winning bidder is unable to receive NFTs", async () => {
       await zapTokenBsc.mint(badBidder.address, TWO_ETH);
       await zapTokenBsc.connect(bidder).approve(badBidder.address, TWO_ETH);
-      await badBidder.connect(bidder).placeBid(0, TWO_ETH, media1.address, zapTokenBsc.address, { value: TWO_ETH });
+      await badBidder.connect(bidder).placeBid(0, TWO_ETH, media1.address, zapTokenBsc.address);
       const endTime =
         (await auctionHouse.auctions(0)).duration.toNumber() +
         (await auctionHouse.auctions(0)).firstBidTime.toNumber();
@@ -996,11 +975,15 @@ describe("AuctionHouse", () => {
     });
 
     describe("ETH auction", () => {
+      // We may need to think this over, AH is using ZapToken for
+      // these tests, not (W)ETH
 
       beforeEach(async () => {
+      //  const [ deity ] = await ethers.getSigners();
+      //   auctionHouse = await deploy(deity, "0x0000000000000000000000000000000000000000");
         await auctionHouse
           .connect(bidder)
-          .createBid(0, ONE_ETH, media1.address, { value: ONE_ETH });
+          .createBid(0, ONE_ETH, media1.address);
 
         const endTime =
           (await auctionHouse.auctions(0)).duration.toNumber() +

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -584,7 +584,7 @@ describe("AuctionHouse", () => {
 
         expect(
           await ethers.provider.getBalance(bidderA.address),
-          "ethBalanceBefore minus gas, but should be gt ethBalanceBefore minus One Eth."
+          "ethBalanceBefore minus gas, should be gt ethBalanceBefore minus One Eth."
           ).to.be.gt(ethBalanceBefore.sub(ONE_ETH));
       });
 


### PR DESCRIPTION
## Summary
Added a require statement in the else clause of https://github.com/zapproject/hardhat-bsc/blob/5712d542d9f6181f0a2e04a060ab8a1862cd4ede/contracts/nft/AuctionHouse.sol#L454

This explicitly ensures that Eth is not transferred from msg.sender to AuctionHouse.
Some tests were written on this branch to ensure this is the case.
closes #78

## Implementation
This require statement was added to the else clause in `_handleIncomingBid` found in `AuctionHouse.sol`. It requires that the `msg.value` is zero, else the execution of `createBid` (and `placeBid` in the `BadBidder.sol` test contract) is reverted.

## Files
* `contracts/nft/AuctionHouse.sol`
* `contracts/nft/test/BadBidder.sol`
* `test/AuctionHouse.ts`

## Visual Preview
### contracts/.../AuctionHouse.sol
![](https://i.imgur.com/NC5Tuvs.png)

### test/AuctionHouse.ts
![](https://i.imgur.com/5PxZMfl.png)