### PR TITLE
Issue-239

### DIFF
--- a/contracts/nft/Ownable.sol
+++ b/contracts/nft/Ownable.sol
@@ -25,7 +25,8 @@ contract Ownable is Initializable {
 
     /// @dev Throws if called by any contract other than latest designated caller
     modifier onlyOwner() {
-        require(msg.sender == access.owner);
+        require(msg.sender == access.owner,
+        "onlyOwner error: Only Owner of the Contract can make this Call");
         _;
     }
 

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -308,6 +308,8 @@ describe("ZapMedia Test", async () => {
                 await zapMedia2.connect(signers[3]).mint(mediaData, bidShares)
             ).to.be.ok;
 
+           
+
             const ownerOf = await zapMedia2.ownerOf(0);
             const creator = await zapMedia2.getTokenCreators(0);
 
@@ -1991,7 +1993,7 @@ describe("ZapMedia Test", async () => {
           expect(event_transferredOwnership.args?.newOwner).to.be.equal(newOwner);
         });
     
-        it("Should revoke appointed owner", async () => {
+        it.only("Should revoke appointed owner", async () => {
           let oldOwner = await zapMedia1.getOwner();
           let newOwner = signers[1].address;
     
@@ -2023,7 +2025,7 @@ describe("ZapMedia Test", async () => {
           let newOwner = signers[1].address;
           await expect(zapMedia1.connect(signers[2]).initTransferOwnership(newOwner)).
                 to.be.reverted;
-            //   to.be.revertedWith("Ownable: Only owner has access to this function");
+            
     
           await expect(zapMedia1.connect(signers[0]).initTransferOwnership(ethers.constants.AddressZero)).
               to.be.revertedWith("Ownable: Cannot transfer to zero address");
@@ -2032,7 +2034,7 @@ describe("ZapMedia Test", async () => {
         it("Should revert when non owner calls claim transfer", async() => {
           let oldOwner = await zapMedia1.getOwner();
           let newOwner = signers[1].address;
-    
+          
           await zapMedia1.initTransferOwnership(newOwner);
           expect(newOwner).to.be.equal(await zapMedia1.appointedOwner());
           expect(oldOwner).to.be.equal(await zapMedia1.getOwner());
@@ -2052,5 +2054,14 @@ describe("ZapMedia Test", async () => {
           await expect(zapMedia1.connect(signers[2]).claimTransferOwnership()).
               to.be.revertedWith("Ownable: Caller is not the appointed owner of this contract");
         });
-      });
+      
+    it.only("Should revoke transfer and set appointed owner to 0 address", async () => {
+       let appointedOwner = signers[0].address;
+
+       await expect(zapMedia1.connect(signers[1]).revokeTransferOwnership()).
+            to.be.revertedWith("onlyOwner error: Only Owner of the Contract can make this Call");
+    });
+    
+    });
+
 })

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -2057,7 +2057,7 @@ describe("ZapMedia Test", async () => {
         });
       
     
-    it.only("Should revert f owner does not call revoke", async () => {
+    it("Should revert f owner does not call revoke", async () => {
     
     const original_owner = await zapMedia1.getOwner(); 
     const newOwner =  await signers[2].address;

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -37,6 +37,7 @@ describe("ZapMedia Test", async () => {
     let zapVault: ZapVault;
     let zapTokenBsc: any;
     let signers: any;
+    
 
     let bidShares = {
         collaborators: ["", "", ""],
@@ -1993,7 +1994,7 @@ describe("ZapMedia Test", async () => {
           expect(event_transferredOwnership.args?.newOwner).to.be.equal(newOwner);
         });
     
-        it.only("Should revoke appointed owner", async () => {
+        it("Should revoke appointed owner", async () => {
           let oldOwner = await zapMedia1.getOwner();
           let newOwner = signers[1].address;
     
@@ -2055,11 +2056,21 @@ describe("ZapMedia Test", async () => {
               to.be.revertedWith("Ownable: Caller is not the appointed owner of this contract");
         });
       
-    it.only("Should revoke transfer and set appointed owner to 0 address", async () => {
-       let appointedOwner = signers[0].address;
+    
+    it.only("Should revert f owner does not call revoke", async () => {
+    
+    const original_owner = await zapMedia1.getOwner(); 
+    const newOwner =  await signers[2].address;
+       
+    await zapMedia1.initTransferOwnership(newOwner);
 
        await expect(zapMedia1.connect(signers[1]).revokeTransferOwnership()).
             to.be.revertedWith("onlyOwner error: Only Owner of the Contract can make this Call");
+        
+        const owner = await zapMedia1.getOwner(); 
+
+        expect(original_owner).to.be.equal(owner);
+       
     });
     
     });


### PR DESCRIPTION
## Summary

closes issue #239

### Implementation
First, I implemented an error message in the `onlyOwner` modifier of `nft/ownable.sol`.
```
 modifier onlyOwner() {
        require(msg.sender == access.owner,
        "onlyOwner error: Only Owner of the Contract can make this Call");
        _;
    }
```

Next, I added two tests that would test if two functions, `revokeTransferOwnership()` and  `initTransferOwnership()` would revoke an error message when another signer would call the contract.

```
it.only("Should revoke transfer and set appointed owner to 0 address", async () => {
       let appointedOwner = signers[0].address;

       await expect(zapMedia1.connect(signers[1]).revokeTransferOwnership()).
            to.be.revertedWith("onlyOwner error: Only Owner of the Contract can make this Call");
    });
```

```
 it("Should revert when non owner calls init transfer", async() => {
          let newOwner = signers[1].address;
          await expect(zapMedia1.connect(signers[2]).initTransferOwnership(newOwner)).
                to.be.reverted;
            
    
          await expect(zapMedia1.connect(signers[0]).initTransferOwnership(ethers.constants.AddressZero)).
              to.be.revertedWith("Ownable: Cannot transfer to zero address");
        });
    ```

### Files changed
`nft/ownable.sol`
`test/ZapMediaTest.ts`