### PR TITLE
Added access control to mintOrBurn() to media only

### DIFF
--- a/contracts/nft/ZapMarket.sol
+++ b/contracts/nft/ZapMarket.sol
@@ -234,6 +234,8 @@ function initializeMarket(address _platformAddress) public initializer {
         uint256 tokenId,
         address mediaContract
     ) external override {
+        require(msg.sender == mediaContract, "Market: Media only function");
+        
         if (isMint == true) {
             emit Minted(tokenId, mediaContract);
         } else {


### PR DESCRIPTION
### Summary
In ZapMarket, of function `mintOrBurn()`, there was no existing access control.

closes #108 

### Implementation
- Added require for msg.sender is the intended media address only

### Files
`contracts/nft/ZapMarket.sol`

### Visuals
![image](https://user-images.githubusercontent.com/18056516/135523211-e7c8142d-74a9-4f3f-93b4-68bb12d09544.png)
