### PR TITLE
Zap 04 m non inclusive fee evaluation

### DIFF
--- a/contracts/zap-miner/Zap.sol
+++ b/contracts/zap-miner/Zap.sol
@@ -115,7 +115,7 @@ contract Zap {
         require(zap.stakerDetails[msg.sender].currentStatus == 1, "Only stakers can begin a dispute");
 
         //ensure the msg.sender is staked and not in dispute
-        require(token.balanceOf(msg.sender) > zap.uintVars[keccak256('disputeFee')], "You do not have a balance to dispute.");
+        require(token.balanceOf(msg.sender) >= zap.uintVars[keccak256('disputeFee')], "You do not have a balance to dispute.");
         
 
         //_miner is the miner being disputed. For every mined value 5 miners are saved in an array and the _minerIndex


### PR DESCRIPTION
# Summary
Closing #236 

Needed to add a equal sign when comparing token balance to disputeFee. Previously only had the greater than, but dispute can also happen with exact amount.

Add test for completeness.

# Visual
![Screen Shot 2021-11-02 at 6 44 05 PM](https://user-images.githubusercontent.com/24558257/139961998-05665959-431f-4f94-a98f-9ce34f204de0.png)

