### PR TITLE
Issue 114

### DIFF
--- a/contracts/zap-miner/libraries/ZapStake.sol
+++ b/contracts/zap-miner/libraries/ZapStake.sol
@@ -65,7 +65,7 @@ library ZapStake {
         ZapStorage.StakeInfo storage stakes = self.stakerDetails[msg.sender];
         //Require the staker has locked for withdraw(currentStatus ==2) and that 7 days have 
         //passed by since they locked for withdraw
-        // require(now - (now % 86400) - stakes.startDate >= 7 days, "Can't withdraw yet. Need to wait at LEAST 7 days from stake start date.");
+        require(now - (now % 86400) - stakes.startDate >= 7 days, "Can't withdraw yet. Need to wait at LEAST 7 days from stake start date.");
         require(stakes.currentStatus == 2, "Required to request withdraw of stake");
         stakes.currentStatus = 0;
 


### PR DESCRIPTION
### Summary
The withdrawal period is not enforced in the linked function as the corresponding require check has been commented out.

closes #114

### Implementation
- Uncommented require statement for request withdraw time lock

### Visuals
![image](https://user-images.githubusercontent.com/18056516/135528275-7e7cf815-f5fd-45ac-8091-cb86a28099c5.png)
