### PR TITLE
ZAP-03M

### DIFF
--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -370,10 +370,10 @@ contract Zap {
         address vaultAddress = zap.addressVars[keccak256('_vault')];
         Vault vault = Vault(vaultAddress);
 
-        token.approve(address(this), stakeAmount);
+       
         transferFrom(msg.sender, vaultAddress, stakeAmount);
         vault.deposit(msg.sender, stakeAmount);
-
+        
     }
 
     /**

--- a/test/MainMinerTests.ts
+++ b/test/MainMinerTests.ts
@@ -248,6 +248,8 @@ describe("Main Miner Functions", () => {
 
     });
 
+    
+
     it("Should not be able to request a stake withdrawal if the stake status is 0(Not Staked)", async () => {
 
         await expect(zap.requestStakingWithdraw()).to.be.revertedWith(
@@ -737,5 +739,7 @@ describe("Main Miner Functions", () => {
         expect(symbol).to.equal("ZAPB");
 
     });
+
+   
 
 })


### PR DESCRIPTION
I omitted  ` token.approve(address(this), stakeAmount);` from the function `depositStake()` on line 360 as this was a redundant function call. Afterwards, I tested MainMinerTests.ts and didMineTest.ts along with every it block correspond to `depositStake()`.