### PR TITLE
Incrementing auctionId immediately after reading it

### DIFF
--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -119,6 +119,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
             'Caller must be approved or owner for token id'
         );
         uint256 auctionId = _auctionIdTracker.current();
+        _auctionIdTracker.increment();
 
         setTokenDetails(tokenId, mediaContract);
 
@@ -141,8 +142,6 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
             address(this),
             tokenId
         );
-
-        _auctionIdTracker.increment();
 
         emit AuctionCreated(
             auctionId,


### PR DESCRIPTION
## Summary
Prior to this PR, the auction ID was being updated after a state-changing, ERC721 transfer was called. This makes `createAuction` within `AuctionHouse.sol` vulnerable to reentrancies from **external contracts**.

closes #97 

## Implementation
`_auctionIdTracker.increment();` is the function that increments the auction ID. It was previously placed after a state-changing contract call.

This increment statement was moved to be called before that state-changing call, which conforms with the [checks-effects-interactions](https://fravoll.github.io/solidity-patterns/checks_effects_interactions.html) pattern where the effects pattern includes the incrementing and the interactions happen afterwards.

## Files
* `contracts/nft/AuctionHouse.sol`