### PR TITLE
Issue 228

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "hardhat-gas-reporter": "^1.0.4",
         "hardhat-tracer": "*",
         "node-cache": "^5.1.2",
+        "openzeppelin-solidity": "^4.3.2",
         "ping": "^0.4.0",
         "pm2": "^4.5.4",
         "solc": "^0.4.26",
@@ -20802,6 +20803,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openzeppelin-solidity": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-4.3.2.tgz",
+      "integrity": "sha512-k20olEz9A58yq3zwFZgOJoe9vWodKaFsMjajpou1NiqzuxuDfIdaGL3/xLcn/48J0AmvqsxHrcgI3WHq370J+w==",
+      "deprecated": "This package is now published as @openzeppelin/contracts. Please change your dependency.",
+      "bin": {
+        "openzeppelin-contracts-migrate-imports": "scripts/migrate-imports.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -41322,6 +41332,11 @@
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
       }
+    },
+    "openzeppelin-solidity": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-4.3.2.tgz",
+      "integrity": "sha512-k20olEz9A58yq3zwFZgOJoe9vWodKaFsMjajpou1NiqzuxuDfIdaGL3/xLcn/48J0AmvqsxHrcgI3WHq370J+w=="
     },
     "optionator": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "hardhat-gas-reporter": "^1.0.4",
     "hardhat-tracer": "*",
     "node-cache": "^5.1.2",
+    "openzeppelin-solidity": "^4.3.2",
     "ping": "^0.4.0",
     "pm2": "^4.5.4",
     "solc": "^0.4.26",

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -1605,9 +1605,12 @@ describe('ZapMarket Test', () => {
 
     });
 
-    // it('Testing', async () => {
-    //   await creatureFactory.connect(signers[8]).mint(0, signers[0].address)
-    // })
+    it('Testing', async () => {
+      console.log(creatureFactory.signer.getAddress());
+      console.log('zero',signers[0].address)
+      await creatureFactory.connect(signers[1]).mint(0, owner.address);
+      // expect()
+    })
 
 
   });

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -35,6 +35,7 @@ import { CreatureLootBox } from '../typechain/CreatureLootBox';
 import { CreatureFactory } from '../typechain/CreatureFactory';
 import { ERC721Tradable } from '../typechain/ERC721Tradable';
 import { MockProxyRegistry } from '../typechain/MockProxyRegistry';
+import { create } from 'domain';
 
 chai.use(solidity);
 
@@ -75,11 +76,11 @@ describe('ZapMarket Test', () => {
     );
     const proxyFactory = await ethers.getContractFactory(
       'MockProxyRegistry'
-      )
+    )
     const proxy = (await proxyFactory.deploy()) as MockProxyRegistry;
     await proxy.deployed();
-    await proxy.setProxy(owner.address,proxyForOwner.address);
-    
+    await proxy.setProxy(owner.address, proxyForOwner.address);
+
     zapTokenBsc = (await zapTokenFactory.deploy()) as ZapTokenBSC;
     await zapTokenBsc.deployed();
   });
@@ -1488,7 +1489,7 @@ describe('ZapMarket Test', () => {
 
       const badBidder2 = await badBidder2Factory.deploy(zapMedia1.address, zapTokenBsc.address);
       await badBidder2.deployed();
-      
+
       bid1.bidder = badBidder2.address;
 
       let metadataHex = ethers.utils.formatBytes32String('{}');
@@ -1536,7 +1537,7 @@ describe('ZapMarket Test', () => {
 
       await zapMedia1.connect(signers[2]).setBid(0, bid2);
       await badBidder2.connect(signers[1]).setBid(zapMarket.address, bid1);
-      
+
       const badBidderPostSet = await zapTokenBsc.balanceOf(badBidder2.address);
       expect(parseInt(badBidderPostSet._hex)).to.equal(parseInt(badBidderPreSet._hex) - bid1.amount);
 
@@ -1565,34 +1566,49 @@ describe('ZapMarket Test', () => {
     });
   })
 
-  describe.only("External mint",() => {
+  describe.only("External mint", () => {
+
+    let owner: SignerWithAddress;
+    let proxyForOwner: SignerWithAddress;
+
     beforeEach(async () => {
-    const owner = signers[0];
-    const proxyForOwner = signers[8];
-    const zapTokenFactory = await ethers.getContractFactory(
-      'ZapTokenBSC',
-      signers[0]
-    );
-    const proxyFactory = await ethers.getContractFactory(
-      'MockProxyRegistry'
-      )
-    const proxy = (await proxyFactory.deploy()) as MockProxyRegistry;
-    await proxy.deployed();
-    await proxy.setProxy(owner.address,proxyForOwner.address);
-    
-    zapTokenBsc = (await zapTokenFactory.deploy()) as ZapTokenBSC;
-    await zapTokenBsc.deployed();
-    const oscreatureFactory = await ethers.getContractFactory(
-      'Creature',
-      )
-    osCreature = (await oscreatureFactory.deploy(proxy.address)) as Creature;
-    await osCreature.deployed();
-    const creatureFactoryFactory = await ethers.getContractFactory(
-      'CreatureFactory',
+
+      owner = signers[0];
+      proxyForOwner = signers[8];
+
+      const zapTokenFactory = await ethers.getContractFactory(
+        'ZapTokenBSC',
+        signers[0]
       );
-    creatureFactory = (await creatureFactoryFactory.deploy(proxy.address, osCreature.address)) as CreatureFactory;
-    await creatureFactory.deployed();
+
+      const proxyFactory = await ethers.getContractFactory(
+        'MockProxyRegistry'
+      )
+
+      const proxy = (await proxyFactory.deploy()) as MockProxyRegistry;
+      await proxy.deployed();
+      await proxy.setProxy(owner.address, proxyForOwner.address);
+
+      zapTokenBsc = (await zapTokenFactory.deploy()) as ZapTokenBSC;
+      await zapTokenBsc.deployed();
+      const oscreatureFactory = await ethers.getContractFactory(
+        'Creature',
+      )
+      osCreature = (await oscreatureFactory.deploy(proxy.address)) as Creature;
+      await osCreature.deployed();
+      const creatureFactoryFactory = await ethers.getContractFactory(
+        'CreatureFactory',
+      );
+      creatureFactory = (await creatureFactoryFactory.deploy(proxy.address, osCreature.address)) as CreatureFactory;
+      await creatureFactory.deployed();
+
+
     });
+
+    // it('Testing', async () => {
+    //   await creatureFactory.connect(signers[8]).mint(0, signers[0].address)
+    // })
+
 
   });
 });

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -1598,6 +1598,7 @@ describe('ZapMarket Test', () => {
 
     it('Should have a external token balance of 1', async () => {
 
+
       expect(await osCreature.balanceOf(signers[10].address)).to.equal(1);
 
     })

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -24,18 +24,15 @@ import { MediaFactory } from '../typechain/MediaFactory';
 
 import { ZapVault } from '../typechain/ZapVault';
 
-import { IERC721Metadata, ZapMarket__factory } from "../typechain";
+import { ZapMarket__factory } from "../typechain";
 
 import { deployJustMedias } from "./utils";
 
 import { BadBidder2 } from "../typechain/BadBidder2";
 
 import { Creature } from '../typechain/Creature';
-import { CreatureLootBox } from '../typechain/CreatureLootBox';
-import { CreatureFactory } from '../typechain/CreatureFactory';
-import { ERC721Tradable } from '../typechain/ERC721Tradable';
+
 import { MockProxyRegistry } from '../typechain/MockProxyRegistry';
-import { create } from 'domain';
 
 chai.use(solidity);
 
@@ -68,18 +65,12 @@ describe('ZapMarket Test', () => {
 
   beforeEach(async () => {
     signers = await ethers.getSigners();
-    const owner = signers[0];
-    const proxyForOwner = signers[8];
+
     const zapTokenFactory = await ethers.getContractFactory(
       'ZapTokenBSC',
       signers[0]
     );
-    const proxyFactory = await ethers.getContractFactory(
-      'MockProxyRegistry'
-    )
-    const proxy = (await proxyFactory.deploy()) as MockProxyRegistry;
-    await proxy.deployed();
-    await proxy.setProxy(owner.address, proxyForOwner.address);
+
 
     zapTokenBsc = (await zapTokenFactory.deploy()) as ZapTokenBSC;
     await zapTokenBsc.deployed();
@@ -90,8 +81,6 @@ describe('ZapMarket Test', () => {
   let zapMedia2: ZapMedia;
   let zapMedia3: ZapMedia;
   let zapVault: ZapVault
-  let osCreature: Creature;
-  let creatureFactory: CreatureFactory;
   let mediaDeployer: MediaFactory;
   let signers: SignerWithAddress[];
 
@@ -1570,6 +1559,8 @@ describe('ZapMarket Test', () => {
 
     let owner: SignerWithAddress;
     let proxyForOwner: SignerWithAddress;
+    let proxy: MockProxyRegistry;
+    let osCreature: Creature;
 
     beforeEach(async () => {
 
@@ -1582,46 +1573,35 @@ describe('ZapMarket Test', () => {
       );
 
       const proxyFactory = await ethers.getContractFactory(
-        'MockProxyRegistry'
+        'MockProxyRegistry',
+        signers[0]
       )
 
-      const proxy = (await proxyFactory.deploy()) as MockProxyRegistry;
+      proxy = (await proxyFactory.deploy()) as MockProxyRegistry;
       await proxy.deployed();
       await proxy.setProxy(owner.address, proxyForOwner.address);
 
       zapTokenBsc = (await zapTokenFactory.deploy()) as ZapTokenBSC;
       await zapTokenBsc.deployed();
 
-
       const oscreatureFactory = await ethers.getContractFactory(
         'Creature',
+        signers[0]
       )
 
       osCreature = (await oscreatureFactory.deploy(proxy.address)) as Creature;
       await osCreature.deployed();
 
-
-
-      // const creatureFactoryFactory = await ethers.getContractFactory(
-      //   'CreatureFactory',
-      // );
-
-
-      // creatureFactory = (await creatureFactoryFactory.deploy(proxy.address, osCreature.address)) as CreatureFactory;
-      // await creatureFactory.deployed();
-
+      await osCreature.mintTo(signers[10].address)
 
     });
 
-    it('Testing', async () => {
+    it('Should have a external token balance of 1', async () => {
 
-      console.log(await osCreature.mintTo(signers[0].address))
-      // console.log(creatureFactory.signer.getAddress());
-      // console.log('zero',signers[0].address)
-      // await creatureFactory.connect(signers[1]).mint(0, signers[0].address);
+      expect(await osCreature.balanceOf(signers[10].address)).to.equal(1);
 
     })
 
-
   });
+
 });

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -1591,25 +1591,35 @@ describe('ZapMarket Test', () => {
 
       zapTokenBsc = (await zapTokenFactory.deploy()) as ZapTokenBSC;
       await zapTokenBsc.deployed();
+
+
       const oscreatureFactory = await ethers.getContractFactory(
         'Creature',
       )
+
       osCreature = (await oscreatureFactory.deploy(proxy.address)) as Creature;
       await osCreature.deployed();
-      const creatureFactoryFactory = await ethers.getContractFactory(
-        'CreatureFactory',
-      );
-      creatureFactory = (await creatureFactoryFactory.deploy(proxy.address, osCreature.address)) as CreatureFactory;
-      await creatureFactory.deployed();
+
+
+
+      // const creatureFactoryFactory = await ethers.getContractFactory(
+      //   'CreatureFactory',
+      // );
+
+
+      // creatureFactory = (await creatureFactoryFactory.deploy(proxy.address, osCreature.address)) as CreatureFactory;
+      // await creatureFactory.deployed();
 
 
     });
 
     it('Testing', async () => {
-      console.log(creatureFactory.signer.getAddress());
-      console.log('zero',signers[0].address)
-      await creatureFactory.connect(signers[1]).mint(0, signers[0].address);
-      
+
+      console.log(await osCreature.mintTo(signers[0].address))
+      // console.log(creatureFactory.signer.getAddress());
+      // console.log('zero',signers[0].address)
+      // await creatureFactory.connect(signers[1]).mint(0, signers[0].address);
+
     })
 
 

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -1608,8 +1608,8 @@ describe('ZapMarket Test', () => {
     it('Testing', async () => {
       console.log(creatureFactory.signer.getAddress());
       console.log('zero',signers[0].address)
-      await creatureFactory.connect(signers[1]).mint(0, owner.address);
-      // expect()
+      await creatureFactory.connect(signers[1]).mint(0, signers[0].address);
+      
     })
 
 


### PR DESCRIPTION
### Summary
Closes issue #228 
Creates a test that deploys an opensea creature NFT. 
Minted creature token on local test net

### Files 
`test/ZapMarketTest.ts`

### Visuals
![osctest](https://user-images.githubusercontent.com/31520665/139348591-678a3176-b394-4a8c-9101-0a6a2c7f64c9.png)
