### PR TITLE
Issue-115: Overwrittance of Existing Stake Withdrawal

### DIFF
--- a/contracts/zap-miner/libraries/ZapStake.sol
+++ b/contracts/zap-miner/libraries/ZapStake.sol
@@ -87,8 +87,8 @@ library ZapStake {
     * and updates the number of stakers in the system.
     */
     function newStake(ZapStorage.ZapStorageStruct storage self, address staker) internal {
-        //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
-        //and they are currently locked for witdhraw
+
+        //Ensure they can only stake if they are not currrently staked 
         require(self.stakerDetails[staker].currentStatus == 0, "ZapStake: Staker is already staked");
         self.uintVars[keccak256("stakerCount")] += 1;
         self.stakerDetails[staker] = ZapStorage.StakeInfo({

--- a/contracts/zap-miner/libraries/ZapStake.sol
+++ b/contracts/zap-miner/libraries/ZapStake.sol
@@ -69,17 +69,6 @@ library ZapStake {
         require(stakes.currentStatus == 2, "Required to request withdraw of stake");
         stakes.currentStatus = 0;
 
-        /*
-            NOT TOTALLY SURE OF THESE FUNCTON NAMES.
-            BUT THE LOGIC SHOULD BE SOMETHING LIKE THIS...
-            // msg.sender is the staker that wants to withdraw their tokens
-            previousBalance = balanceOf(msg.sender); // grab the balance of the staker
-            updateBalanceAtNow(self.balancecs(msg.sender), previousBalance) // update 
-            tranferFrom(vault, msg.sender);
-            
-            // updates the storage portion that keeps track of balances at a block. set it to 0 since staker is unstaking
-            updateBalanceAtNow(self.balancecs(msg.sender), 0) 
-        */
         emit StakeWithdrawn(msg.sender);
     }
 
@@ -100,7 +89,7 @@ library ZapStake {
     function newStake(ZapStorage.ZapStorageStruct storage self, address staker) internal {
         //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
         //and they are currently locked for witdhraw
-        require(self.stakerDetails[staker].currentStatus == 0 || self.stakerDetails[staker].currentStatus == 2, "ZapStake: Either already staked or stake time frame ended");
+        require(self.stakerDetails[staker].currentStatus == 0, "ZapStake: Staker is already staked");
         self.uintVars[keccak256("stakerCount")] += 1;
         self.stakerDetails[staker] = ZapStorage.StakeInfo({
             currentStatus: 1,

--- a/test/MainMinerTests.ts
+++ b/test/MainMinerTests.ts
@@ -220,7 +220,7 @@ describe("Main Miner Functions", () => {
             expect(stakerInfo[1]).to.greaterThan(0)
         })
 
-    it('Should not be able to depositStake if the stake status is 1', async () => {
+    it('Should not be able to depositStake if the stake status is 1(Staked)', async () => {
 
         // Allocate enough to stake
         await zapTokenBsc.allocate(signers[1].address, (BigNumber.from("1000000000000000000000000")));
@@ -248,7 +248,7 @@ describe("Main Miner Functions", () => {
 
     });
 
-    it("Should not be able to request a stake withdrawal if the stake status is 0", async () => {
+    it("Should not be able to request a stake withdrawal if the stake status is 0(Not Staked)", async () => {
 
         await expect(zap.requestStakingWithdraw()).to.be.revertedWith(
             'Miner is not staked'
@@ -256,7 +256,7 @@ describe("Main Miner Functions", () => {
 
     });
 
-    it("Should not be able to depositStake if the stake status is 2", async () => {
+    it("Should not be able to depositStake if the stake status is 2(Request to withdraw)", async () => {
 
         // Allocate enough to stake
         await zapTokenBsc.allocate(signers[1].address, (BigNumber.from("1000000000000000000000000")));


### PR DESCRIPTION
## Summary
Closes #115 


## Implementation
- Removed the or statement that allowed stakers with a status of 2 to redeposit a stake
- Verified a staker with a status of 1 cannot redeposit a stake with this test case```Should not be able to depositStake if the stake status is 1(Staked)```
- Verified a staker with the status of 0 cannot put in a request to withdraw with this test case ```Should not be able to request a stake withdrawal if the stake status is 0(Not Staked)```
- Verified a staker with the status of 2 cannot redeposit a stake with this test case ```Should not be able to depositStake if the stake status is 2(Request to withdraw)```


## Files
```contracts/zap-miner/libraries/ZapStake.sol```
```test/MainMinerTests.ts```

## Visual Preview
The line ```self.stakerDetails[staker].currentStatus == 2, "ZapStake: Either already staked or stake time frame ended"``` inside the first require statement of the newStake function  allowed stakers who requested withdrawals the ability to redeposit a stake. This would cause an issue by overriding their initial request to withdraw and restart their stake timestamp even if the 7-day waiting period was met.

```
function newStake(ZapStorage.ZapStorageStruct storage self, address staker) internal {
    // require(ZapTransfer.balanceOf(self,staker) >= self.uintVars[keccak256("stakeAmount")]);
    //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
    //and they are currently locked for witdhraw
    require(self.stakerDetails[staker].currentStatus == 0 || self.stakerDetails[staker].currentStatus == 2);
    self.uintVars[keccak256("stakerCount")] += 1;
    self.stakerDetails[staker] = ZapStorage.StakeInfo({
        currentStatus: 1,
        //this resets their stake start date to today
        startDate: now - (now % 86400)
    });
    // self.uintVars[keccak256("stakeAmount")]
    // ZapTransfer.updateBalanceAtNow(self.balances[staker], self.uintVars[keccak256("stakeAmount")]);

    emit NewStake(staker);
}
```

Removed the or statement inside the require so only addresses with the status of 0 can stake. This will prevent stakers with 1=Staked , 2=Request Withdraw, 3=In Dispute statuses from ever being able to deposit a stake.
<img width="907" alt="Screen Shot 2021-10-12 at 5 44 37 PM" src="https://user-images.githubusercontent.com/42893948/137033311-650a38ab-4c70-44d7-b575-48ca0af740b8.png">