### PR TITLE
assert for neg values in SafeMathM max()

### DIFF
--- a/contracts/zap-miner/libraries/SafeMathM.sol
+++ b/contracts/zap-miner/libraries/SafeMathM.sol
@@ -9,6 +9,7 @@ library SafeMathM {
     }
 
     function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        assert(a >= 0 && b > 0);
         return a > b ? a : b;
     }
 

--- a/contracts/zap-miner/libraries/SafeMathM.sol
+++ b/contracts/zap-miner/libraries/SafeMathM.sol
@@ -9,7 +9,7 @@ library SafeMathM {
     }
 
     function max(uint256 a, uint256 b) internal pure returns (uint256) {
-        assert(a >= 0 && b > 0);
+        assert(a >= 0 && b >= 0);
         return a > b ? a : b;
     }
 


### PR DESCRIPTION
### Summary
The max() in SafeMathM.sol contained unsafe type casting, not ensuring values are negative values.

closes #157 

### Implementation
Added an `assert` to ensure that both the int256 parameters are `>= 0`.

### File
`contracts/zap-miner/libraries/SafeMathM.sol`

### Visual
![image](https://user-images.githubusercontent.com/18056516/135131165-cca48feb-021c-4a04-94d2-b895a250ee61.png)
