### PR TITLE
Issue #234

### DIFF
--- a/contracts/nft/MediaFactory.sol
+++ b/contracts/nft/MediaFactory.sol
@@ -33,7 +33,7 @@ contract MediaFactory is OwnableUpgradeable {
             _collectionMetadata
         );
 
-        zapMedia.transferOwnership(payable(msg.sender));
+        zapMedia.initTransferOwnership(payable(msg.sender));
 
         zapMarket.registerMedia(address(zapMedia));
 

--- a/test/MediaFactoryTest.ts
+++ b/test/MediaFactoryTest.ts
@@ -65,10 +65,10 @@ describe("MediaFactory", () => {
         return mediaFactory as MediaFactory;
     }
 
-    async function deployAuction(signer: SignerWithAddress, currency: string) {
+    async function deployAuction(signer: SignerWithAddress, currency: string, market: string) {
         const ahFact = await ethers.getContractFactory("AuctionHouse", signer);
 
-        const auctionHouse = await upgrades.deployProxy(ahFact, [currency], { initializer: 'initialize' }) as AuctionHouse;
+        const auctionHouse = await upgrades.deployProxy(ahFact, [currency, market], { initializer: 'initialize' }) as AuctionHouse;
 
         return auctionHouse as AuctionHouse;
     }
@@ -213,9 +213,9 @@ describe("MediaFactory", () => {
         let badMedia: ZapMedia;
 
         beforeEach(async () => {
-            auctionHouse = await deployAuction(deployer, zapTokenBsc.address);
+            auctionHouse = await deployAuction(deployer, zapTokenBsc.address, zapMarket.address);
             zapMedia = new ethers.Contract(mediaAddress, zmABI, mediaOwner) as ZapMedia;
-
+            
             const platformFee = {
                 fee: {
                     value: BigNumber.from('5000000000000000000')
@@ -237,7 +237,6 @@ describe("MediaFactory", () => {
                 ],
                 { initializer: 'initialize' }
             ) as ZapMedia;
-
             await mintFrom(badMedia);
 
             const token = 0;

--- a/test/MediaFactoryTest.ts
+++ b/test/MediaFactoryTest.ts
@@ -237,21 +237,25 @@ describe("MediaFactory", () => {
                 ],
                 { initializer: 'initialize' }
             ) as ZapMedia;
-            await mintFrom(badMedia);
 
-            const token = 0;
-            const duration = 60 * 60 * 24;
-            const reservePrice = BigNumber.from(10).pow(18).div(2);
+            await expect(mintFrom(badMedia)).to.be.revertedWith("Market: Only media contract");
 
-            await expect (auctionHouse.createAuction(
-                token,
-                badMedia.address,
-                duration,
-                reservePrice,
-                badActor.address,
-                5,
-                zapTokenBsc.address
-            )).to.be.revertedWith("Media contract is not registered with the marketplace");
+            // These (original) tests  will revert as the bad media is not configured to market
+            // await mintFrom(badMedia);
+
+            // const token = 0;
+            // const duration = 60 * 60 * 24;
+            // const reservePrice = BigNumber.from(10).pow(18).div(2);
+
+            // await expect (auctionHouse.createAuction(
+            //     token,
+            //     badMedia.address,
+            //     duration,
+            //     reservePrice,
+            //     badActor.address,
+            //     5,
+            //     zapTokenBsc.address
+            // )).to.be.revertedWith("Media contract is not registered with the marketplace");
         });
 
         it("Should create an auction for a registered media contract", async () => {

--- a/test/NftVaultTest.ts
+++ b/test/NftVaultTest.ts
@@ -51,7 +51,9 @@ describe('NFT Platform Vault Test', () => {
 
         const initialOwner = await zapVault.getOwner();
 
-        await zapVault.transferOwnership(signers[1].address);
+        await zapVault.initTransferOwnership(signers[1].address);
+
+        await zapVault.connect(signers[1]).claimTransferOwnership();
 
         const zapVaultFilter =
             zapVault.filters.OwnershipTransferred(null, null);

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -193,6 +193,10 @@ describe('ZapMarket Test', () => {
       zapMedia2 = medias[1];
       zapMedia3 = medias[2];
 
+      await zapMedia1.claimTransferOwnership();
+      await zapMedia2.claimTransferOwnership();
+      await zapMedia3.claimTransferOwnership();
+
       ask1.currency = zapTokenBsc.address;
 
       let metadataHex = ethers.utils.formatBytes32String('{}');
@@ -390,6 +394,10 @@ describe('ZapMarket Test', () => {
       zapMedia1 = medias[0];
       zapMedia2 = medias[1];
       zapMedia3 = medias[2];
+
+      await zapMedia1.claimTransferOwnership();
+      await zapMedia2.claimTransferOwnership();
+      await zapMedia3.claimTransferOwnership();
 
       ask1.currency = zapTokenBsc.address;
 
@@ -646,6 +654,10 @@ describe('ZapMarket Test', () => {
       zapMedia2 = medias[1];
       zapMedia3 = medias[2];
 
+      await zapMedia1.claimTransferOwnership();
+      await zapMedia2.claimTransferOwnership();
+      await zapMedia3.claimTransferOwnership();
+
       ask1.currency = zapTokenBsc.address;
       ask2.currency = zapTokenBsc.address;
 
@@ -880,6 +892,10 @@ describe('ZapMarket Test', () => {
       zapMedia1 = medias[0];
       zapMedia2 = medias[1];
       zapMedia3 = medias[2];
+
+      await zapMedia1.claimTransferOwnership();
+      await zapMedia2.claimTransferOwnership();
+      await zapMedia3.claimTransferOwnership();
 
       bid1 = {
         amount: 200,
@@ -1454,6 +1470,10 @@ describe('ZapMarket Test', () => {
       zapMedia1 = medias[0];
       zapMedia2 = medias[1];
       zapMedia3 = medias[2];
+
+      await zapMedia1.claimTransferOwnership();
+      await zapMedia2.claimTransferOwnership();
+      await zapMedia3.claimTransferOwnership();
 
       bid1 = {
         amount: 200,

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -8,7 +8,7 @@ import chai, { expect } from "chai";
 
 import { ZapTokenBSC } from "../typechain/ZapTokenBSC";
 
-import { signPermit, signMintWithSig } from "./utils";
+import { signPermit, signMintWithSig, deployOneMedia } from "./utils";
 
 import { ZapMedia } from '../typechain/ZapMedia';
 import { ZapMarket } from "../typechain/ZapMarket";
@@ -175,6 +175,10 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
+
             ask.currency = zapTokenBsc.address;
         });
 
@@ -266,6 +270,10 @@ describe("ZapMedia Test", async () => {
             zapMedia1 = medias[0];
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
+
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
         });
 
         it("should not mint token if caller is not approved", async () => {
@@ -465,6 +473,9 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
         })
 
         it("should mint a token for a given creator with a valid signature", async () => {
@@ -872,6 +883,10 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
+
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
@@ -980,6 +995,10 @@ describe("ZapMedia Test", async () => {
             zapMedia1 = medias[0];
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
+
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
 
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
@@ -1097,6 +1116,10 @@ describe("ZapMedia Test", async () => {
             zapMedia1 = medias[0];
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
+            
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
 
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
@@ -1281,6 +1304,10 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
+
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
@@ -1346,6 +1373,10 @@ describe("ZapMedia Test", async () => {
             zapMedia1 = medias[0];
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
+
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
 
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
@@ -1481,6 +1512,10 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
+
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
@@ -1592,6 +1627,10 @@ describe("ZapMedia Test", async () => {
             zapMedia1 = medias[0];
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
+
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
 
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
@@ -1714,6 +1753,10 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
+
             tokenURI = String('media contract 1 - token 1 uri');
             metadataURI = String('media contract 1 - metadata 1 uri');
 
@@ -1794,6 +1837,9 @@ describe("ZapMedia Test", async () => {
             zapMedia2 = medias[1];
             zapMedia3 = medias[2];
 
+            await zapMedia1.claimTransferOwnership();
+            await zapMedia2.claimTransferOwnership();
+            await zapMedia3.claimTransferOwnership();
         })
 
         it('should return true to supporting metadata interface', async () => {
@@ -1826,6 +1872,9 @@ describe("ZapMedia Test", async () => {
                 zapMedia2 = medias[1];
                 zapMedia3 = medias[2];
 
+                await zapMedia1.claimTransferOwnership();
+                await zapMedia2.claimTransferOwnership();
+                await zapMedia3.claimTransferOwnership();
 
                 tokenURI = String('media contract 1 - token 1 uri');
                 metadataURI = String('media contract 1 - metadata 1 uri');
@@ -1880,4 +1929,128 @@ describe("ZapMedia Test", async () => {
 
         });
     });
+
+    describe("Ownership", () => {
+        beforeEach(async () => {
+            mediaData = {
+                tokenURI,
+                metadataURI,
+                contentHash: contentHashBytes,
+                metadataHash: metadataHashBytes,
+            };
+
+            const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
+
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+                initializer: 'initialize'
+            })) as MediaFactory;
+
+            await mediaDeployer.deployed();
+
+            await zapMarket.setMediaFactory(mediaDeployer.address);
+
+            const medias = await deployOneMedia(signers[0], zapMarket, mediaDeployer, 101);
+
+            zapMedia1 = medias;
+            await zapMedia1.claimTransferOwnership();
+        });
+    
+        it("Should successfully transfer ownership", async () => {
+          let oldOwner = await zapMedia1.getOwner();
+          let newOwner = signers[1].address;
+          await zapMedia1.initTransferOwnership(newOwner);
+          expect(newOwner).to.be.equal(await zapMedia1.appointedOwner());
+          expect(oldOwner).to.be.equal(await zapMedia1.getOwner());
+          // listen for transferOwnershipInitiated event
+          const filter_transferInitiated: EventFilter = zapMedia1.filters.OwnershipTransferInitiated(
+            null, null
+          );
+    
+          const event_transferOwnershipInitated: Event = (
+            await zapMedia1.queryFilter(filter_transferInitiated)
+          )[1]
+    
+          expect(event_transferOwnershipInitated.event).to.be.equal("OwnershipTransferInitiated");
+          expect(event_transferOwnershipInitated.args?.owner).to.be.equal(oldOwner);
+          expect(event_transferOwnershipInitated.args?.appointedOwner).to.be.equal(newOwner);
+    
+          await zapMedia1.connect(signers[1]).claimTransferOwnership();
+          expect(newOwner).to.be.equal(await zapMedia1.getOwner());
+          expect(ethers.constants.AddressZero).to.be.equal(await zapMedia1.appointedOwner());
+          // listen for transferOwnership event
+          const filter_transfered: EventFilter = zapMedia1.filters.OwnershipTransferred(
+            null, null
+          );
+    
+          const event_transferredOwnership: Event = (
+            await zapMedia1.queryFilter(filter_transfered)
+          )[1]
+    
+          expect(event_transferredOwnership.event).to.be.equal("OwnershipTransferred");
+          expect(event_transferredOwnership.args?.previousOwner).to.be.equal(oldOwner);
+          expect(event_transferredOwnership.args?.newOwner).to.be.equal(newOwner);
+        });
+    
+        it("Should revoke appointed owner", async () => {
+          let oldOwner = await zapMedia1.getOwner();
+          let newOwner = signers[1].address;
+    
+          await zapMedia1.initTransferOwnership(newOwner);
+          expect(newOwner).to.be.equal(await zapMedia1.appointedOwner());
+          expect(oldOwner).to.be.equal(await zapMedia1.getOwner());
+          // listen for transferOwnershipInitiated event
+          const filter_transferInitiated: EventFilter = zapMedia1.filters.OwnershipTransferInitiated(
+            null, null
+          );
+    
+          const event_transferOwnershipInitated: Event = (
+            await zapMedia1.queryFilter(filter_transferInitiated)
+          )[1]
+    
+          expect(event_transferOwnershipInitated.event).to.be.equal("OwnershipTransferInitiated");
+          expect(event_transferOwnershipInitated.args?.owner).to.be.equal(oldOwner);
+          expect(event_transferOwnershipInitated.args?.appointedOwner).to.be.equal(newOwner);
+    
+          await zapMedia1.revokeTransferOwnership();
+          expect(ethers.constants.AddressZero).to.be.equal(await zapMedia1.appointedOwner());
+          expect(oldOwner).to.be.equal(await zapMedia1.getOwner());
+    
+          await expect(zapMedia1.connect(signers[1]).claimTransferOwnership()).
+              to.be.revertedWith("Ownable: No ownership transfer have been initiated");
+        });
+    
+        it("Should revert when non owner calls init transfer", async() => {
+          let newOwner = signers[1].address;
+          await expect(zapMedia1.connect(signers[2]).initTransferOwnership(newOwner)).
+                to.be.reverted;
+            //   to.be.revertedWith("Ownable: Only owner has access to this function");
+    
+          await expect(zapMedia1.connect(signers[0]).initTransferOwnership(ethers.constants.AddressZero)).
+              to.be.revertedWith("Ownable: Cannot transfer to zero address");
+        });
+    
+        it("Should revert when non owner calls claim transfer", async() => {
+          let oldOwner = await zapMedia1.getOwner();
+          let newOwner = signers[1].address;
+    
+          await zapMedia1.initTransferOwnership(newOwner);
+          expect(newOwner).to.be.equal(await zapMedia1.appointedOwner());
+          expect(oldOwner).to.be.equal(await zapMedia1.getOwner());
+          // listen for transferOwnershipInitiated event
+          const filter_transferInitiated: EventFilter = zapMedia1.filters.OwnershipTransferInitiated(
+            null, null
+          );
+    
+          const event_transferOwnershipInitated: Event = (
+            await zapMedia1.queryFilter(filter_transferInitiated)
+          )[1]
+    
+          expect(event_transferOwnershipInitated.event).to.be.equal("OwnershipTransferInitiated");
+          expect(event_transferOwnershipInitated.args?.owner).to.be.equal(oldOwner);
+          expect(event_transferOwnershipInitated.args?.appointedOwner).to.be.equal(newOwner);
+    
+          await expect(zapMedia1.connect(signers[2]).claimTransferOwnership()).
+              to.be.revertedWith("Ownable: Caller is not the appointed owner of this contract");
+        });
+      });
 })


### PR DESCRIPTION
### Summary
closes #234 

### Implementation
- Added `initiateTransferOwnership()` & `claimTransferOwnership()` functions to replace `transferOwnership()` for a validation of ownership transfer
- Added `OwnershipTransferInitiated` event
- Test cases for ownership transfer scenarios
- Adjusted `MediaFactory.sol` & `ZapMarketTest.ts` to reflect accordingly
   - In `MediaFactory.sol`, added a call for `initiateTransferOwnership()`. Now, the deployer must call `claimTransferOwnership()` for every Media contract.

### Visuals
![image](https://user-images.githubusercontent.com/18056516/140166294-bde03e4a-cedf-4820-b17d-23546ed20844.png)
