### PR TITLE
Sanitized duration when creating auctions; 24hr Auction duration

### DIFF
--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -102,6 +102,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
         uint8 curatorFeePercentage,
         address auctionCurrency
     ) public override nonReentrant returns (uint256) {
+        require(duration == 60 * 60 * 24 , "AuctionHouse: We only support Auctions with a 24 hour duration");
         require(
             IERC165Upgradeable(mediaContract).supportsInterface(interfaceId),
             'tokenContract does not support ERC721 interface'

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -95,10 +95,11 @@ describe("AuctionHouse", () => {
   async function createAuction(
     auctionHouse: AuctionHouse,
     curator: string,
-    currency: string
+    currency: string,
+    duration?: number
   ) {
     const tokenId = 0;
-    const duration = 60 * 60 * 24;
+    if (!duration) duration = 60 * 60 * 24;
     const reservePrice = BigNumber.from(10).pow(18).div(2);
 
 
@@ -260,6 +261,13 @@ describe("AuctionHouse", () => {
         `curatorFeePercentage must be less than 100`
       );
     });
+
+    it("should revert if the duration is not 24 hrs", async () => {
+      const [_, expectedCurator] = await ethers.getSigners();
+      await expect(
+        createAuction(auctionHouse, expectedCurator.address, zapTokenBsc.address, 60 * 15)
+      ).to.be.revertedWith("AuctionHouse: We only support Auctions with a 24 hour duration");
+    })
 
     it("should create an auction", async () => {
 


### PR DESCRIPTION
## Summary
closes #98 
Auctions created using the `createAuction` function on https://github.com/zapproject/hardhat-bsc/commit/fde779c0afecc1c2230b24390a154ffbc6b6a4c3#L96 now ensures that the given duration is 24hrs.

A test was written to ensure this is the desired behavior of `createAuction`.

## Implementation
A require statement was added to ensure that the given duration equals `60 * 60 *24` which is 1 day or 24 hrs.

## Files
* `contracts/nft/AuctionHouse.sol`
* `test/AuctionHouseTest.ts`

## Visual preview
### contracts/nft/AuctionHouse.sol
![image](https://user-images.githubusercontent.com/13321394/135274641-07cc433f-f076-445f-a73b-9c881527c4d8.png)

### test/AuctionHouseTest.ts
create auction function wrapper, it sets up and calls the `createAuction` function
![image](https://user-images.githubusercontent.com/13321394/135274758-e40e33a9-3b2a-4eec-a3c3-e763d7fba889.png)

this test uses 15 mins (60 seconds times 15) as the duration
![image](https://user-images.githubusercontent.com/13321394/135275037-c70654c6-b34a-4a34-b24d-e87d4842821f.png)

