### PR TITLE
setTokenDetails using stricter access control

### DIFF
--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -64,12 +64,6 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
     /*
      * Constructor
      */
-    // constructor(address _weth) {
-    //     wethAddress = _weth;
-    //     timeBuffer = 15 * 60; // extend 15 minutes after every bid made in last 15 minutes
-    //     minBidIncrementPercentage = 5; // 5%
-    // }
-
     function initialize(address _weth) public initializer {
         wethAddress = _weth;
         timeBuffer = 15 * 60; // extend 15 minutes after every bid made in last 15 minutes

--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -80,6 +80,11 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
         internal
         returns (bool)
     {
+        require(mediaContract != address(0), "AuctionHouse: Media Contract Address can not be the zero address");
+        if(
+            tokenDetails[mediaContract][tokenId].mediaContract != address(0)
+        ) return false;
+
         tokenDetails[mediaContract][tokenId] = TokenDetails({
             tokenId: tokenId,
             mediaContract: mediaContract

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -17,7 +17,6 @@ import {
   TWO_ETH,
 } from "./utils";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { execPath } from "process";
 
 describe("AuctionHouse", () => {
   let market: ZapMarket;
@@ -161,7 +160,6 @@ describe("AuctionHouse", () => {
   describe("#createAuction", () => {
 
     let auctionHouse: AuctionHouse;
-    let signers: SignerWithAddress[]
 
     beforeEach(async () => {
 
@@ -188,7 +186,7 @@ describe("AuctionHouse", () => {
           reservePrice,
           curator.address,
           5,
-          "0x0000000000000000000000000000000000000000"
+          ethers.constants.AddressZero
         )
       ).revertedWith(
         `tokenContract does not support ERC721 interface`
@@ -209,7 +207,7 @@ describe("AuctionHouse", () => {
             reservePrice,
             curator.address,
             5,
-            "0x0000000000000000000000000000000000000000"
+            ethers.constants.AddressZero
           )
       ).revertedWith(
         `Caller must be approved or owner for token id`
@@ -233,7 +231,7 @@ describe("AuctionHouse", () => {
             reservePrice,
             curator.address,
             5,
-            "0x0000000000000000000000000000000000000000"
+            ethers.constants.AddressZero
           )
       ).revertedWith(
         `ERC721: owner query for nonexistent token`
@@ -254,7 +252,7 @@ describe("AuctionHouse", () => {
           reservePrice,
           curator.address,
           100,
-          "0x0000000000000000000000000000000000000000"
+          ethers.constants.AddressZero
         )
       ).revertedWith(
         `curatorFeePercentage must be less than 100`
@@ -280,6 +278,17 @@ describe("AuctionHouse", () => {
       expect(createdAuction.curator).to.eq(expectedCurator.address);
       expect(createdAuction.approved).to.eq(true);
 
+    });
+
+    it("should revert if the media contract address is the zero address", async () => {
+      const duration = 60 * 60 * 24;
+      const reservePrice = BigNumber.from(10).pow(18).div(2);
+      await expect(
+        auctionHouse.createAuction(
+          0, ethers.constants.AddressZero, duration, reservePrice,
+          signers[1].address, 5, zapTokenBsc.address
+          )
+      ).to.be.revertedWith("function call to a non-contract account")
     });
 
     it("should be automatically approved if the creator is the curator", async () => {
@@ -978,7 +987,7 @@ describe("AuctionHouse", () => {
 
       beforeEach(async () => {
       //  const [ deity ] = await ethers.getSigners();
-      //   auctionHouse = await deploy(deity, "0x0000000000000000000000000000000000000000");
+      //   auctionHouse = await deploy(deity, ethers.constants.AddressZero);
         await auctionHouse
           .connect(bidder)
           .createBid(0, ONE_ETH, media1.address);


### PR DESCRIPTION
## Summary
Access control for setTokenDetails was improved within setTokenDetails. If the media contract address is already set in the `tokenDetails` mapping, then it will not set it again.

The previously written tests ensures that the changes are not breaking.

closes #93.

## Implementation
Before the audit, an `external` visibility was set on setTokenDetails, however, during the audit it was replaced with `internal` and is now called within `createAuction`.

Because of this, the only relevant addition to this PR is this tidbit from `setTokenDetails`
```solidity
      if(
            tokenDetails[mediaContract][tokenId].mediaContract != address(0)
        ) return false;
```
A token can only be minted from one contract, so I think it only makes sense that this change is made.

It also makes it possible to create an auction for a token that has previously been auctioned off.

## Files
* ` contracts/nft/AuctionHouse.sol`
* `test/AuctionHouseTest.ts`

## Visual Preview
### contracts/nft/AuctionHouse.sol
![image](https://user-images.githubusercontent.com/13321394/135132147-239d2993-e2ee-436e-be14-f77cb215d4d2.png)
