### PR TITLE
Media Bugfix: MintWithSig & Permit function tests failing

### DIFF
--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -326,9 +326,6 @@ contract ZapMedia is
 
         address recoveredAddress = ECDSA.recover(digest, sig.v, sig.r, sig.s);
 
-        console.log('Recovered', recoveredAddress);
-        console.log('Creator', creator);
-
         require(
             recoveredAddress != address(0) && creator == recoveredAddress,
             'Media: Signature invalid'

--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -326,6 +326,9 @@ contract ZapMedia is
 
         address recoveredAddress = ECDSA.recover(digest, sig.v, sig.r, sig.s);
 
+        console.log('Recovered', recoveredAddress);
+        console.log('Creator', creator);
+
         require(
             recoveredAddress != address(0) && creator == recoveredAddress,
             'Media: Signature invalid'

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -423,7 +423,7 @@ describe("ZapMedia Test", async () => {
 
     });
 
-    describe("#mintWithSig", () => {
+    describe.only("#mintWithSig", () => {
 
         const version = "1";
 
@@ -467,7 +467,7 @@ describe("ZapMedia Test", async () => {
 
         })
 
-        it.only("should mint a token for a given creator with a valid signature", async () => {
+        it("should mint a token for a given creator with a valid signature", async () => {
 
             const sig = await signMintWithSig(
                 zapMedia1,
@@ -477,10 +477,9 @@ describe("ZapMedia Test", async () => {
                 version
             );
 
-            // const beforeNonce = (
-            //     await zapMedia1.getSigNonces(signers[1].address)
-            // ).toNumber();
-
+            const beforeNonce = (
+                await zapMedia1.getSigNonces(signers[1].address)
+            ).toNumber();
 
             await zapMedia1.connect(signers[1]).mintWithSig(
                 signers[1].address,
@@ -489,43 +488,47 @@ describe("ZapMedia Test", async () => {
                 sig
             );
 
-            // const recovered = await zapMedia1.getTokenCreators(1);
-            // const recoveredTokenURI = await zapMedia1.tokenURI(1);
-            // const recoveredMetadataURI = await zapMedia1.tokenMetadataURI(1);
-            // const recoveredContentHash = await zapMedia1.getTokenContentHashes(
-            //     1
-            // );
-            // const recoveredMetadataHash =
-            //     await zapMedia1.getTokenMetadataHashes(1);
-            // const recoveredCreatorBidShare = (
-            //     await zapMarket.bidSharesForToken(zapMedia1.address, 1)
-            // ).creator.value;
-            // const afterNonce = await zapMedia1.getSigNonces(signers[1].address);
+            const recovered = await zapMedia1.getTokenCreators(0);
+            const recoveredTokenURI = await zapMedia1.tokenURI(0);
+            const recoveredMetadataURI = await zapMedia1.tokenMetadataURI(0);
+            const recoveredContentHash = await zapMedia1.getTokenContentHashes(0);
+            const recoveredMetadataHash = await zapMedia1.getTokenMetadataHashes(0);
 
-            // expect(recovered).to.eq(signers[1].address);
-            // expect(recoveredTokenURI).to.eq(tokenURI);
-            // expect(recoveredMetadataURI).to.eq(metadataURI);
-            // expect(recoveredContentHash).to.eq(contentHash);
-            // expect(recoveredMetadataHash).to.eq(metadataHash);
-            // expect(recoveredCreatorBidShare).to.eq(
-            //     BigInt(10000000000000000000)
-            // );
-            // expect(afterNonce).to.eq(BigNumber.from(beforeNonce + 1));
+            const recoveredCreatorBidShare = (
+                await zapMarket.bidSharesForToken(zapMedia1.address, 0)
+            ).creator.value;
+
+            const afterNonce = await zapMedia1.getSigNonces(signers[1].address);
+
+            expect(recovered).to.eq(signers[1].address);
+            expect(recoveredTokenURI).to.eq(tokenURI);
+            expect(recoveredMetadataURI).to.eq(metadataURI);
+            expect(recoveredContentHash).to.eq(contentHash);
+            expect(recoveredMetadataHash).to.eq(metadataHash);
+
+            expect(recoveredCreatorBidShare).to.eq(
+                BigInt(parseInt(bidShares.creator.value._hex))
+            );
+            expect(afterNonce).to.eq(BigNumber.from(beforeNonce + 1));
+
         });
 
         it("should not mint token if caller is not approved", async () => {
+
             const sig = await signMintWithSig(
-                zapMedia1,
+                zapMedia2,
                 signers,
                 contentHashBytes,
                 metadataHashBytes,
                 version
             );
+
             await expect(
-                zapMedia1
-                    .connect(signers[2])
-                    .mintWithSig(signers[1].address, mediaData, bidShares, sig)
+                zapMedia2
+                    .connect(signers[1])
+                    .mintWithSig(signers[2].address, mediaData, bidShares, sig)
             ).revertedWith("Media: Only Approved users can mint");
+
         });
 
         it("should mint token if caller is approved", async () => {

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -472,14 +472,15 @@ describe("ZapMedia Test", async () => {
             const sig = await signMintWithSig(
                 zapMedia1,
                 signers,
-                contentHashBytes,
-                metadataHashBytes,
+                contentHash,
+                metadataHash,
                 version
             );
 
-            const beforeNonce = (
-                await zapMedia1.getSigNonces(signers[1].address)
-            ).toNumber();
+            // const beforeNonce = (
+            //     await zapMedia1.getSigNonces(signers[1].address)
+            // ).toNumber();
+
 
             await zapMedia1.connect(signers[1]).mintWithSig(
                 signers[1].address,
@@ -488,28 +489,28 @@ describe("ZapMedia Test", async () => {
                 sig
             );
 
-            const recovered = await zapMedia1.getTokenCreators(1);
-            const recoveredTokenURI = await zapMedia1.tokenURI(1);
-            const recoveredMetadataURI = await zapMedia1.tokenMetadataURI(1);
-            const recoveredContentHash = await zapMedia1.getTokenContentHashes(
-                1
-            );
-            const recoveredMetadataHash =
-                await zapMedia1.getTokenMetadataHashes(1);
-            const recoveredCreatorBidShare = (
-                await zapMarket.bidSharesForToken(zapMedia1.address, 1)
-            ).creator.value;
-            const afterNonce = await zapMedia1.getSigNonces(signers[1].address);
+            // const recovered = await zapMedia1.getTokenCreators(1);
+            // const recoveredTokenURI = await zapMedia1.tokenURI(1);
+            // const recoveredMetadataURI = await zapMedia1.tokenMetadataURI(1);
+            // const recoveredContentHash = await zapMedia1.getTokenContentHashes(
+            //     1
+            // );
+            // const recoveredMetadataHash =
+            //     await zapMedia1.getTokenMetadataHashes(1);
+            // const recoveredCreatorBidShare = (
+            //     await zapMarket.bidSharesForToken(zapMedia1.address, 1)
+            // ).creator.value;
+            // const afterNonce = await zapMedia1.getSigNonces(signers[1].address);
 
-            expect(recovered).to.eq(signers[1].address);
-            expect(recoveredTokenURI).to.eq(tokenURI);
-            expect(recoveredMetadataURI).to.eq(metadataURI);
-            expect(recoveredContentHash).to.eq(contentHash);
-            expect(recoveredMetadataHash).to.eq(metadataHash);
-            expect(recoveredCreatorBidShare).to.eq(
-                BigInt(10000000000000000000)
-            );
-            expect(afterNonce).to.eq(BigNumber.from(beforeNonce + 1));
+            // expect(recovered).to.eq(signers[1].address);
+            // expect(recoveredTokenURI).to.eq(tokenURI);
+            // expect(recoveredMetadataURI).to.eq(metadataURI);
+            // expect(recoveredContentHash).to.eq(contentHash);
+            // expect(recoveredMetadataHash).to.eq(metadataHash);
+            // expect(recoveredCreatorBidShare).to.eq(
+            //     BigInt(10000000000000000000)
+            // );
+            // expect(afterNonce).to.eq(BigNumber.from(beforeNonce + 1));
         });
 
         it("should not mint token if caller is not approved", async () => {

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -531,7 +531,7 @@ describe("ZapMedia Test", async () => {
 
         });
 
-        it.only("should mint token if caller is approved", async () => {
+        it("should mint token if caller is approved", async () => {
 
             const sig = await signMintWithSig(
                 zapMedia2,
@@ -581,6 +581,7 @@ describe("ZapMedia Test", async () => {
         });
 
         it("should not mint a token for a different creator", async () => {
+
             const sig = await signMintWithSig(
                 zapMedia1,
                 signers,
@@ -646,7 +647,8 @@ describe("ZapMedia Test", async () => {
             ).revertedWith("Media: Signature invalid");
         });
 
-        it("should not mint a token for a different creator bid share", async () => {
+        it.only("should not mint a token for a different creator bid share", async () => {
+
             const sig = await signMintWithSig(
                 zapMedia1,
                 signers,
@@ -655,14 +657,35 @@ describe("ZapMedia Test", async () => {
                 version
             );
 
+            let invalidBidShares = {
+
+                collaborators: [
+                    ethers.constants.AddressZero,
+                    ethers.constants.AddressZero,
+                    ethers.constants.AddressZero,
+                ],
+                collabShares: [
+                    BigNumber.from('15000000000000000000'),
+                    BigNumber.from('15000000000000000000'),
+                    BigNumber.from('15000000000000000000')
+                ],
+                creator: {
+                    value: BigNumber.from('14000000000000000000')
+                },
+                owner: {
+                    value: BigNumber.from('35000000000000000000')
+                },
+            };
+
             await expect(
                 zapMedia1.mintWithSig(
                     signers[1].address,
                     mediaData,
-                    bidShares,
+                    invalidBidShares,
                     sig
                 )
             ).revertedWith("Media: Signature invalid");
+
         });
 
         it("should not mint a token with an invalid deadline", async () => {

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -467,7 +467,7 @@ describe("ZapMedia Test", async () => {
 
         })
 
-        it("should mint a token for a given creator with a valid signature", async () => {
+        it.only("should mint a token for a given creator with a valid signature", async () => {
 
             const sig = await signMintWithSig(
                 zapMedia1,

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -423,7 +423,7 @@ describe("ZapMedia Test", async () => {
 
     });
 
-    describe.only("#mintWithSig", () => {
+    describe("#mintWithSig", () => {
 
         const version = "1";
 
@@ -647,7 +647,7 @@ describe("ZapMedia Test", async () => {
             ).revertedWith("Media: Signature invalid");
         });
 
-        it.only("should not mint a token for a different creator bid share", async () => {
+        it("should not mint a token for a different creator bid share", async () => {
 
             const sig = await signMintWithSig(
                 zapMedia1,
@@ -1740,22 +1740,21 @@ describe("ZapMedia Test", async () => {
         });
 
         it("should allow a wallet to set themselves to approved with a valid signature", async () => {
+
             const sig = await signPermit(
                 zapMedia1,
-                signers[3].address,
+                signers[5].address,
                 signers,
                 0,
                 "1"
             );
 
-            await zapMedia1
-                .connect(signers[3])
-                .permit(signers[5].address, 0, sig)
-
+            await zapMedia1.connect(signers[4]).permit(signers[5].address, 0, sig);
 
             expect(await zapMedia1.connect(signers[5]).getApproved(0)).eq(
                 signers[5].address
             );
+
         });
 
         it("should not allow a wallet to set themselves to approved with an invalid signature", async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -350,15 +350,15 @@ export async function signPermit(
 }
 
 export async function signMintWithSig(
-  zapMedia1: ZapMedia,
+  zapMedia: ZapMedia,
   signers: any,
   contentHash: any,
   metadataHash: any,
   version: string
 ) {
-  const nonce = (await zapMedia1.getSigNonces(signers[1].address)).toNumber();
+  const nonce = (await zapMedia.getSigNonces(signers[1].address)).toNumber();
   const deadline = Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24; // 24 hours
-  const name = await zapMedia1.name();
+  const name = await zapMedia.name();
 
   const chainId = await signers[1].getChainId();
   const creatorShare = BigInt(15000000000000000000);
@@ -366,7 +366,7 @@ export async function signMintWithSig(
     name,
     version,
     chainId,
-    verifyingContract: zapMedia1.address,
+    verifyingContract: zapMedia.address,
   };
   const types = {
     MintWithSig: [

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -361,7 +361,7 @@ export async function signMintWithSig(
   const name = await zapMedia1.name();
 
   const chainId = await signers[1].getChainId();
-  const creatorShare = BigInt(10000000000000000000);
+  const creatorShare = BigInt(15000000000000000000);
   const domain = {
     name,
     version,
@@ -391,9 +391,11 @@ export async function signMintWithSig(
   );
   sig = fromRpcSig(sig);
   sig = {
+
     r: sig.r,
     s: sig.s,
     v: sig.v,
+
     deadline: deadline.toString(),
   }
   return sig;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -301,23 +301,23 @@ export const revert = (messages: TemplateStringsArray) =>
   `VM Exception while processing transaction: revert ${messages[0]}`;
 
 export async function signPermit(
-  zapMedia1: ZapMedia,
+  zapMedia: ZapMedia,
   toAddress: any,
   signers: any,
   tokenId: any,
   version: string
 ) {
-  const nonce = (await zapMedia1.getPermitNonce(signers[3].address, tokenId)).toNumber();
+  const nonce = (await zapMedia.getPermitNonce(signers[4].address, tokenId)).toNumber();
 
   const deadline = Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24; // 24 hours
-  const name = await zapMedia1.name();
+  const name = await zapMedia.name();
 
   const chainId = await signers[5].getChainId();
   const domain = {
     name,
     version,
     chainId,
-    verifyingContract: zapMedia1.address,
+    verifyingContract: zapMedia.address,
   };
   const types = {
     Permit: [
@@ -333,16 +333,16 @@ export async function signPermit(
     nonce,
     deadline,
   };
-  let sig = await signers[3]._signTypedData(
+  let sig = await signers[4]._signTypedData(
     domain,
     types,
     value
   );
   sig = fromRpcSig(sig);
   sig = {
+    v: sig.v,
     r: sig.r,
     s: sig.s,
-    v: sig.v,
     deadline: deadline.toString(),
   }
 


### PR DESCRIPTION
## Summary
Closes #206 
The MintWithSig & Permit function tests were failing due to incorrect signer position and owner bidShare values

## Implementation
- Fixed the mintWitSig functions by matching the creator value bidShares so the recovery signature matched up 
- Fixed the permit functions by placing the correct media token owner in the correct position in the signPermit function & sig function

## Files
```test/ZapMediaTest.ts```
```test/utils.ts```

## Visual Preview
MintWithSig & Permit tests no longer failing all Media tests are passing
<img width="1129" alt="Screen Shot 2021-10-07 at 3 04 24 PM" src="https://user-images.githubusercontent.com/42893948/136446733-cf73159a-9adc-4ab7-b6fd-86c8d189a2f9.png">

