### PR TITLE
Related Issue #249

### DIFF
--- a/contracts/nft/Ownable.sol
+++ b/contracts/nft/Ownable.sol
@@ -62,7 +62,7 @@ contract Ownable is Initializable {
         require(appointedOwner != address(0), "Ownable: No ownership transfer have been initiated");
         require(msg.sender == appointedOwner, "Ownable: Caller is not the appointed owner of this contract");
 
-        emit OwnershipTransferred(access.owner, appointedOwner);
+        emit OwnershipTransferred(access.owner, msg.sender); // where msg.sender == appointedOwner
         access.owner = appointedOwner;
         appointedOwner = address(0);
     }


### PR DESCRIPTION
## Summary
This branch addresses an issue related to #249.

## Implementation
Issue #249 required changing the `newOwner` variable within the `OwnershipTransferred` event into `msg.sender`.

The test "Should successfully transfer ownership" found within `./test/ZapMediaTest.ts` shows that `msg.sender == newOwner`.