### PR TITLE
transferFrom -> transfer; Saving gas by removing approval

### DIFF
--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -339,16 +339,13 @@ contract Zap {
             // Pay the miners
             for (uint256 i = 0; i < 5; i++) {
                 if (a[i].miner != address(0)){
-                    token.approve(address(this), minerReward);
-                    transferFrom(address(this), address(vault), minerReward);
+                    transfer(address(vault), minerReward);
                     vault.deposit(a[i].miner, minerReward);
                 }
             }
 
             // Pay the devshare
-            token.approve(address(this), zap.uintVars[keccak256('devShare')]);
-            transferFrom(
-                address(this),
+            transfer(
                 zap.addressVars[keccak256('_owner')],
                 zap.uintVars[keccak256('devShare')]
             );


### PR DESCRIPTION
## Summary
The msg.sender of `submitMiningSolution`, found in `Zap.sol`, is the miner and they are always approved for transfer. `transferFrom` therefore is redundant and costs more gas.

## Implementation
The safe ERC20 `transfer` was used instead of `transferFrom` within `submitMiningSolution`.

Tests shows that the changes are not breaking.

## Files
`contracts/zap-miner/Zap.sol`