### PR TITLE
Using SafeERC20 opportunistic evaluation of token transfer success

### DIFF
--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -201,7 +201,7 @@ contract Zap {
         (address _from, address _to, uint256 _disputeFee) = zap.tallyVotes(_disputeId);
 
         approve(_from, _disputeFee);
-        token.transferFrom(_from, _to, _disputeFee);
+        transferFrom(_from, _to, _disputeFee);
     }
 
     /**
@@ -210,7 +210,11 @@ contract Zap {
      */
     function proposeFork(address _propNewZapAddress) external {
         zap.proposeFork(_propNewZapAddress);
-        token.transferFrom(msg.sender, zap.addressVars[keccak256("_owner")], zap.uintVars[keccak256('disputeFee')]);
+            transferFrom(
+                msg.sender,
+                zap.addressVars[keccak256("_owner")],
+                zap.uintVars[keccak256('disputeFee')]
+            );
     }
 
     /**
@@ -265,7 +269,7 @@ contract Zap {
 
             //If the tip > 0 it tranfers the tip to this contract
             if (_tip > 0) {
-                token.transferFrom(msg.sender, address(this), _tip);
+                transferFrom(msg.sender, address(this), _tip);
             }
             updateOnDeck(_requestId, _tip);
             emit DataRequested(
@@ -307,32 +311,19 @@ contract Zap {
             // Pay the miners
             for (uint256 i = 0; i < 5; i++) {
                 if (a[i].miner != address(0)){
-                    // console.log("++++++++++++++++");
-                    // console.log("++++++++++++++++");
-                    // console.log("++++++++++++++++");
-                    // console.log("miner: ", a[i].miner);
-                    // console.log("address(this): ", address(this));
-                    // console.log("master balance: ", token.balanceOf(address(this)));
-                    // console.log("vault balance: ", token.balanceOf(address(vault)));
-                    // console.log("minerReward: ", minerReward);
-                    // console.log("++++++++++++++++");
-                    // console.log("++++++++++++++++");
-                    // console.log("++++++++++++++++");
                     token.approve(address(this), minerReward);
-                    token.transferFrom(address(this), address(vault), minerReward);
-                    // console.log("++++++++++++++++");
-                    // console.log("vault balance after: ", token.balanceOf(address(vault)));
-                    // console.log("++++++++++++++++");
+                    transferFrom(address(this), address(vault), minerReward);
                     vault.deposit(a[i].miner, minerReward);
                 }
             }
 
             // Pay the devshare
             token.approve(address(this), zap.uintVars[keccak256('devShare')]);
-            token.transferFrom(
+            transferFrom(
                 address(this),
                 zap.addressVars[keccak256('_owner')],
-                zap.uintVars[keccak256('devShare')]);
+                zap.uintVars[keccak256('devShare')]
+            );
         }
 
         zap.uintVars[keccak256('currentMinerReward')] = 0;
@@ -355,7 +346,7 @@ contract Zap {
         Vault vault = Vault(vaultAddress);
 
         token.approve(address(this), stakeAmount);
-        token.transferFrom(msg.sender, vaultAddress, stakeAmount);
+        transferFrom(msg.sender, vaultAddress, stakeAmount);
         vault.deposit(msg.sender, stakeAmount);
 
     }
@@ -380,11 +371,7 @@ contract Zap {
 
         uint256 userBalance = vault.userBalance(msg.sender);
 
-        token.transferFrom(
-            address(vault),
-            msg.sender,
-            userBalance
-        );
+        transferFrom(address(vault), msg.sender, userBalance);
 
         vault.withdraw(msg.sender, userBalance);
     }
@@ -405,8 +392,9 @@ contract Zap {
      * @param _amount The amount of tokens to send
      * @return true if transfer is successful
      */
-    function transfer(address _to, uint256 _amount) public returns (bool) {
-        return token.transfer(_to, _amount);
+    function transfer(address _to, uint256 _amount) public {
+        bool transfered = token.transfer(_to, _amount);
+        require(transfered == true, "ZapTokenBsc: ERC20 Transfer failed");
     }
 
     /**
@@ -421,8 +409,9 @@ contract Zap {
         address _from,
         address _to,
         uint256 _amount
-    ) public returns (bool) {
-        return token.transferFrom(_from, _to, _amount);
+    ) public {
+        bool transfered = token.transferFrom(_from, _to, _amount);
+        require(transfered == true, "ZapTokenBsc: ERC20 Transfer failed");
     }
 
     /**
@@ -458,7 +447,7 @@ contract Zap {
         //If the tip > 0 transfer the tip to this contract
         if (_tip > 0) {
             // doTransfer(msg.sender, address(this), _tip);
-            token.transferFrom(msg.sender, address(this), _tip);
+            transferFrom(msg.sender, address(this), _tip);
         }
 
         //Update the information for the request that should be mined next based on the tip submitted

--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -563,15 +563,15 @@ contract Zap {
     /**
      * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
      * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param token The token targeted by the call.
+     * @param _token The token targeted by the call.
      * @param data The call data (encoded using abi.encode or one of its variants).
      */
-    function _callOptionalReturn(ZapTokenBSC token, bytes memory data) private {
+    function _callOptionalReturn(ZapTokenBSC _token, bytes memory data) private {
         // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
         // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
         // the target address contains contract code and also asserts for success in the low-level call.
 
-        bytes memory returndata = address(token).functionCall(data, "ZapTokenBSC: low-level call failed");
+        bytes memory returndata = address(_token).functionCall(data, "ZapTokenBSC: low-level call failed");
         if (returndata.length > 0) {
             // Return data is optional
             require(abi.decode(returndata, (bool)), "ZapTokenBSC: ERC20 operation did not succeed");

--- a/contracts/zap-miner/ZapMaster.sol
+++ b/contracts/zap-miner/ZapMaster.sol
@@ -79,11 +79,10 @@ contract ZapMaster is ZapGetters {
         uint256 zapBalance = token.balanceOf(address(this));
         // approve entire balance
         token.approve(address(this), zapBalance);
-        bytes memory data = abi.encodeWithSignature(
-                "transferFrom(address,address,uint256)", address(this), _newZapMaster, zapBalance
+        bytes memory data = abi.encodeWithSelector(
+                token.transferFrom.selector, address(this), _newZapMaster, zapBalance
         );
-        (bool success, bytes memory returnData) = address(zap.addressVars[keccak256('zapContract')]).call(data);
-        require(success && returnData.length > 0);
+        _callOptionalReturn(token, data);
     }
 
     /**
@@ -113,6 +112,24 @@ contract ZapMaster is ZapGetters {
             default {
                 return(ptr, size)
             }
+        }
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param _token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(ZapTokenBSC _token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = address(_token).functionCall(data, "ZapTokenBSC: low-level call failed");
+        if (returndata.length > 0) {
+            // Return data is optional
+            require(abi.decode(returndata, (bool)), "ZapTokenBSC: ERC20 operation did not succeed");
         }
     }
 }

--- a/contracts/zap-miner/ZapMaster.sol
+++ b/contracts/zap-miner/ZapMaster.sol
@@ -70,7 +70,6 @@ contract ZapMaster is ZapGetters {
         zap.changeVaultContract(_vaultContract);
     }
 
-
     // function to send balance to a New Zap Master contract
     function sendBalToNewZM(address _newZapMaster) external onlyOwner {
         // require to be the owner of ZM to send to new ZM
@@ -82,7 +81,6 @@ contract ZapMaster is ZapGetters {
         bool transfered = token.transferFrom(address(this), _newZapMaster, zapBalance);
         require(transfered == true, "ZapTokenBsc: ERC20 Transfer failed");
     }
-
 
     /**
      * @dev This is the fallback function that allows contracts to call the zap contract at the address stored

--- a/contracts/zap-miner/ZapMaster.sol
+++ b/contracts/zap-miner/ZapMaster.sol
@@ -79,7 +79,8 @@ contract ZapMaster is ZapGetters {
         uint256 zapBalance = token.balanceOf(address(this));
         // approve entire balance
         token.approve(address(this), zapBalance);
-        token.transferFrom(address(this), _newZapMaster, zapBalance);
+        bool transfered = token.transferFrom(address(this), _newZapMaster, zapBalance);
+        require(transfered == true, "ZapTokenBsc: ERC20 Transfer failed");
     }
 
 

--- a/contracts/zap-miner/ZapMaster.sol
+++ b/contracts/zap-miner/ZapMaster.sol
@@ -1,7 +1,7 @@
 pragma solidity =0.5.16;
 
 import './ZapGetters.sol';
-
+import './libraries/Address.sol';
 
 /**
  * @title Zap Master
@@ -11,6 +11,7 @@ import './ZapGetters.sol';
  */
 contract ZapMaster is ZapGetters {
     event NewZapAddress(address _newZap);
+    using Address for address;
 
 
     ZapTokenBSC public token;
@@ -78,8 +79,11 @@ contract ZapMaster is ZapGetters {
         uint256 zapBalance = token.balanceOf(address(this));
         // approve entire balance
         token.approve(address(this), zapBalance);
-        bool transfered = token.transferFrom(address(this), _newZapMaster, zapBalance);
-        require(transfered == true, "ZapTokenBsc: ERC20 Transfer failed");
+        bytes memory data = abi.encodeWithSignature(
+                "transferFrom(address,address,uint256)", address(this), _newZapMaster, zapBalance
+        );
+        (bool success, bytes memory returnData) = address(zap.addressVars[keccak256('zapContract')]).call(data);
+        require(success && returnData.length > 0);
     }
 
     /**

--- a/contracts/zap-miner/libraries/Address.sol
+++ b/contracts/zap-miner/libraries/Address.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.5.16;
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library Address {
+    /**
+     * @dev Returns true if `account` is a contract.
+     *
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
+     *
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
+     */
+    function isContract(address account) internal view returns (bool) {
+        // This method relies on extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        uint256 size;
+        assembly {
+            size := extcodesize(account)
+        }
+        return size > 0;
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        (bool success, ) = recipient.call.value(amount)("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason, it is bubbled up by this
+     * function (like regular Solidity function calls).
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionCall(target, data, "Address: low-level call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`], but with
+     * `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, 0, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value
+    ) internal returns (bytes memory) {
+        return functionCallWithValue(target, data, value, "Address: low-level call with value failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCallWithValue-address-bytes-uint256-}[`functionCallWithValue`], but
+     * with `errorMessage` as a fallback revert reason when `target` reverts.
+     *
+     * _Available since v3.1._
+     */
+    function functionCallWithValue(
+        address target,
+        bytes memory data,
+        uint256 value,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(address(this).balance >= value, "Address: insufficient balance for call");
+        require(isContract(target), "Address: call to non-contract");
+
+        (bool success, bytes memory returndata) = target.call.value(value)(data);
+        return verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(address target, bytes memory data) internal view returns (bytes memory) {
+        return functionStaticCall(target, data, "Address: low-level static call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a static call.
+     *
+     * _Available since v3.3._
+     */
+    function functionStaticCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal view returns (bytes memory) {
+        require(isContract(target), "Address: static call to non-contract");
+
+        (bool success, bytes memory returndata) = target.staticcall(data);
+        return verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(address target, bytes memory data) internal returns (bytes memory) {
+        return functionDelegateCall(target, data, "Address: low-level delegate call failed");
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-string-}[`functionCall`],
+     * but performing a delegate call.
+     *
+     * _Available since v3.4._
+     */
+    function functionDelegateCall(
+        address target,
+        bytes memory data,
+        string memory errorMessage
+    ) internal returns (bytes memory) {
+        require(isContract(target), "Address: delegate call to non-contract");
+
+        (bool success, bytes memory returndata) = target.delegatecall(data);
+        return verifyCallResult(success, returndata, errorMessage);
+    }
+
+    /**
+     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the
+     * revert reason using the provided one.
+     *
+     * _Available since v4.3._
+     */
+    function verifyCallResult(
+        bool success,
+        bytes memory returndata,
+        string memory errorMessage
+    ) internal pure returns (bytes memory) {
+        if (success) {
+            return returndata;
+        } else {
+            // Look for revert reason and bubble it up if present
+            if (returndata.length > 0) {
+                // The easiest way to bubble the revert reason is using memory via assembly
+
+                assembly {
+                    let returndata_size := mload(returndata)
+                    revert(add(32, returndata), returndata_size)
+                }
+            } else {
+                revert(errorMessage);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Direct token transfers using ZapToken have been replaced in favor of the SafeERC20, low level transfer that reverts if the transfer is unsuccessful.

Previously, the success of a transfer wasn't being evaluated.

closes #84 

## Implementation
The [OpenZeppelin `Address.sol`](https://docs.openzeppelin.com/contracts/4.x/api/utils#Address) library was added to the miner contracts and solidity's `address` functionality was extended using this library.

`Address.sol` enabled safe ERC20 transactions, where the success or failure of the transfer is irrelevant at the high level, but the transaction will nonetheless revert at a low level if it fails.

`_callOptionalReturn` is used within `Zap.sol` and `ZapMaster.sol` to evaluate the success/failure of a transfer and provides a revert message if it fails. The existing tests show that the token transfers are working as expected after these changes.

## Files
* `contracts/zap-miner/libraries/Address.sol`
* `contracts/zap-miner/Zap.sol`
* `contracts/zap-miner/ZapMaster.sol`

## Visual Preview
### contracts/.../Zap.sol
![](https://i.ibb.co/bQdcJMz/image.png)
![](https://i.ibb.co/dDy3TkB/image.png)

### contracts/.../ZapMaster.sol
![](https://i.ibb.co/ZBccdGv/image.png)

### contracts/.../Address.sol
this is where the actual ZapToken call takes place
![image](https://user-images.githubusercontent.com/13321394/135064235-d2f24432-41df-4c79-970f-d1bb21136c64.png)