### PR TITLE
Using DAO to decide if a new Zap Master gets the previous' funds

### DIFF
--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -144,6 +144,7 @@ contract Zap {
         zap.disputesById[disputeId] = ZapStorage.Dispute({
             hash: _hash,
             isPropFork: false,
+            isZM: false,
             reportedMiner: _miner,
             reportingParty: msg.sender,
             proposedForkAddress: address(0),

--- a/contracts/zap-miner/ZapMaster.sol
+++ b/contracts/zap-miner/ZapMaster.sol
@@ -67,21 +67,6 @@ contract ZapMaster is ZapGetters {
         zap.changeVaultContract(_vaultContract);
     }
 
-    // function to send balance to a New Zap Master contract
-    function sendBalToNewZM(address _newZapMaster) external onlyOwner {
-        // require to be the owner of ZM to send to new ZM
-
-        // total balance of current ZapMaster
-        uint256 zapBalance = token.balanceOf(address(this));
-
-        bytes memory data = abi.encodeWithSelector(
-            token.transfer.selector,
-            _newZapMaster,
-            zapBalance
-        );
-        _callOptionalReturn(token, data);
-    }
-
     /**
      * @dev This is the fallback function that allows contracts to call the zap contract at the address stored
      */
@@ -109,32 +94,6 @@ contract ZapMaster is ZapGetters {
             default {
                 return(ptr, size)
             }
-        }
-    }
-
-    /**
-     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
-     * on the return value: the return value is optional (but if data is returned, it must not be false).
-     * @param _token The token targeted by the call.
-     * @param data The call data (encoded using abi.encode or one of its variants).
-     */
-    function _callOptionalReturn(ZapTokenBSC _token, bytes memory data)
-        private
-    {
-        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
-        // we're implementing it ourselves. We use {Address.functionCall} to perform this call, which verifies that
-        // the target address contains contract code and also asserts for success in the low-level call.
-
-        bytes memory returndata = address(_token).functionCall(
-            data,
-            'ZapTokenBSC: low-level call failed'
-        );
-        if (returndata.length > 0) {
-            // Return data is optional
-            require(
-                abi.decode(returndata, (bool)),
-                'ZapTokenBSC: ERC20 operation did not succeed'
-            );
         }
     }
 }

--- a/contracts/zap-miner/libraries/ZapDispute.sol
+++ b/contracts/zap-miner/libraries/ZapDispute.sol
@@ -196,8 +196,9 @@ library ZapDispute {
                     disp.disputeUintVars[keccak256('quorum')] >
                         ((self.uintVars[keccak256('total_supply')] * 20) / 100)
                 );
-                self.addressVars[keccak256('zapContract')] = disp
-                .proposedForkAddress;
+                if (!disp.isZM) {
+                    self.addressVars[keccak256('zapContract')] = disp.proposedForkAddress;
+                }
                 disp.disputeVotePassed = true;
                 emit NewZapAddress(disp.proposedForkAddress);
             }
@@ -221,7 +222,8 @@ library ZapDispute {
      */
     function proposeFork(
         ZapStorage.ZapStorageStruct storage self,
-        address _propNewZapAddress
+        address _propNewZapAddress,
+        bool zm
     ) public {
         bytes32 _hash = keccak256(abi.encodePacked(_propNewZapAddress));
         require(self.disputeIdByDisputeHash[_hash] == 0,"Dispute Hash is not equal to zero");
@@ -232,6 +234,7 @@ library ZapDispute {
         self.disputesById[disputeId] = ZapStorage.Dispute({
             hash: _hash,
             isPropFork: true,
+            isZM: zm,
             reportedMiner: msg.sender,
             reportingParty: msg.sender,
             proposedForkAddress: _propNewZapAddress,

--- a/contracts/zap-miner/libraries/ZapStorage.sol
+++ b/contracts/zap-miner/libraries/ZapStorage.sol
@@ -19,6 +19,7 @@ library ZapStorage {
         bool executed; //is the dispute settled
         bool disputeVotePassed; //did the vote pass?
         bool isPropFork; //true for fork proposal NEW
+        bool isZM; //true if proposed fork is to change Zap Master
         address reportedMiner; //miner who alledgedly submitted the 'bad value' will get disputeFee if dispute vote fails
         address reportingParty; //miner reporting the 'bad value'-pay disputeFee will get reportedMiner's stake if dispute vote passes
         address proposedForkAddress; //new fork address (if fork proposal)


### PR DESCRIPTION
## Summary
`sendBalToNewZM` was removed from Zap Master. It allowed nefarious token transfers by ZM's owner from the contract to whichever address they chooses.

Closes #109.

Instead, if a new Zap Market is proposed then it would have to be approved/voted in by the community, via `proposeFork`.

If the quorum for this vote is more than a hard-coded threshold, the tokens are transferred from the current Zap Master to the proposed one.

## Implementation
A new flag was added to disputes, `isZM`. This flag is true if the proposed fork is to change the ZapMaster address.

If this flag is true for a proposed fork, and the quorum is over a set percentage, then the current Zap Master's balance is transferred to the proposed one once `tallyVotes` is called.

## Files
* `contracts/zap-miner/libraries/ZapDispute.sol`
* `contracts/zap-miner/Zap.sol`
* `contracts/zap-miner/ZapMaster.sol`

## Visual Preview
### contracts/zap-miner/libraries/ZapDispute.sol
![image](https://user-images.githubusercontent.com/13321394/135657225-7da87ea8-e6aa-4a28-bf77-837fd0b3c5ce.png)

### contracts/zap-miner/Zap.sol
![image](https://user-images.githubusercontent.com/13321394/135657383-6bcdd257-6dae-4aac-9d64-cbf3ebd1a28f.png)

