### PR TITLE
ZapMedia Contract-level metadata

### DIFF
--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -20,6 +20,7 @@ import {Ownable} from './Ownable.sol';
 import {MediaGetter} from './MediaGetter.sol';
 import {MediaStorage} from './libraries/MediaStorage.sol';
 import './libraries/Constants.sol';
+import 'hardhat/console.sol';
 
 /**
  * @title A media value system, with perpetual equity to creators
@@ -142,9 +143,9 @@ contract ZapMedia is
 
     address public testing;
 
-     //function contractURI() public view returns (string memory) {
-        //return _contractURI;
-        console.log(bytes _contractURI)
+     //geting the contractURI value
+     function contractURI() public pure returns (string memory) {
+        return "https://creatures-api.opensea.io/contract/opensea-creatures";
     }
 
     /**

--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -143,6 +143,11 @@ contract ZapMedia is
 
     address public testing;
 
+     //function contractURI() public view returns (string memory) {
+        //return _contractURI;
+        console.log(bytes _contractURI)
+    }
+
     /**
      * @notice On deployment, set the market contract address and register the
      * ERC721 metadata interface
@@ -700,10 +705,6 @@ contract ZapMedia is
                     address(this)
                 )
             );
-    }
-
-    function get(contractURI) public returns (string memory) {
-        return _contractURI;
     }
 
 }

--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -141,11 +141,9 @@ contract ZapMedia is
         _;
     }
 
-    address public testing;
-
      //geting the contractURI value
-     function contractURI() public pure returns (string memory) {
-        return "https://creatures-api.opensea.io/contract/opensea-creatures";
+     function contractURI() public view returns (bytes memory) {
+        return _contractURI;
     }
 
     /**

--- a/contracts/nft/ZapMedia.sol
+++ b/contracts/nft/ZapMedia.sol
@@ -52,7 +52,7 @@ contract ZapMedia is
 
     mapping(bytes4 => bool) private _supportedInterfaces;
 
-    bytes public collectionMetadata;
+    bytes internal _contractURI;
 
     bytes32 private constant kecEIP712Domain =
         keccak256(
@@ -153,7 +153,7 @@ contract ZapMedia is
         string calldata symbol,
         address marketContractAddr,
         bool permissive,
-        string calldata _collectionMetadata
+        string calldata collectionURI
     ) external override initializer {
         __ERC721_init(name, symbol);
         initialize_ownable();
@@ -174,7 +174,7 @@ contract ZapMedia is
         _registerInterface(type(IMedia).interfaceId);
 
         access.isPermissive = permissive;
-        collectionMetadata = bytes(_collectionMetadata);
+        _contractURI = bytes(collectionURI);
     }
 
     /**
@@ -701,4 +701,9 @@ contract ZapMedia is
                 )
             );
     }
+
+    function get(contractURI) public returns (string memory) {
+        return _contractURI;
+    }
+
 }

--- a/test/AuctionHouseTest.ts
+++ b/test/AuctionHouseTest.ts
@@ -329,7 +329,7 @@ describe("AuctionHouse", () => {
         symbol: "TM" + `${5}`,
         marketContractAddr: badMarket.address,
         permissive: false,
-        _collectionMetadata: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
+        collectionURI: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
       }
       const badMediaFact = await ethers.getContractFactory("BadMedia", signers[5]);
       const badMedia = await upgrades.deployProxy(
@@ -337,7 +337,7 @@ describe("AuctionHouse", () => {
         [
           mediaArgs.name, mediaArgs.symbol,
           mediaArgs.marketContractAddr, mediaArgs.permissive,
-          mediaArgs._collectionMetadata
+          mediaArgs.collectionURI
         ]
       ) as BadMedia;
       // const badMedia = await badMediaFact.deploy(mediaArgs);

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -272,9 +272,9 @@ describe('ZapMarket Test', () => {
 
     it('Should get collection metadata', async () => {
 
-      const metadata1 = await zapMedia1.collectionMetadata();
-      const metadata2 = await zapMedia2.collectionMetadata();
-      const metadata3 = await zapMedia3.collectionMetadata();
+      const metadata1 = await zapMedia1.contractURI();
+      const metadata2 = await zapMedia2.contractURI();
+      const metadata3 = await zapMedia3.contractURI();
 
       expect(ethers.utils.toUtf8String(metadata1)).to.equal(
         'https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV'

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -2075,16 +2075,5 @@ describe("ZapMedia Test", async () => {
 
     });
 
-    it.only("Should return contractURI value", async () => {
-
-        //console.log(_contractURI)
-        //const original_owner = await zapMedia1.getOwner();
-
-        //await zapMedia1.initTransferOwnership(newOwner);
-
-        //await expect(zapMedia1.connect(signers[1]).revokeTransferOwnership()).
-            //to.be.revertedWith("onlyOwner error: Only Owner of the Contract can make this Call");
-
-    });
 
 })

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -2075,4 +2075,16 @@ describe("ZapMedia Test", async () => {
 
     });
 
+    it.only("Should return contractURI value", async () => {
+
+        //console.log(_contractURI)
+        //const original_owner = await zapMedia1.getOwner();
+
+        //await zapMedia1.initTransferOwnership(newOwner);
+
+        //await expect(zapMedia1.connect(signers[1]).revokeTransferOwnership()).
+            //to.be.revertedWith("onlyOwner error: Only Owner of the Contract can make this Call");
+
+    });
+
 })

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -72,21 +72,21 @@ export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: 
       symbol: "TM1",
       marketContractAddr: zapMarket.address,
       permissive: true,
-      _collectionMetadata: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
+      collectionURI: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
     },
     {
       name: "TEST MEDIA 2",
       symbol: "TM2",
       marketContractAddr: zapMarket.address,
       permissive: false,
-      _collectionMetadata: "https://ipfs.io/ipfs/QmTDCTPF6CpUK7DTqcUvRpGysfA1EbgRob5uGsStcCZie6"
+      collectionURI: "https://ipfs.io/ipfs/QmTDCTPF6CpUK7DTqcUvRpGysfA1EbgRob5uGsStcCZie6"
     },
     {
       name: "TEST MEDIA 2",
       symbol: "TM2",
       marketContractAddr: zapMarket.address,
       permissive: false,
-      _collectionMetadata: "https://ipfs.moralis.io:2053/ipfs/QmXtZVM1JwnCXax1y5r6i4ARxADUMLm9JSq5Rnn3vq9qsN"
+      collectionURI: "https://ipfs.moralis.io:2053/ipfs/QmXtZVM1JwnCXax1y5r6i4ARxADUMLm9JSq5Rnn3vq9qsN"
     }
   ]
 
@@ -106,7 +106,7 @@ export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: 
   for (let i = 0; i < mediaArgs.length; i++) {
     const args = mediaArgs[i];
     await mediaDeploy.connect(mediaDeployers[i]).deployMedia(
-      args.name, args.symbol, args.marketContractAddr, args.permissive, args._collectionMetadata
+      args.name, args.symbol, args.marketContractAddr, args.permissive, args.collectionURI
     );
 
     filter = mediaDeploy.filters.MediaDeployed(null);
@@ -127,7 +127,7 @@ export const deployOneMedia = async (signer: SignerWithAddress, zapMarket: ZapMa
     symbol: "TM" + `${q}`,
     marketContractAddr: zapMarket.address,
     permissive: false,
-    _collectionMetadata: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
+    collectionURI: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
   }
 
   let media: ZapMedia;
@@ -139,7 +139,7 @@ export const deployOneMedia = async (signer: SignerWithAddress, zapMarket: ZapMa
   await fact.deployMedia(
     mediaArgs.name, mediaArgs.symbol,
     mediaArgs.marketContractAddr, mediaArgs.permissive,
-    mediaArgs._collectionMetadata
+    mediaArgs.collectionURI
   );
 
   filter = fact.filters.MediaDeployed(null);
@@ -203,21 +203,21 @@ export const deployZapNFTMarketplace = async () => {
       symbol: "TM1",
       marketContractAddr: market.address,
       permissive: true,
-      _collectionMetadata: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
+      collectionURI: "https://ipfs.moralis.io:2053/ipfs/QmeWPdpXmNP4UF9Urxyrp7NQZ9unaHfE2d43fbuur6hWWV"
     },
     {
       name: "Test Media 1",
       symbol: "TM1",
       marketContractAddr: market.address,
       permissive: false,
-      _collectionMetadata: "https://ipfs.io/ipfs/QmTDCTPF6CpUK7DTqcUvRpGysfA1EbgRob5uGsStcCZie6"
+      collectionURI: "https://ipfs.io/ipfs/QmTDCTPF6CpUK7DTqcUvRpGysfA1EbgRob5uGsStcCZie6"
     },
     {
       name: "Test Media 1",
       symbol: "TM1",
       marketContractAddr: market.address,
       permissive: false,
-      _collectionMetadata: "https://ipfs.moralis.io:2053/ipfs/QmXtZVM1JwnCXax1y5r6i4ARxADUMLm9JSq5Rnn3vq9qsN"
+      collectionURI: "https://ipfs.moralis.io:2053/ipfs/QmXtZVM1JwnCXax1y5r6i4ARxADUMLm9JSq5Rnn3vq9qsN"
     }
   ]
 
@@ -235,7 +235,7 @@ export const deployZapNFTMarketplace = async () => {
   for (let i = 0; i < mediaArgs.length; i++) {
     const args = mediaArgs[i];
     await mediaFactory.connect(mediaDeployers[i]).deployMedia(
-      args.name, args.symbol, args.marketContractAddr, args.permissive, args._collectionMetadata
+      args.name, args.symbol, args.marketContractAddr, args.permissive, args.collectionURI
     );
 
     filter = mediaFactory.filters.MediaDeployed(null);


### PR DESCRIPTION
## Summary
Updated the ```ZapMedia.sol``` contract metadata to follow the OpenSea metadata standards, https://docs.opensea.io/docs/contract-level-metadata

## Implementation
- [x] stayed on branch ```issue-267```
- [x] Changed ```collectionMetadata``` to ```_contractURI```
- [x] Changed newly made ```_contractURI``` visibility to ```internal```
- [x] Changed ```_collectionMetadata``` to ```collectionURI```
- [x] Created a ```contractURI``` function that returned the ```_contractURI``` value
- [x] Created a pull request from the branch addressing this issue into ```develop```

## Files
```contracts/nft/ZapMedia.sol```
```test/ZapMarketTest.ts```
```test/ZapMediaTest.ts```
```test/AuctionHouseTest.ts```
```test/utils.ts```

## Visual
<img width="627" alt="Screen Shot 2021-11-12 at 10 39 15 AM" src="https://user-images.githubusercontent.com/58867896/141506612-d52ac1ea-f235-4cb2-96a9-218be43406d2.png">

<img width="596" alt="Screen Shot 2021-11-12 at 10 39 35 AM" src="https://user-images.githubusercontent.com/58867896/141506661-d2a171c4-5e05-424d-85d4-a6ef6b55fcae.png">