### PR TITLE
Literal Boolean Comparison

### DIFF
--- a/contracts/zap-miner/libraries/ZapLibrary.sol
+++ b/contracts/zap-miner/libraries/ZapLibrary.sol
@@ -8,7 +8,7 @@ import './ZapStorage.sol';
 import './ZapDispute.sol';
 import './ZapStake.sol';
 import './ZapGettersLibrary.sol';
-
+import 'hardhat/console.sol';
 
 /**
  * @title Zap Oracle System Library
@@ -145,7 +145,7 @@ library ZapLibrary {
             self.uintVars[keccak256('currentReward')] = 6e18;
         }
         if (self.uintVars[keccak256('currentReward')] > 1e18) {
-        // adjust payout = payout * ratio 0.000030612633181126/1e18  
+            // adjust payout = payout * ratio 0.000030612633181126/1e18
             self.uintVars[keccak256('currentReward')] =
                 self.uintVars[keccak256('currentReward')] -
                 (self.uintVars[keccak256('currentReward')] * 30612633181126) /
@@ -299,10 +299,16 @@ library ZapLibrary {
         uint256 _value
     ) public {
         //requre miner is staked
-        require(self.stakerDetails[msg.sender].currentStatus == 1, "Miner is not staked");
+        require(
+            self.stakerDetails[msg.sender].currentStatus == 1,
+            'Miner is not staked'
+        );
 
         //Check the miner is submitting the pow for the current request Id
-        require(_requestId == self.uintVars[keccak256('currentRequestId')], "The solution submitted is not for the current request ID");
+        require(
+            _requestId == self.uintVars[keccak256('currentRequestId')],
+            'The solution submitted is not for the current request ID'
+        );
 
         //Saving the challenge information as unique by using the msg.sender
         require(
@@ -324,12 +330,15 @@ library ZapLibrary {
                 )
             ) %
                 self.uintVars[keccak256('difficulty')] ==
-                0
-            , "Challenge info is not unique"
+                0,
+            'Challenge info is not unique'
         );
 
         //Make sure the miner does not submit a value more than once
-        require(self.minersByChallenge[self.currentChallenge][msg.sender] == false, "Miner has already submitted a value");
+        require(
+            !self.minersByChallenge[self.currentChallenge][msg.sender],
+            'Miner has already submitted a value'
+        );
 
         // Set miner reward to zero to prevent it from giving rewards before a block is mined
         self.uintVars[keccak256('currentMinerReward')] = 0;

--- a/contracts/zap-miner/libraries/ZapLibrary.sol
+++ b/contracts/zap-miner/libraries/ZapLibrary.sol
@@ -8,7 +8,6 @@ import './ZapStorage.sol';
 import './ZapDispute.sol';
 import './ZapStake.sol';
 import './ZapGettersLibrary.sol';
-import 'hardhat/console.sol';
 
 /**
  * @title Zap Oracle System Library

--- a/test/didMineTest.ts
+++ b/test/didMineTest.ts
@@ -307,12 +307,16 @@ describe('Did Mine Test', () => {
     // Each tip will be stored inside the requestQ array
     await zap.requestData(api, 'USD', 1000, 52);
 
+    // Signer 1 submits a solution
     await zap.connect(signers[1]).submitMiningSolution('nonce', 1, 1200);
 
+    // Signer 2 submits a solution
     await zap.connect(signers[2]).submitMiningSolution('nonce', 1, 1200);
 
+    // Signer 3 submits a solution
     await zap.connect(signers[3]).submitMiningSolution('nonce', 1, 1200);
 
+    // Signer 3 attempts to submit another solution and will cause the transaction to revert
     await expect(zap.connect(signers[3]).submitMiningSolution('nonce', 1, 1200)).to.be.revertedWith(
       'Miner has already submitted a value'
     );

--- a/test/didMineTest.ts
+++ b/test/didMineTest.ts
@@ -323,6 +323,7 @@ describe('Did Mine Test', () => {
 
   })
 
+
   it('Test increased difficulty', async () => {
     // Allocates 5000 ZAP to signer 0
     await zapTokenBsc.allocate(


### PR DESCRIPTION
## Summary
Closes #240 

## Implementation
- [x] Negated the bool variable ```self.minersByChallenge[self.currentChallenge][msg.sender]``` into ```!self.minersByChallenge[self.currentChallenge][msg.sender]```
- [x] Ensure the change kept its original functionality by creating the test ```Should revert if a miner already submitted a value``` 
- [x] The ```submitMiningSolution``` function will fail if a miner tries to submit a second value

## Files
```test/didMineTest.ts```
```contracts/zap-miner/libraries/ZapLibrary.sol```

## Visual

Removed the bool variable to bool literal comparison
<img width="653" alt="Screen Shot 2021-11-02 at 5 43 53 PM" src="https://user-images.githubusercontent.com/42893948/139955995-c84f0433-ad13-4e4b-8591-9b21ef6da3b8.png">

Test passing 
<img width="989" alt="Screen Shot 2021-11-02 at 5 45 22 PM" src="https://user-images.githubusercontent.com/42893948/139956160-039c8989-38d4-456d-8360-762c2771e2a7.png">
