### PR TITLE
Vault audit

### DIFF
--- a/contracts/zap-miner/Vault.sol
+++ b/contracts/zap-miner/Vault.sol
@@ -9,7 +9,6 @@ contract Vault {
     address public zapToken;
     ZapMaster zapMaster;
     mapping(address => uint256) private balances;
-    mapping(address => mapping(address => bool)) private keys;
 
     uint256 constant MAX_UINT = 2**256 - 1;
 
@@ -17,31 +16,14 @@ contract Vault {
         zapToken = token;
         zapMaster = ZapMaster(address(uint160(master)));
         
-        token.call(abi.encodeWithSignature("approve(address,uint256)", master, MAX_INT));
+        token.call(abi.encodeWithSignature("approve(address,uint256)", master, MAX_UINT));
     }
 
     function increaseApproval() public returns (bool) {
         (bool s, bytes memory balance) = zapToken.call(abi.encodeWithSignature("allowance(address,address)", address(this), zapMaster));
-        uint256 amount = MAX_INT.sub(toUint256(balance, 0));
+        uint256 amount = MAX_UINT.sub(toUint256(balance, 0));
         (bool success, bytes memory data) = zapToken.call(abi.encodeWithSignature("increaseApproval(address,uint256)", zapMaster, amount));
         return success;
-    }
-
-    function lockSmith(address miniVault, address authorizedUser) public {
-        require(msg.sender == miniVault, "You do not own this vault.");
-        require(msg.sender != address(0) || miniVault != msg.sender, "The zero address can not own a vault.");
-
-        // gives the mini-vault owner keys if they don't already have
-        if (!keys[miniVault][msg.sender]){
-            keys[miniVault][miniVault] = true;
-        }
-
-        keys[miniVault][authorizedUser] = true;
-    }
-
-    function hasAccess(address user, address miniVault) public view returns (bool) {
-        require(msg.sender != address(0) || miniVault != msg.sender, "The zero address does not own a vault.");
-        return keys[miniVault][user];
     }
 
     function toUint256(bytes memory _bytes, uint256 _start) internal pure returns (uint256) {
@@ -57,13 +39,13 @@ contract Vault {
 
     function deposit(address userAddress, uint256 value) public {
         require(userAddress != address(0), "The zero address does not own a vault.");
-        require(hasAccess(msg.sender, userAddress), "You are not authorized to access this vault.");
+        require(msg.sender == address(zapMaster), "Only Zap contract accessible");
         balances[userAddress] = balances[userAddress].add(value);
     }
 
     function withdraw(address userAddress, uint256 value) public {
         require(userAddress != address(0), "The zero address does not own a vault.");
-        require(hasAccess(msg.sender, userAddress), "You are not authorized to access this vault.");
+        require(msg.sender == address(zapMaster), "Only Zap contract accessible");
         require(userBalance(userAddress) >= value, "Your balance is insufficient.");
         balances[userAddress] = balances[userAddress].sub(value);
     }

--- a/contracts/zap-miner/Vault.sol
+++ b/contracts/zap-miner/Vault.sol
@@ -8,8 +8,8 @@ contract Vault {
 
     address public zapToken;
     ZapMaster zapMaster;
-    mapping(address => uint256) balances;
-    mapping(address => mapping(address => bool)) keys;
+    mapping(address => uint256) private balances;
+    mapping(address => mapping(address => bool)) private keys;
 
     uint256 constant MAX_UINT = 2**256 - 1;
 

--- a/contracts/zap-miner/Vault.sol
+++ b/contracts/zap-miner/Vault.sol
@@ -11,7 +11,7 @@ contract Vault {
     mapping(address => uint256) balances;
     mapping(address => mapping(address => bool)) keys;
 
-    uint256 constant MAX_INT = 2**256 - 1;
+    uint256 constant MAX_UINT = 2**256 - 1;
 
     constructor (address token, address master) public {
         zapToken = token;

--- a/contracts/zap-miner/libraries/SafeMathM.sol
+++ b/contracts/zap-miner/libraries/SafeMathM.sol
@@ -9,6 +9,7 @@ library SafeMathM {
     }
 
     function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        assert(a >= 0 && b > 0);
         return a > b ? a : b;
     }
 

--- a/contracts/zap-miner/libraries/SafeMathM.sol
+++ b/contracts/zap-miner/libraries/SafeMathM.sol
@@ -9,7 +9,7 @@ library SafeMathM {
     }
 
     function max(uint256 a, uint256 b) internal pure returns (uint256) {
-        assert(a >= 0 && b > 0);
+        assert(a >= 0 && b >= 0);
         return a > b ? a : b;
     }
 

--- a/test/DisputeTest.ts
+++ b/test/DisputeTest.ts
@@ -137,7 +137,6 @@ describe("Test ZapDispute and it's dispute functions", () => {
     for (let i = 1; i <= 5; i++) {
       await zapTokenBsc.allocate(signers[i].address, BigNumber.from("1100000000000000000000000"));
       zap = zap.connect(signers[i]);
-      await vault.connect(signers[i]).lockSmith(signers[i].address, zap.address);
 
       await zapTokenBsc.connect(signers[i]).approve(zapMaster.address, BigNumber.from("500000000000000000000000"));
       await zap.depositStake();
@@ -172,9 +171,6 @@ describe("Test ZapDispute and it's dispute functions", () => {
 
       // Each Miner will submit a mining solution
       const mining = await zap.submitMiningSolution('nonce', 1, 1200);
-      //   const res = await mining.wait();
-      //   console.log(res)
-
       // Checks if the miners mined the challenge
       // true = Miner did mine the challenge
       // false = Miner did not mine the challenge

--- a/test/MainMinerTests.ts
+++ b/test/MainMinerTests.ts
@@ -192,7 +192,7 @@ describe("Main Miner Functions", () => {
 
             await zapTokenBsc.connect(signers[1]).approve(zapMaster.address, (BigNumber.from("500000000000000000000000")));
 
-            await vault.connect(signers[1]).lockSmith(signers[1].address, zap.address);
+            // await vault.connect(signers[1]).lockSmith(signers[1].address, zap.address);
 
             // Stakes 500k Zap to initiate a miner
             await zap.depositStake();
@@ -318,7 +318,6 @@ describe("Main Miner Functions", () => {
         // await zapTokenBsc.allocate(signers[1].address, 600000e18);
         await zapTokenBsc.allocate(signers[1].address, (BigNumber.from("600000000000000000000000")));
 
-
         // Connects address 1 as the signer
         zap = zap.connect(signers[1]);
 
@@ -335,8 +334,6 @@ describe("Main Miner Functions", () => {
         // Vault balance before staking
         const getVaultPreBal: BigNumber = await zapMaster.balanceOf(vault.address);
         const vaultPreBal: Number = parseInt(getVaultPreBal._hex);
-
-        await vault.connect(signers[1]).lockSmith(signers[1].address, zap.address);
 
         // Stakes 500k Zap to initiate a miner
         await zap.depositStake();
@@ -435,8 +432,6 @@ describe("Main Miner Functions", () => {
 
         await zapTokenBsc.connect(signers[1]).approve(zapMaster.address, (BigNumber.from("500000000000000000000000")));
 
-        await vault.connect(signers[1]).lockSmith(signers[1].address, zap.address);
-
         // Stakes 500000 Zap to initiate a miner
         await zap.depositStake();
 
@@ -506,8 +501,6 @@ describe("Main Miner Functions", () => {
 
         await zapTokenBsc.connect(signers[1]).approve(zapMaster.address, (BigNumber.from("500000000000000000000000")));
         
-        await vault.connect(signers[1]).lockSmith(signers[1].address, zap.address);
-
         // Stakes 500k Zap to initiate a miner
         await zap.depositStake();
 

--- a/test/didMineTest.ts
+++ b/test/didMineTest.ts
@@ -173,7 +173,7 @@ describe('Did Mine Test', () => {
 
             await zapTokenBsc.connect(signers[i]).approve(zapMaster.address, (BigNumber.from("500000000000000000000000")));
 
-            await vault.connect(signers[i]).lockSmith(signers[i].address, zap.address);
+            // await vault.connect(signers[i]).lockSmith(signers[i].address, zap.address);
 
             // Stakes 600k Zap to initiate a miner
             await zap.depositStake();


### PR DESCRIPTION
### Summary
**Issue 83** - Inexistent Visibility Specifiers
Visibility of mappings was unspecified and could cause conflicts in future Solidity versions.
**Issue 101** - Potential Hijack of Functionality
The potential vulnerability of Vault contract, where one of the multiple authorized users could attack `deposit()` & `withdraw()`.
 **Issue 128** - Mislabeled Variable
Mislabled constant `MAX_INT`, when should be `MAX_UINT`.

closes #83 
closes #101 
closes #128

### Implementation
**Issue 83**
- Set `balances` mapping to private. There is an existing getter.

**Issue 101**
- Removed `keys` mapping.
- Replaced require of `msg.sender` being one of the authorized users with `ZapMaster` being the only authorized user.

**Issue 128**
- Renamed constant `MAX_INT` to `MAX_UINT`

### Files
`contracts/zap-miner/Vault.sol`
`test/VaultSecurityTest.ts`
`test/DisputeTest.ts`
`test/MainMinerTests.ts`
`test/VaultSecurityTest.ts`
`test/didMineTest.ts `

### Visuals
![image](https://user-images.githubusercontent.com/18056516/135162772-26b1f42c-372e-465e-af28-c5b248540faf.png)