### PR TITLE
Test contract and case for reentrancy of ZapMarket

### DIFF
--- a/contracts/nft/test/BadBidder2.sol
+++ b/contracts/nft/test/BadBidder2.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.8.4;
+
+import '../interfaces/IMedia.sol';
+import '../ZapMedia.sol';
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+contract BadBidder2 {
+    ZapMedia mediaContract;
+    IERC20 tokenContract;
+    uint256 tokenId;
+
+    constructor(address _mediaContract, address _tokenContract) {
+        mediaContract = ZapMedia(_mediaContract);
+        tokenContract = IERC20(_tokenContract);
+        tokenId = 0;
+    }
+
+    function setBid(address marketAddress, IMarket.Bid memory bid) external {
+        tokenContract.approve(marketAddress, 300);
+        mediaContract.setBid(tokenId, bid);
+    }
+
+    function acceptRemoveBid(IMarket.Bid memory bid) external payable {
+        mediaContract.acceptBid(0, bid);
+    }
+
+    fallback() external payable {
+        mediaContract.removeBid(0);
+    }
+}

--- a/contracts/zap-miner/libraries/ZapStake.sol
+++ b/contracts/zap-miner/libraries/ZapStake.sol
@@ -100,7 +100,7 @@ library ZapStake {
     function newStake(ZapStorage.ZapStorageStruct storage self, address staker) internal {
         //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
         //and they are currently locked for witdhraw
-        require(self.stakerDetails[staker].currentStatus == 0 || self.stakerDetails[staker].currentStatus == 2, "ZapStake: Either already staked or stake time frame ended");
+        
         self.uintVars[keccak256("stakerCount")] += 1;
         self.stakerDetails[staker] = ZapStorage.StakeInfo({
             currentStatus: 1,

--- a/contracts/zap-miner/libraries/ZapStake.sol
+++ b/contracts/zap-miner/libraries/ZapStake.sol
@@ -100,7 +100,7 @@ library ZapStake {
     function newStake(ZapStorage.ZapStorageStruct storage self, address staker) internal {
         //Ensure they can only stake if they are not currrently staked or if their stake time frame has ended
         //and they are currently locked for witdhraw
-        
+        require(self.stakerDetails[staker].currentStatus == 0 || self.stakerDetails[staker].currentStatus == 2, "ZapStake: Either already staked or stake time frame ended");
         self.uintVars[keccak256("stakerCount")] += 1;
         self.stakerDetails[staker] = ZapStorage.StakeInfo({
             currentStatus: 1,


### PR DESCRIPTION
### Summary
Continuation from commit https://github.com/zapproject/hardhat-bsc/commit/ab23ff8e0946689a6aa1ca229e5840447da852ca

closes #105 

### Implementation

- Created malicious contract `BadBidder2`, which can accept bid and fallback call a remove bid
- Test case of valid accept bid through the malicious contract and verified the fallback call does not take effect, as it is mutex locked.

### Files
`contracts/nft/test/BadBidder2`
`test/ZapMarketTest.ts`

### Visuals
![image](https://user-images.githubusercontent.com/18056516/137073044-7fd7e0d8-73c7-48d7-a742-295ec2700d2c.png)
