### PR TITLE
Validating media contracts when creating an Auction

### DIFF
--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -72,21 +72,22 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
 
     function setTokenDetails(uint256 tokenId, address mediaContract)
         internal
-        returns (bool)
     {
         require(
             mediaContract != address(0),
             'AuctionHouse: Media Contract Address can not be the zero address'
         );
-        if (tokenDetails[mediaContract][tokenId].mediaContract != address(0))
-            return false;
+
+        if (tokenDetails[mediaContract][tokenId].mediaContract != address(0)){
+            require(
+                mediaContract == tokenDetails[mediaContract][tokenId].mediaContract,
+                "Token is already set for a different collection");
+        }
 
         tokenDetails[mediaContract][tokenId] = TokenDetails({
             tokenId: tokenId,
             mediaContract: mediaContract
         });
-
-        return true;
     }
 
     /**
@@ -127,11 +128,7 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
         uint256 auctionId = _auctionIdTracker.current();
         _auctionIdTracker.increment();
 
-        if (setTokenDetails(tokenId, mediaContract) == false) {
-            require(
-                mediaContract == tokenDetails[mediaContract][tokenId].mediaContract,
-                "Token is already set for a different collection");
-        }
+        setTokenDetails(tokenId, mediaContract);
 
         auctions[auctionId] = Auction({
             token: tokenDetails[mediaContract][tokenId],

--- a/contracts/nft/AuctionHouse.sol
+++ b/contracts/nft/AuctionHouse.sol
@@ -127,7 +127,11 @@ contract AuctionHouse is IAuctionHouse, ReentrancyGuardUpgradeable {
         uint256 auctionId = _auctionIdTracker.current();
         _auctionIdTracker.increment();
 
-        setTokenDetails(tokenId, mediaContract);
+        if (setTokenDetails(tokenId, mediaContract) == false) {
+            require(
+                mediaContract == tokenDetails[mediaContract][tokenId].mediaContract,
+                "Token is already set for a different collection");
+        }
 
         auctions[auctionId] = Auction({
             token: tokenDetails[mediaContract][tokenId],

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -29,7 +29,7 @@ import {
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { signPermitMessage } from "@zoralabs/zdk";
 
-describe("AuctionHouse", () => {
+describe.only("AuctionHouse", () => {
   let market: ZapMarket;
   let media1: ZapMedia;
   let media2: ZapMedia;
@@ -82,7 +82,8 @@ describe("AuctionHouse", () => {
     auctionHouse: AuctionHouse,
     curator: string,
     currency: string,
-    duration?: number
+    duration?: number,
+    media?: string
   ) {
     const tokenId = 0;
     if (!duration) duration = 60 * 60 * 24;
@@ -90,7 +91,7 @@ describe("AuctionHouse", () => {
 
     await auctionHouse.createAuction(
       tokenId,
-      media1.address,
+      media == null ? media1.address : media,
       duration,
       reservePrice,
       curator,
@@ -100,7 +101,7 @@ describe("AuctionHouse", () => {
 
   }
 
-  describe("#constructor", () => {
+  describe.only("#constructor", () => {
 
     it("should be able to deploy", async () => {
 
@@ -174,7 +175,7 @@ describe("AuctionHouse", () => {
     });
   });
 
-  describe("#createAuction", () => {
+  describe.only("#createAuction", () => {
 
     let auctionHouse: AuctionHouse;
 
@@ -313,6 +314,21 @@ describe("AuctionHouse", () => {
           signers[1].address, 5, zapTokenBsc.address
         )
       ).to.be.revertedWith("function call to a non-contract account")
+    });
+
+    it.skip("should revert if the given media contract address differs from the one that is already set", async () => {
+      // don't mind this, this test will always fail
+      // tokens and their medias/collections have a 1-to-1 relationship, not 1-to-many
+      const [_, curator] = await ethers.getSigners();
+      await createAuction(auctionHouse, curator.address, zapTokenBsc.address);
+
+      await mint(media2.connect(signers[2]));
+
+      await approveAuction(media2, auctionHouse);
+
+      await expect(
+        createAuction(auctionHouse.connect(signers[2]), curator.address, zapTokenBsc.address, undefined, media2.address)
+      ).to.be.revertedWith("Token is already set for a different collection");
     });
 
     it("should be automatically approved if the creator is the curator", async () => {

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -29,7 +29,7 @@ import {
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { signPermitMessage } from "@zoralabs/zdk";
 
-describe.only("AuctionHouse", () => {
+describe("AuctionHouse", () => {
   let market: ZapMarket;
   let media1: ZapMedia;
   let media2: ZapMedia;
@@ -101,7 +101,7 @@ describe.only("AuctionHouse", () => {
 
   }
 
-  describe.only("#constructor", () => {
+  describe("#constructor", () => {
 
     it("should be able to deploy", async () => {
 
@@ -175,7 +175,7 @@ describe.only("AuctionHouse", () => {
     });
   });
 
-  describe.only("#createAuction", () => {
+  describe("#createAuction", () => {
 
     let auctionHouse: AuctionHouse;
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -220,7 +220,7 @@ export const deployZapNFTMarketplace = async () => {
 
   for (let i = 0; i < mediaArgs.length; i++) {
     const args = mediaArgs[i];
-    await mediaFactory.deployMedia(
+    await mediaFactory.connect(mediaDeployers[i]).deployMedia(
       args.name, args.symbol, args.marketContractAddr, args.permissive, args._collectionMetadata
     );
 


### PR DESCRIPTION
## Summary
The return value for `setTokenDetails` is now being validated when `createAuction` is called.

This should ensure that the media contract given when `createAuction` is called will always be the media contract that belongs to the given `mediaContract`, or collection.

## Implementation
This change  uses the return value for `setTokenDetails` to in an if block, it returns a boolean. `setTokenDetails` basically attaches the media contract to a NFT.

If the boolean is false then `createAuction` checks if the given mediaContract is the one the token belongs to, and reverts if not.

Tests show that this typically will not happen, but this change was recommended by Omniscia to cover edge cases.