### PR TITLE
Issue104 quorum

### DIFF
--- a/contracts/zap-miner/libraries/ZapDispute.sol
+++ b/contracts/zap-miner/libraries/ZapDispute.sol
@@ -158,12 +158,12 @@ library ZapDispute {
                 // return (address(this), disp.reportedMiner, disputeFeeForDisputeId);
 
             }
-            //If the vote is for a proposed fork require a 20% quorum before exceduting the update to the new zap contract address
+            //If the vote is for a proposed fork require 35% quorum before executing the update to the new zap contract address
         } else {
             if (disp.tally > 0) {
                 require(
                     disp.disputeUintVars[keccak256('quorum')] >
-                        ((self.uintVars[keccak256('total_supply')] * 20) / 100)
+                        ((self.uintVars[keccak256('total_supply')] * 35) / 100)
                 );
                 if (!disp.isZM) {
                     self.addressVars[keccak256('zapContract')] = disp.proposedForkAddress;


### PR DESCRIPTION
### Summary
The proposal of a fork only requires for 20% of staked users to vote on the new address. This would make us vulnerable to malicious intent.

closes #104  

### Implementation
- Increased the quorum to 35% of staked users

### Files
`contracts/zap-miner/ZapDispute.sol`

### Visuals
![image](https://user-images.githubusercontent.com/56772634/136068553-8f61f102-365b-4a04-9dfe-651968c24c79.png)
