### PR TITLE
Issue-107

### DIFF
--- a/contracts/nft/ZapMarket.sol
+++ b/contracts/nft/ZapMarket.sol
@@ -368,18 +368,24 @@ contract ZapMarket is IMarket, Ownable {
         // We must check the balance that was actually transferred to the market,
         // as some tokens impose a transfer fee and would not actually transfer the
         // full amount to the market, resulting in locked funds for refunds & bid acceptance
+
         uint256 beforeBalance = token.balanceOf(address(this));
+
         token.safeTransferFrom(spender, address(this), bid.amount);
 
-        uint256 afterBalance = token.balanceOf(address(this));
+        require(
+            token.balanceOf(address(this)) == beforeBalance + bid.amount,
+            'Market: Market balance did not increase from bid'
+        );
 
         _tokenBidders[msg.sender][tokenId][bid.bidder] = Bid(
-            afterBalance - (beforeBalance),
+            bid.amount,
             bid.currency,
             bid.bidder,
             bid.recipient,
             bid.sellOnShare
         );
+
         emit BidCreated(msg.sender, tokenId, bid);
 
         // If a bid meets the criteria for an ask, automatically accept the bid.


### PR DESCRIPTION
## Summary
Closes #107 
The audit recommendation was to add a nonReentrant to the setBid function but in ZapMedia the setBid function already has that available. The ```safeTransferFrom``` imports from ```SafeERC20Upgradeable``` and will prevent a bidder from setting a bid with tokens that are not approved with the ZapMarket and prevents the bidder from placing a bid if their balance isn't equal to the amount their bidding with.

## Implementation
- Added a require statement after ```token.safeTransferFrom(spender, address(this), bid.amount);``` to ensure the bid amount was transferred to ZapMarket
- Removed ```afterBalance - beforeBalance``` to determine the bid amount and replaced directly with the bid.amount

## Files
```contracts/nft/ZapMarket.sol```

## Visual Preview 
Before Changes
<img width="629" alt="Screen Shot 2021-10-08 at 11 45 05 AM" src="https://user-images.githubusercontent.com/42893948/136585893-9ae462b3-7897-405d-b6ed-dd887bc47d17.png">

After Changes
<img width="639" alt="Screen Shot 2021-10-08 at 11 41 26 AM" src="https://user-images.githubusercontent.com/42893948/136585335-7f97d829-963d-4722-9ef9-7d28ab5b600a.png">



