### PR TITLE
Removed redundant initialize-related require statement and variable

### DIFF
--- a/contracts/nft/ZapMarket.sol
+++ b/contracts/nft/ZapMarket.sol
@@ -54,8 +54,6 @@ contract ZapMarket is IMarket, Ownable {
     // Mapping of token ids of accepted bids to their mutex
     mapping(uint256 => bool) private bidMutex;
 
-    bool private initialized;
-
     address platformAddress;
 
     IMarket.PlatformFee platformFee;
@@ -191,10 +189,7 @@ contract ZapMarket is IMarket, Ownable {
      * ****************
      */
 
-function initializeMarket(address _platformAddress) public initializer {
-        require(!initialized, 'Market: Instance has already been initialized');
-
-        initialized = true;
+    function initializeMarket(address _platformAddress) public initializer {
 
         owner = msg.sender;
 

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -22,6 +22,8 @@ import { ZapMarket } from '../typechain/ZapMarket';
 
 import { ZapVault } from '../typechain/ZapVault';
 
+import { ZapMarket__factory } from "../typechain";
+
 chai.use(solidity);
 
 type MediaData = {
@@ -133,6 +135,7 @@ describe('ZapMarket Test', () => {
   };
 
   describe('#Configure', () => {
+    let zapMarketFactory: ZapMarket__factory;
 
     beforeEach(async () => {
 
@@ -150,7 +153,7 @@ describe('ZapMarket Test', () => {
         initializer: 'initializeVault'
       })) as ZapVault;
 
-      const zapMarketFactory = await ethers.getContractFactory('ZapMarket');
+      zapMarketFactory = await ethers.getContractFactory('ZapMarket') as ZapMarket__factory;
 
       zapMarket = (await upgrades.deployProxy(zapMarketFactory, [zapVault.address], {
         initializer: 'initializeMarket'
@@ -217,6 +220,13 @@ describe('ZapMarket Test', () => {
       bidShares2.collaborators = [signers[10].address, signers[11].address, signers[12].address];
 
     });
+
+    describe("#Initialize", function () {
+      it("Should not initialize twice", async () => {
+        await expect(
+          zapMarket.initializeMarket(zapVault.address)).to.be.revertedWith("Initializable: contract is already initialized")
+      })
+    })
 
 
     it('Should get the platform fee', async () => {


### PR DESCRIPTION
## Summary
Closes #140 
A redundant require statement and variable that checks to see if Zap Market is initialized, referring to the OpenZeppelin Upgradeable patterns, was removed.

## Implementation
This check is already taking place with the `initializer` modifier imported from OpenZeppelin's `Initializable` smart contract.

A test was written to ensure that the Zap Market can't be initialized twice after the changes were made.

## Files
* `contracts/nft/ZapMarket.sol`
* `test/ZapMarketTest.ts`
## Visual Preview
### test/ZapMarketTest.ts
![image](https://user-images.githubusercontent.com/13321394/135891034-2bb5d8d9-e653-485b-92c0-1f192226879f.png)
![image](https://user-images.githubusercontent.com/13321394/135891123-69158faf-301e-495e-b069-71b1585c49e5.png)

