### PR TITLE
Issue 111 - ECDSA Signature Malleability

### DIFF
--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -7,6 +7,7 @@ import '@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpg
 import '@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 import {SafeMath} from '@openzeppelin/contracts/utils/math/SafeMath.sol';
 import {Math} from '@openzeppelin/contracts/utils/math/Math.sol';
@@ -324,7 +325,7 @@ contract ZapMedia is
             )
         );
 
-        address recoveredAddress = ecrecover(digest, sig.v, sig.r, sig.s);
+        address recoveredAddress = ECDSA.recover(digest, sig.v, sig.r, sig.s);
 
         require(
             recoveredAddress != address(0) && creator == recoveredAddress,
@@ -535,7 +536,7 @@ contract ZapMedia is
             )
         );
 
-        address recoveredAddress = ecrecover(digest, sig.v, sig.r, sig.s);
+        address recoveredAddress = ECDSA.recover(digest, sig.v, sig.r, sig.s);
 
         require(
             recoveredAddress != address(0) &&


### PR DESCRIPTION
### Summary
There were potential vulnerabilities in the standard library function, `ecrecover()`.

closes #111 

### Implementation
- Imported OpenZeppellin's `ECDSA.sol`
- Replaced `ecrecover()` with OpenZepppelin's `ECDSA.recover()`.

### Files
`contracts/nft/ZapMedia.sol`

### Visuals
![image](https://user-images.githubusercontent.com/18056516/135312052-5a0d6fb5-304a-4f1a-9ea3-f056ce4dc77b.png)
