### PR TITLE
Registering Zap Media interface in its Initializer

### DIFF
--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -173,6 +173,7 @@ contract ZapMedia is
         kecName = keccak256(name_b);
         _registerInterface(0x80ac58cd); // registers old erc721 interface for AucitonHouse
         _registerInterface(0x5b5e139f); // registers current metadata upgradeable interface for AuctionHouse
+        _registerInterface(type(IMedia).interfaceId);
         zapMarket.configure(msg.sender, address(this), name_b32, symbol_b32);
 
         access.approvedToMint[msg.sender] = true;
@@ -192,8 +193,7 @@ contract ZapMedia is
         returns (bool)
     {
         return
-            interfaceId == type(IMedia).interfaceId ||
-            _supportedInterfaces[interfaceId];
+            super.supportsInterface(interfaceId);
     }
 
     /**


### PR DESCRIPTION
## Summary
Closes #148 

ZapMedia had an override to a `supportsInterface` function that returns whether or not a given interface id hash is registered to use safe ERC721 functions.

This is redundant, as the interface for ZapMedia could just be used in the initializer, then the superclass contracts can handle the rest of the logic as intended.

Tests were ran after changes to ensure changes are not breaking.

## Implementation
`_registerInterface(type(IMedia).interfaceId);`  is now being called in the `initialize` function found in ZapMedia.

`super.supportsInterface(interfaceId);` is not being called in the `supportsInterface` function found in ZapMedia (it is still required to override the function, else it would not compile, super makes sure the superclass function is called).

## Files
`contracts/nft/ZapMedia.sol`