### PR TITLE
ZapMedia: Ambiguous Overrides

### DIFF
--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -210,7 +210,7 @@ contract ZapMedia is
         virtual
         override(ERC721EnumerableUpgradeable, ERC721Upgradeable)
     {
-        super._beforeTokenTransfer(from, to, tokenId);
+        ERC721EnumerableUpgradeable._beforeTokenTransfer(from, to, tokenId);
     }
 
     /* *************
@@ -647,7 +647,7 @@ contract ZapMedia is
         internal
         override(ERC721URIStorageUpgradeable, ERC721Upgradeable)
     {
-        super._burn(tokenId);
+        ERC721URIStorageUpgradeable._burn(tokenId);
 
         delete tokens.previousTokenOwners[tokenId];
 
@@ -668,7 +668,7 @@ contract ZapMedia is
     ) internal override {
         IMarket(access.marketContract).removeAsk(address(this), tokenId);
 
-        super._transfer(from, to, tokenId);
+        ERC721Upgradeable._transfer(from, to, tokenId);
     }
 
     /**

--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -168,8 +168,6 @@ contract ZapMedia is
         access.approvedToMint[msg.sender] = true;
         access.isPermissive = permissive;
         collectionMetadata = bytes(_collectionMetadata);
-
-        console.log(name, symbol, _collectionMetadata);
     }
 
     function supportsInterface(bytes4 interfaceId)

--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -137,7 +137,6 @@ contract ZapMedia is
      * ERC721 metadata interface
      */
 
-
     function initialize(
         string calldata name,
         string calldata symbol,
@@ -170,7 +169,7 @@ contract ZapMedia is
         access.isPermissive = permissive;
         collectionMetadata = bytes(_collectionMetadata);
 
-        console.log( name, symbol, _collectionMetadata);
+        console.log(name, symbol, _collectionMetadata);
     }
 
     function supportsInterface(bytes4 interfaceId)
@@ -196,7 +195,7 @@ contract ZapMedia is
         override(ERC721URIStorageUpgradeable, ERC721Upgradeable)
         returns (string memory)
     {
-        return super.tokenURI(tokenId);
+        return ERC721URIStorageUpgradeable.tokenURI(tokenId);
     }
 
     function _registerInterface(bytes4 interfaceId) internal virtual override {


### PR DESCRIPTION
## Summary
Closes #144
The following functions in ZapMedia ```tokenURI```, ```_beforeTokenTransfer```, ```_burn``` used the super keyword to inherit functions from the parent contract. The super keyword was replaced with the contract actual contract name it inherits from.

## Implementation
- Replaced super with ```ERC721URIStorageUpgradeable``` in the tokenURI function
- Replaced super with ``` ERC721EnumerableUpgradeable``` in the _beforeTokenTransfer function
- Replaced super with ```ERC721URIStorageUpgradeable``` in the _burn function
- After changes ensured media related tests still passed and the values were the same as if the super keyword was still in place

## File
```contracts/nft/ZapMedia.sol```

## Visual Preview
super keyword removed from tokenURI and replaced with the parent contract
<img width="638" alt="Screen Shot 2021-09-29 at 11 33 56 AM" src="https://user-images.githubusercontent.com/42893948/135301355-21f88213-971f-4287-9cee-acef1ff97c56.png">

super keyword removed from _beforeTokenTransfer and replaced with the parent contract
<img width="758" alt="Screen Shot 2021-09-29 at 11 34 31 AM" src="https://user-images.githubusercontent.com/42893948/135301467-5079f8c1-8bce-4abe-9964-da0ab56b8684.png">

super keyword removed from _burn and replaced with the parent contract
<img width="621" alt="Screen Shot 2021-09-29 at 11 35 48 AM" src="https://user-images.githubusercontent.com/42893948/135301654-2a904505-c091-473a-aa9b-acfc1e2bee99.png">
