### PR TITLE
Feat/media upgrades

### DIFF
--- a/contracts/nft/MediaFactory.sol
+++ b/contracts/nft/MediaFactory.sol
@@ -79,6 +79,7 @@ contract MediaFactory is OwnableUpgradeable {
             permissive,
             _collectionMetadata
         );
+
         address proxyAddress = address(proxy);
 
         zapMarket.registerMedia(proxyAddress);

--- a/contracts/nft/MediaProxy.sol
+++ b/contracts/nft/MediaProxy.sol
@@ -3,22 +3,24 @@ pragma solidity ^0.8.4;
 pragma experimental ABIEncoderV2;
 
 import {ERC1967UpgradeUpgradeable} from '@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol';
-import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
+import {IBeacon} from '@openzeppelin/contracts/proxy/beacon/IBeacon.sol';
 
 /// @title Upgradeable proxy contract for a ZapMedia
 /// @notice This contract acts as a proxy that delegates calls for ZapMedia.
 ///         it stores the ZapMedia implementation address which can be upgraded by the admin
 /// @dev Implements the OpenZeppelin ERC1967UpgradeUpgradeable contract
 contract MediaProxy is ERC1967UpgradeUpgradeable {
-
     modifier onlyAdmin() {
-        require(msg.sender == _getAdmin(), "Only the Admin can call this function");
+        require(
+            msg.sender == _getAdmin(),
+            'Only the Admin can call this function'
+        );
         _;
     }
 
     /// @notice Constructor for the ZapMedia proxy and its implementation
     /// @dev This function is initializable and implements the OZ Initializable contract by inheiritance
-    /// @param implementation the address of the uninitialized ZapMedia contract
+    /// @param beacon the address of the Beacon contract which has the implementation contract address
     /// @param owner the intended owner of the ZapMedia contract
     /// @param name name of the collection
     /// @param symbol collection's symbol
@@ -26,7 +28,7 @@ contract MediaProxy is ERC1967UpgradeUpgradeable {
     /// @param permissive whether or not you would like this contract to be minted by everyone or just the owner
     /// @param collectionURI the metadata URI of the collection
     function initialize(
-        address implementation,
+        address beacon,
         address payable owner,
         string calldata name,
         string calldata symbol,
@@ -34,10 +36,10 @@ contract MediaProxy is ERC1967UpgradeUpgradeable {
         bool permissive,
         string calldata collectionURI
     ) public {
-        _upgradeToAndCall(
-            implementation,
+        _upgradeBeaconToAndCall(
+            beacon,
             abi.encodeWithSignature(
-                "initialize(string,string,address,bool,string)",
+                'initialize(string,string,address,bool,string)',
                 name,
                 symbol,
                 marketContractAddr,
@@ -49,15 +51,16 @@ contract MediaProxy is ERC1967UpgradeUpgradeable {
 
         _changeAdmin(msg.sender);
 
-        (bool success, bytes memory returndata) = implementation.delegatecall(
-            abi.encodeWithSignature("initTransferOwnership(address)", owner)
-        );
+        (bool success, bytes memory returndata) = (
+            IBeacon(beacon).implementation()
+        ).delegatecall(
+                abi.encodeWithSignature('initTransferOwnership(address)', owner)
+            );
 
         require(
             success && returndata.length == 0,
-            "Creating ZapMedia proxy: Can not transfer ownership of proxy"
+            'Creating ZapMedia proxy: Can not transfer ownership of proxy'
         );
-
     }
 
     /// @notice Changes the admin contract of this ERC1967 contract
@@ -68,33 +71,23 @@ contract MediaProxy is ERC1967UpgradeUpgradeable {
         _changeAdmin(newAdmin);
     }
 
-    /// @notice Upgrades the ERC1967 Proxy to a new implementation
-    /// @dev This is a wrapper function for the ERC1967 _upgradeTo function and uses a modifier
-    ///      to ensure that only the current admin contract can change the admin
-    /// @param _impl the address of the new implementaion contract
-    function upgrateTo(address _impl) external onlyAdmin {
-        _upgradeTo(_impl);
-    }
-
-    /// @notice Upgrades the ERC1967 Proxy to a new implementation and immediately calls a function on it
-    /// @dev This is a wrapper function for the ERC1967 _upgradeToAndCall function and uses a modifier
-    ///      to ensure that only the current admin contract can change the admin
-    /// @param _impl the address of the new implementaion contract
-    /// @param data calldata containing function signature and params to call once `_impl` is updated
-    function upgradeToAndCall(address _impl, bytes memory data) external onlyAdmin{
-        _upgradeToAndCall(_impl, data, false);
-    }
-
     /// @notice Get the owner of the ZapMedia implementation
     /// @dev This makes a `delegatecall`, which means that __the `owner` is stored in this proxy's state__
     /// @param _impl address of the implementation which has the getOwner function bytecode
     /// @return _implOwner address of this ZapMedia's owner
-    function getImplOwner(address _impl) public onlyAdmin returns (address _implOwner){
+    function getImplOwner(address _impl)
+        public
+        onlyAdmin
+        returns (address _implOwner)
+    {
         (bool success, bytes memory returndata) = _impl.delegatecall(
-            abi.encodeWithSignature("getOwner()")
+            abi.encodeWithSignature('getOwner()')
         );
 
-        require(success && returndata.length > 0, "Can not get the owner of this ZapMedia");
+        require(
+            success && returndata.length > 0,
+            'Can not get the owner of this ZapMedia'
+        );
         _implOwner = abi.decode(returndata, (address));
     }
 
@@ -102,34 +95,27 @@ contract MediaProxy is ERC1967UpgradeUpgradeable {
         assembly {
             calldatacopy(0, 0, calldatasize())
 
-            let result := delegatecall(
-                gas(),
-                _impl,
-                0,
-                calldatasize(),
-                0,
-                0
-            )
+            let result := delegatecall(gas(), _impl, 0, calldatasize(), 0, 0)
 
             // Copy the returned data.
             returndatacopy(0, 0, returndatasize())
 
             switch result
-                // delegatecall returns 0 on error.
-                case 0 {
-                    revert(0, returndatasize())
-                }
-                default {
-                    return(0, returndatasize())
-                }
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
             }
+            default {
+                return(0, returndatasize())
+            }
+        }
     }
 
     fallback() external {
         // ensures that the call is always made to the implementation (ZapMedia)
-        // https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies#transparent-proxies-and-function-clashes 
-        if (msg.sender != _getAdmin()){
-            _delegate(_getImplementation());
+        // https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies#transparent-proxies-and-function-clashes
+        if (msg.sender != _getAdmin()) {
+            _delegate(IBeacon(_getBeacon()).implementation());
         }
     }
 }

--- a/contracts/nft/develop/AuctionHouseOld.sol
+++ b/contracts/nft/develop/AuctionHouseOld.sol
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+import {SafeMathUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol';
+import {IERC721Upgradeable, IERC165Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol';
+import {ReentrancyGuardUpgradeable} from '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
+import {IERC20Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol';
+import {SafeERC20Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol';
+import {Counters} from '@openzeppelin/contracts/utils/Counters.sol';
+import {IMarket} from './interfaces/IMarket.sol';
+import {Decimal} from './Decimal.sol';
+import {IMedia} from './interfaces/IMedia.sol';
+import {IAuctionHouse} from './interfaces/IAuctionHouse.sol';
+import {Initializable} from '@openzeppelin/contracts/proxy/utils/Initializable.sol';
+
+interface IWETH {
+    function deposit() external payable;
+
+    function withdraw(uint256 wad) external;
+
+    function transfer(address to, uint256 value) external returns (bool);
+}
+
+interface IMediaExtended is IMedia {
+    function marketContract() external returns (address);
+}
+
+/**
+ * @title An open auction house, enabling collectors and curators to run their own auctions
+ */
+contract AuctionHouseOld is IAuctionHouse, ReentrancyGuardUpgradeable {
+    using SafeMathUpgradeable for uint256;
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+    using Counters for Counters.Counter;
+
+    // The minimum amount of time left in an auction after a new bid is created
+    uint256 public constant timeBuffer = 15 * 60;
+
+    // The minimum percentage difference between the last bid amount and the current bid.
+    uint8 public constant minBidIncrementPercentage = 5;
+
+    // / The address of the WETH contract, so that any ETH transferred can be handled as an ERC-20
+    address public wethAddress;
+
+    // verified Market Contract
+    address private marketContract;
+
+    // A mapping of all of the auctions currently running.
+    mapping(uint256 => IAuctionHouse.Auction) public auctions;
+
+    mapping(address => mapping(uint256 => TokenDetails)) private tokenDetails;
+
+    bytes4 private constant interfaceId = type(IERC721Upgradeable).interfaceId; // 721 interface id
+    uint8 public constant hundredPercent = 100;
+    Counters.Counter private _auctionIdTracker;
+
+    /**
+     * @notice Require that the specified auction exists
+     */
+    modifier auctionExists(uint256 auctionId) {
+        require(_exists(auctionId), "Auction doesn't exist");
+        _;
+    }
+
+    /*
+     * Constructor
+     */
+    function initialize(address _weth, address _marketContract)
+        public
+        initializer
+    {
+        __ReentrancyGuard_init();
+        wethAddress = _weth;
+        marketContract = _marketContract;
+    }
+
+    function setTokenDetails(uint256 tokenId, address mediaContract) internal {
+        require(
+            mediaContract != address(0),
+            'AuctionHouseOld: Media Contract Address can not be the zero address'
+        );
+
+        if (tokenDetails[mediaContract][tokenId].mediaContract != address(0)) {
+            require(
+                mediaContract ==
+                    tokenDetails[mediaContract][tokenId].mediaContract,
+                'Token is already set for a different collection'
+            );
+        }
+
+        tokenDetails[mediaContract][tokenId] = TokenDetails({
+            tokenId: tokenId,
+            mediaContract: mediaContract
+        });
+    }
+
+    /**
+     * @notice Create an auction.
+     * @dev Store the auction details in the auctions mapping and emit an AuctionCreated event.
+     * If there is no curator, or if the curator is the auction creator, automatically approve the auction.
+     */
+    function createAuction(
+        uint256 tokenId,
+        address mediaContract,
+        uint256 duration,
+        uint256 reservePrice,
+        address payable curator,
+        uint8 curatorFeePercentage,
+        address auctionCurrency
+    ) public override nonReentrant returns (uint256) {
+        require(
+            duration >= 60 * 15,
+            'Your auction needs to go on for at least 15 minutes'
+        );
+        require(
+            IERC165Upgradeable(mediaContract).supportsInterface(interfaceId),
+            'tokenContract does not support ERC721 interface'
+        );
+        require(
+            IMediaExtended(mediaContract).marketContract() == marketContract,
+            "This market contract is not from Zap's NFT MarketPlace"
+        );
+        require(
+            IMarket(marketContract).isRegistered(mediaContract),
+            'Media contract is not registered with the marketplace'
+        );
+        require(
+            curatorFeePercentage < hundredPercent,
+            'curatorFeePercentage must be less than 100'
+        );
+        address tokenOwner = IERC721Upgradeable(mediaContract).ownerOf(tokenId);
+
+        require(
+            msg.sender ==
+                IERC721Upgradeable(mediaContract).getApproved(tokenId) ||
+                msg.sender == tokenOwner,
+            'Caller must be approved or owner for token id'
+        );
+        uint256 auctionId = _auctionIdTracker.current();
+        _auctionIdTracker.increment();
+
+        setTokenDetails(tokenId, mediaContract);
+
+        auctions[auctionId] = Auction({
+            token: tokenDetails[mediaContract][tokenId],
+            approved: false,
+            amount: 0,
+            duration: duration,
+            firstBidTime: 0,
+            reservePrice: reservePrice,
+            curatorFeePercentage: curatorFeePercentage,
+            tokenOwner: tokenOwner,
+            bidder: payable(address(0)),
+            curator: curator,
+            auctionCurrency: auctionCurrency
+        });
+
+        IERC721Upgradeable(mediaContract).transferFrom(
+            tokenOwner,
+            address(this),
+            tokenId
+        );
+
+        emit AuctionCreated(
+            auctionId,
+            tokenId,
+            mediaContract,
+            duration,
+            reservePrice,
+            tokenOwner,
+            curator,
+            curatorFeePercentage,
+            auctionCurrency
+        );
+
+        if (
+            auctions[auctionId].curator == address(0) || curator == tokenOwner
+        ) {
+            _approveAuction(auctionId, true);
+        }
+
+        return auctionId;
+    }
+
+    /**
+     * @notice Approve an auction, opening up the auction for bids.
+     * @dev Only callable by the curator. Cannot be called if the auction has already started.
+     */
+    function startAuction(uint256 auctionId, bool approved)
+        external
+        override
+        auctionExists(auctionId)
+    {
+        require(
+            msg.sender == auctions[auctionId].curator,
+            'Must be auction curator'
+        );
+
+        require(
+            auctions[auctionId].firstBidTime == 0,
+            'Auction has already started'
+        );
+        _approveAuction(auctionId, approved);
+    }
+
+    function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice)
+        external
+        override
+        auctionExists(auctionId)
+    {
+        require(
+            msg.sender == auctions[auctionId].curator ||
+                msg.sender == auctions[auctionId].tokenOwner,
+            'Must be auction curator or token owner'
+        );
+        require(
+            auctions[auctionId].firstBidTime == 0,
+            'Auction has already started'
+        );
+
+        auctions[auctionId].reservePrice = reservePrice;
+
+        emit AuctionReservePriceUpdated(
+            auctionId,
+            auctions[auctionId].token.tokenId,
+            auctions[auctionId].token.mediaContract,
+            reservePrice
+        );
+    }
+
+    /**
+     * @notice Create a bid on a token, with a given amount.
+     * @dev If provided a valid bid, transfers the provided amount to this contract.
+     * If the auction is run in native ETH, the ETH is wrapped so it can be identically to other
+     * auction currencies in this contract.
+     */
+    function createBid(
+        uint256 auctionId,
+        uint256 amount,
+        address mediaContract
+    ) external payable override auctionExists(auctionId) nonReentrant {
+        address payable lastBidder = auctions[auctionId].bidder;
+        require(
+            auctions[auctionId].approved,
+            'Auction must be approved by curator'
+        );
+        require(
+            auctions[auctionId].firstBidTime != 0,
+            "Auction hasn't started yet"
+        );
+        require(
+            block.timestamp <
+                auctions[auctionId].firstBidTime.add(
+                    auctions[auctionId].duration
+                ),
+            'Auction expired'
+        );
+        require(
+            amount >= auctions[auctionId].reservePrice,
+            'Must send at least reservePrice'
+        );
+
+        require(
+            amount >=
+                auctions[auctionId].amount.add(
+                    auctions[auctionId]
+                        .amount
+                        .mul(minBidIncrementPercentage)
+                        .div(hundredPercent)
+                ),
+            'Must send more than last bid by minBidIncrementPercentage amount'
+        );
+
+        require(
+            IERC165Upgradeable(mediaContract).supportsInterface(interfaceId),
+            "Doesn't support NFT interface"
+        );
+
+        // For Zap NFT Marketplace Protocol, ensure that the bid is valid for the current bidShare configuration
+        if (auctions[auctionId].token.mediaContract == mediaContract) {
+            require(
+                IMarket(IMediaExtended(mediaContract).marketContract())
+                    .isValidBid(
+                        mediaContract,
+                        auctions[auctionId].token.tokenId,
+                        amount
+                    ),
+                'Bid invalid for share splitting'
+            );
+        }
+
+        // If this is the first valid bid we should refund the last bidder
+        if (lastBidder != address(0)) {
+            _handleOutgoingBid(
+                lastBidder,
+                auctions[auctionId].amount,
+                auctions[auctionId].auctionCurrency
+            );
+        }
+
+        _handleIncomingBid(amount, auctions[auctionId].auctionCurrency);
+
+        auctions[auctionId].amount = amount;
+
+        auctions[auctionId].bidder = payable(msg.sender);
+
+        bool extended = false;
+        // at this point we know that the timestamp is less than start + duration (since the auction would be over, otherwise)
+        // we want to know by how much the timestamp is less than start + duration
+        // if the difference is less than the timeBuffer, increase the duration by the timeBuffer
+        uint256 timeDiff = auctions[auctionId]
+            .firstBidTime
+            .add(auctions[auctionId].duration)
+            .sub(block.timestamp);
+
+        if (timeDiff < timeBuffer) {
+            // Playing code golf for gas optimization:
+            // uint256 expectedEnd = auctions[auctionId].firstBidTime.add(auctions[auctionId].duration);
+            // uint256 timeRemaining = expectedEnd.sub(block.timestamp);
+            // uint256 timeToAdd = timeBuffer.sub(timeRemaining);
+            // uint256 newDuration = auctions[auctionId].duration.add(timeToAdd);
+            uint256 oldDuration = auctions[auctionId].duration;
+            auctions[auctionId].duration = oldDuration.add(
+                timeBuffer.sub(timeDiff)
+            );
+            extended = true;
+        }
+
+        emit AuctionBid(
+            auctionId,
+            auctions[auctionId].token.tokenId,
+            auctions[auctionId].token.mediaContract,
+            msg.sender,
+            amount,
+            lastBidder == address(0), // firstBid boolean
+            extended
+        );
+
+        if (extended) {
+            emit AuctionDurationExtended(
+                auctionId,
+                auctions[auctionId].token.tokenId,
+                auctions[auctionId].token.mediaContract,
+                auctions[auctionId].duration
+            );
+        }
+    }
+
+    /**
+     * @notice End an auction, finalizing the bid on Zap NFT Marketplace if applicable and paying out the respective parties.
+     * @dev If for some reason the auction cannot be finalized (invalid token recipient, for example),
+     * The auction is reset and the NFT is transferred back to the auction creator.
+     */
+    function endAuction(uint256 auctionId, address mediaContract)
+        external
+        override
+        auctionExists(auctionId)
+        nonReentrant
+    {
+        require(
+            uint256(auctions[auctionId].firstBidTime) != 0,
+            "Auction hasn't begun"
+        );
+        require(
+            block.timestamp >=
+                auctions[auctionId].firstBidTime.add(
+                    auctions[auctionId].duration
+                ),
+            "Auction hasn't completed"
+        );
+
+        address currency = auctions[auctionId].auctionCurrency == address(0)
+            ? wethAddress
+            : auctions[auctionId].auctionCurrency;
+        uint256 curatorFee = 0;
+
+        uint256 tokenOwnerProfit = auctions[auctionId].amount;
+
+        if (auctions[auctionId].token.mediaContract == mediaContract) {
+            // If the auction is running on mediaContract, settle it on the protocol
+            (
+                bool success,
+                uint256 remainingProfit
+            ) = _handleZapAuctionSettlement(auctionId, mediaContract);
+
+            tokenOwnerProfit = remainingProfit;
+
+            if (success != true) {
+                _handleOutgoingBid(
+                    auctions[auctionId].bidder,
+                    auctions[auctionId].amount,
+                    auctions[auctionId].auctionCurrency
+                );
+                _cancelAuction(auctionId);
+                return;
+            }
+        } else {
+            // Otherwise, transfer the token to the winner and pay out the participants below
+            try
+                IERC721Upgradeable(auctions[auctionId].token.mediaContract)
+                    .safeTransferFrom(
+                        address(this),
+                        auctions[auctionId].bidder,
+                        auctions[auctionId].token.tokenId
+                    )
+            {} catch {
+                _handleOutgoingBid(
+                    auctions[auctionId].bidder,
+                    auctions[auctionId].amount,
+                    auctions[auctionId].auctionCurrency
+                );
+                _cancelAuction(auctionId);
+                return;
+            }
+        }
+
+        if (auctions[auctionId].curator != address(0)) {
+            curatorFee = tokenOwnerProfit
+                .mul(auctions[auctionId].curatorFeePercentage)
+                .div(hundredPercent);
+
+            tokenOwnerProfit = tokenOwnerProfit.sub(curatorFee);
+
+            _handleOutgoingBid(
+                auctions[auctionId].curator,
+                curatorFee,
+                auctions[auctionId].auctionCurrency
+            );
+        }
+        _handleOutgoingBid(
+            auctions[auctionId].tokenOwner,
+            tokenOwnerProfit,
+            auctions[auctionId].auctionCurrency
+        );
+
+        emit AuctionEnded(
+            auctionId,
+            auctions[auctionId].token.tokenId,
+            auctions[auctionId].token.mediaContract,
+            auctions[auctionId].tokenOwner,
+            auctions[auctionId].curator,
+            auctions[auctionId].bidder,
+            tokenOwnerProfit,
+            curatorFee,
+            currency
+        );
+        delete auctions[auctionId];
+    }
+
+    /**
+     * @notice Cancel an auction.
+     * @dev Transfers the NFT back to the auction creator and emits an AuctionCanceled event
+     */
+    function cancelAuction(uint256 auctionId)
+        external
+        override
+        nonReentrant
+        auctionExists(auctionId)
+    {
+        require(
+            auctions[auctionId].tokenOwner == msg.sender ||
+                auctions[auctionId].curator == msg.sender,
+            'Can only be called by auction creator or curator'
+        );
+        require(
+            auctions[auctionId].bidder == address(0),
+            "You can't cancel an auction that has a bid"
+        );
+        _cancelAuction(auctionId);
+    }
+
+    /**
+     * @dev Given an amount and a currency, transfer the currency to this contract.
+     * If the currency is ETH (0x0), attempt to wrap the amount as WETH
+     */
+    function _handleIncomingBid(uint256 amount, address currency) internal {
+        // If this is an ETH bid, ensure they sent enough and convert it to WETH under the hood
+
+        if (currency == address(0)) {
+            require(
+                msg.value == amount,
+                'Sent ETH Value does not match specified bid amount'
+            );
+
+            IWETH(wethAddress).deposit{value: amount}();
+        } else {
+            require(
+                msg.value == 0,
+                'AuctionHouseOld: Ether is not required for this transaction'
+            );
+            // We must check the balance that was actually transferred to the auction,
+            // as some tokens impose a transfer fee and would not actually transfer the
+            // full amount to the market, resulting in potentally locked funds
+            IERC20Upgradeable token = IERC20Upgradeable(currency);
+            uint256 beforeBalance = token.balanceOf(address(this));
+            token.safeTransferFrom(msg.sender, address(this), amount);
+            uint256 afterBalance = token.balanceOf(address(this));
+            require(
+                beforeBalance.add(amount) == afterBalance,
+                'Token transfer call did not transfer expected amount'
+            );
+        }
+    }
+
+    function _handleOutgoingBid(
+        address to,
+        uint256 amount,
+        address currency
+    ) internal {
+        // If the auction is in ETH, unwrap it from its underlying WETH and try to send it to the recipient.
+        if (currency == address(0)) {
+            IWETH(wethAddress).withdraw(amount);
+
+            // If the ETH transfer fails (sigh), rewrap the ETH and try send it as WETH.
+            if (!_safeTransferETH(to, amount)) {
+                IWETH(wethAddress).deposit{value: amount}();
+                IERC20Upgradeable(wethAddress).safeTransfer(to, amount);
+            }
+        } else {
+            IERC20Upgradeable(currency).safeTransfer(to, amount);
+        }
+    }
+
+    function _safeTransferETH(address to, uint256 value)
+        internal
+        returns (bool)
+    {
+        (bool success, ) = to.call{value: value}(new bytes(0));
+        return success;
+    }
+
+    function _cancelAuction(uint256 auctionId) internal {
+        address tokenOwner = auctions[auctionId].tokenOwner;
+        IERC721Upgradeable(auctions[auctionId].token.mediaContract)
+            .safeTransferFrom(
+                address(this),
+                tokenOwner,
+                auctions[auctionId].token.tokenId
+            );
+
+        emit AuctionCanceled(
+            auctionId,
+            auctions[auctionId].token.tokenId,
+            auctions[auctionId].token.mediaContract,
+            tokenOwner
+        );
+        delete auctions[auctionId];
+    }
+
+    function _approveAuction(uint256 auctionId, bool approved) internal {
+        auctions[auctionId].approved = approved;
+
+        auctions[auctionId].firstBidTime = block.timestamp;
+
+        emit AuctionApprovalUpdated(
+            auctionId,
+            auctions[auctionId].token.tokenId,
+            auctions[auctionId].token.mediaContract,
+            approved
+        );
+    }
+
+    function _exists(uint256 auctionId) internal view returns (bool) {
+        return auctions[auctionId].tokenOwner != address(0);
+    }
+
+    function _handleZapAuctionSettlement(
+        uint256 auctionId,
+        address mediaContract
+    ) internal returns (bool, uint256) {
+        require(
+            IMediaExtended(mediaContract).marketContract() == marketContract,
+            "This market contract is not from Zap's NFT MarketPlace"
+        );
+        require(
+            IMarket(marketContract).isRegistered(mediaContract),
+            'This Media Contract is unauthorised to settle auctions'
+        );
+        address currency = auctions[auctionId].auctionCurrency == address(0)
+            ? wethAddress
+            : auctions[auctionId].auctionCurrency;
+
+        IMarket.Bid memory bid = IMarket.Bid({
+            amount: auctions[auctionId].amount,
+            currency: currency,
+            bidder: address(this),
+            recipient: auctions[auctionId].bidder,
+            sellOnShare: Decimal.D256(0)
+        });
+
+        IERC20Upgradeable(currency).approve(
+            IMediaExtended(mediaContract).marketContract(),
+            bid.amount
+        );
+
+        IMedia(mediaContract).setBid(auctions[auctionId].token.tokenId, bid);
+
+        // 1e18
+        uint256 beforeBalance = IERC20Upgradeable(currency).balanceOf(
+            address(this)
+        );
+
+        try
+            IMedia(mediaContract).acceptBid(
+                auctions[auctionId].token.tokenId,
+                bid
+            )
+        {} catch {
+            // If the underlying NFT transfer here fails, we should cancel the auction and refund the winner
+            IMediaExtended(mediaContract).removeBid(
+                auctions[auctionId].token.tokenId
+            );
+            return (false, 0);
+        }
+
+        // 5e17
+        uint256 afterBalance = IERC20Upgradeable(currency).balanceOf(
+            address(this)
+        );
+
+        // We have to calculate the amount to send to the token owner here in case there was a
+        // sell-on share on the token
+
+        return (true, afterBalance.sub(beforeBalance));
+    }
+
+    receive() external payable {
+        require(
+            msg.sender == wethAddress,
+            'AuctionHouseOld: Fallback function receive() - sender is not WETH'
+        );
+    }
+}

--- a/contracts/nft/develop/Decimal.sol
+++ b/contracts/nft/develop/Decimal.sol
@@ -1,0 +1,74 @@
+/*
+    Copyright 2019 dYdX Trading Inc.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+/**
+ * NOTE: This file is a clone of the dydx protocol's Decimal.sol contract. It was forked from https://github.com/dydxprotocol/solo
+ * at commit 2d8454e02702fe5bc455b848556660629c3cad36
+ *
+ * It has two modifications:
+ *      - it uses a newer solidity in the pragma to match the rest of the contract suite of this project
+ *      - it uses BASE_POW to add a level of abstraction for BASE
+ */
+
+import {SafeMath} from '@openzeppelin/contracts/utils/math/SafeMath.sol';
+import {Math} from './Math.sol';
+
+/**
+ * @title Decimal
+ *
+ * Library that defines a fixed-point number with 18 decimal places.
+ */
+library Decimal {
+    using SafeMath for uint256;
+
+    // ============ Constants ============
+
+    uint256 constant BASE_POW = 18;
+    uint256 constant BASE = 10**BASE_POW;
+
+    // ============ Structs ============
+
+    struct D256 {
+        uint256 value;
+    }
+
+    // ============ Functions ============
+
+    function one() internal pure returns (D256 memory) {
+        return D256({value: BASE});
+    }
+
+    function onePlus(D256 memory d) internal pure returns (D256 memory) {
+        return D256({value: d.value.add(BASE)});
+    }
+
+    function mul(uint256 target, D256 memory d)
+        internal
+        pure
+        returns (uint256)
+    {
+        return Math.getPartial(target, d.value, BASE);
+    }
+
+    function div(uint256 target, D256 memory d)
+        internal
+        pure
+        returns (uint256)
+    {
+        return Math.getPartial(target, BASE, d.value);
+    }
+}

--- a/contracts/nft/develop/ERC721.sol
+++ b/contracts/nft/develop/ERC721.sol
@@ -1,0 +1,608 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.4;
+
+/**
+ * NOTE: This file is a clone of the OpenZeppelin ERC721.sol contract. It was forked from https://github.com/OpenZeppelin/openzeppelin-contracts
+ * at commit 1ada3b633e5bfd9d4ffe0207d64773a11f5a7c40
+ *
+ *
+ * The following functions needed to be modified, prompting this clone:
+ *  - `_tokenURIs` visibility was changed from private to internal to support updating URIs after minting
+ *  - `_baseURI` visibiility was changed from private to internal to support fetching token URI even after the token was burned
+ *  - `_INTERFACE_ID_ERC721_METADATA` is no longer registered as an interface because _tokenURI now returns raw content instead of a JSON file, and supports updatable URIs
+ *  - `_approve` visibility was changed from private to internal to support EIP-2612 flavored permits and approval revocation by an approved address
+ */
+
+import '@openzeppelin/contracts/utils/Context.sol';
+import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol';
+import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
+import '@openzeppelin/contracts/utils/introspection/ERC165Storage.sol';
+import '@openzeppelin/contracts/utils/introspection/ERC165.sol';
+import '@openzeppelin/contracts/utils/math/SafeMath.sol';
+import '@openzeppelin/contracts/utils/Address.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableMap.sol';
+import '@openzeppelin/contracts/utils/Strings.sol';
+
+/**
+ * @title ERC721 Non-Fungible Token Standard basic implementation
+ * @dev see https://eips.ethereum.org/EIPS/eip-721
+ */
+contract ERC721 is
+    Context,
+    ERC165Storage,
+    IERC721,
+    IERC721Metadata,
+    IERC721Enumerable
+{
+    using SafeMath for uint256;
+    using Address for address;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using EnumerableMap for EnumerableMap.UintToAddressMap;
+    using Strings for uint256;
+
+    // Equals to `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
+    // which can be also obtained as `IERC721Receiver(0).onERC721Received.selector`
+    bytes4 private constant _ERC721_RECEIVED = 0x150b7a02;
+
+    // Mapping from holder address to their (enumerable) set of owned tokens
+    mapping(address => EnumerableSet.UintSet) private _holderTokens;
+
+    // Enumerable mapping from token ids to their owners
+    EnumerableMap.UintToAddressMap private _tokenOwners;
+
+    // Mapping from token ID to approved address
+    mapping(uint256 => address) private _tokenApprovals;
+
+    // Mapping from owner to operator approvals
+    mapping(address => mapping(address => bool)) private _operatorApprovals;
+
+    // Token name
+    string private _name;
+
+    // Token symbol
+    string private _symbol;
+
+    // Optional mapping for token URIs
+    mapping(uint256 => string) internal _tokenURIs;
+
+    // Base URI
+    string internal _baseURI;
+
+    /*
+     *     bytes4(keccak256('balanceOf(address)')) == 0x70a08231
+     *     bytes4(keccak256('ownerOf(uint256)')) == 0x6352211e
+     *     bytes4(keccak256('approve(address,uint256)')) == 0x095ea7b3
+     *     bytes4(keccak256('getApproved(uint256)')) == 0x081812fc
+     *     bytes4(keccak256('setApprovalForAll(address,bool)')) == 0xa22cb465
+     *     bytes4(keccak256('isApprovedForAll(address,address)')) == 0xe985e9c5
+     *     bytes4(keccak256('transferFrom(address,address,uint256)')) == 0x23b872dd
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256)')) == 0x42842e0e
+     *     bytes4(keccak256('safeTransferFrom(address,address,uint256,bytes)')) == 0xb88d4fde
+     *
+     *     => 0x70a08231 ^ 0x6352211e ^ 0x095ea7b3 ^ 0x081812fc ^
+     *        0xa22cb465 ^ 0xe985e9c5 ^ 0x23b872dd ^ 0x42842e0e ^ 0xb88d4fde == 0x80ac58cd
+     */
+    bytes4 private constant _INTERFACE_ID_ERC721 = 0x80ac58cd;
+
+    /*
+     *     bytes4(keccak256('totalSupply()')) == 0x18160ddd
+     *     bytes4(keccak256('tokenOfOwnerByIndex(address,uint256)')) == 0x2f745c59
+     *     bytes4(keccak256('tokenByIndex(uint256)')) == 0x4f6ccce7
+     *
+     *     => 0x18160ddd ^ 0x2f745c59 ^ 0x4f6ccce7 == 0x780e9d63
+     */
+    bytes4 private constant _INTERFACE_ID_ERC721_ENUMERABLE = 0x780e9d63;
+
+    /**
+     * @dev Initializes the contract by setting a `name` and a `symbol` to the token collection.
+     */
+    constructor(string memory __name, string memory __symbol) {
+        _name = __name;
+        _symbol = __symbol;
+
+        // register the supported interfaces to conform to ERC721 via ERC165
+        _registerInterface(_INTERFACE_ID_ERC721);
+        _registerInterface(_INTERFACE_ID_ERC721_ENUMERABLE);
+    }
+
+    /**
+     * @dev See {IERC721-balanceOf}.
+     */
+    function balanceOf(address owner) public view override returns (uint256) {
+        require(
+            owner != address(0),
+            'ERC721: balance query for the zero address'
+        );
+
+        return _holderTokens[owner].length();
+    }
+
+    /**
+     * @dev See {IERC721-ownerOf}.
+     */
+    function ownerOf(uint256 tokenID) public view override returns (address) {
+        return
+            _tokenOwners.get(
+                tokenID,
+                'ERC721: owner query for nonexistent token'
+            );
+    }
+
+    /**
+     * @dev See {IERC721Metadata-name}.
+     */
+    function name() public view override returns (string memory) {
+        return _name;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-symbol}.
+     */
+    function symbol() public view override returns (string memory) {
+        return _symbol;
+    }
+
+    /**
+     * @dev See {IERC721Metadata-tokenURI}.
+     */
+    function tokenURI(uint256 tokenID)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        require(
+            _exists(tokenID),
+            'ERC721Metadata: URI query for nonexistent token'
+        );
+
+        string memory _tokenURI = _tokenURIs[tokenID];
+
+        // If there is no base URI, return the token URI.
+        if (bytes(_baseURI).length == 0) {
+            return _tokenURI;
+        }
+        // If both are set, concatenate the baseURI and tokenURI (via abi.encodePacked).
+        if (bytes(_tokenURI).length > 0) {
+            return string(abi.encodePacked(_baseURI, _tokenURI));
+        }
+        // If there is a baseURI but no tokenURI, concatenate the tokenID to the baseURI.
+        return string(abi.encodePacked(_baseURI, tokenID.toString()));
+    }
+
+    /**
+     * @dev Returns the base URI set via {_setBaseURI}. This will be
+     * automatically added as a prefix in {tokenURI} to each token's URI, or
+     * to the token ID if no specific URI is set for that token ID.
+     */
+    function baseURI() public view returns (string memory) {
+        return _baseURI;
+    }
+
+    /**
+     * @dev See {IERC721Enumerable-tokenOfOwnerByIndex}.
+     */
+    function tokenOfOwnerByIndex(address owner, uint256 index)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        return _holderTokens[owner].at(index);
+    }
+
+    /**
+     * @dev See {IERC721Enumerable-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        // _tokenOwners are indexed by tokenIDs, so .length() returns the number of tokenIDs
+        return _tokenOwners.length();
+    }
+
+    /**
+     * @dev See {IERC721Enumerable-tokenByIndex}.
+     */
+    function tokenByIndex(uint256 index)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        (uint256 tokenID, ) = _tokenOwners.at(index);
+        return tokenID;
+    }
+
+    /**
+     * @dev See {IERC721-approve}.
+     */
+    function approve(address to, uint256 tokenID) public virtual override {
+        address owner = ownerOf(tokenID);
+
+        require(to != owner, 'ERC721: approval to current owner');
+
+        require(
+            _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
+            'ERC721: approve caller is not owner nor approved for all'
+        );
+
+        _approve(to, tokenID);
+    }
+
+    /**
+     * @dev See {IERC721-getApproved}.
+     */
+    function getApproved(uint256 tokenID)
+        public
+        view
+        override
+        returns (address)
+    {
+        require(
+            _exists(tokenID),
+            'ERC721: approved query for nonexistent token'
+        );
+
+        return _tokenApprovals[tokenID];
+    }
+
+    /**
+     * @dev See {IERC721-setApprovalForAll}.
+     */
+    function setApprovalForAll(address operator, bool approved)
+        public
+        virtual
+        override
+    {
+        require(operator != _msgSender(), 'ERC721: approve to caller');
+
+        _operatorApprovals[_msgSender()][operator] = approved;
+        emit ApprovalForAll(_msgSender(), operator, approved);
+    }
+
+    /**
+     * @dev See {IERC721-isApprovedForAll}.
+     */
+    function isApprovedForAll(address owner, address operator)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return _operatorApprovals[owner][operator];
+    }
+
+    /**
+     * @dev See {IERC721-transferFrom}.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 tokenID
+    ) public virtual override {
+        //solhint-disable-next-line max-line-length
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenID),
+            'ERC721: transfer caller is not owner nor approved'
+        );
+
+        _transfer(from, to, tokenID);
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenID
+    ) public virtual override {
+        safeTransferFrom(from, to, tokenID, '');
+    }
+
+    /**
+     * @dev See {IERC721-safeTransferFrom}.
+     */
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 tokenID,
+        bytes memory _data
+    ) public virtual override {
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenID),
+            'ERC721: transfer caller is not owner nor approved'
+        );
+        _safeTransfer(from, to, tokenID, _data);
+    }
+
+    /**
+     * @dev Safely transfers `tokenID` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * `_data` is additional data, it has no specified format and it is sent in call to `to`.
+     *
+     * This internal function is equivalent to {safeTransferFrom}, and can be used to e.g.
+     * implement alternative mechanisms to perform token transfer, such as signature-based.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenID` token must exist and be owned by `from`.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeTransfer(
+        address from,
+        address to,
+        uint256 tokenID,
+        bytes memory _data
+    ) internal virtual {
+        _transfer(from, to, tokenID);
+        require(
+            _checkOnERC721Received(from, to, tokenID, _data),
+            'ERC721: transfer to non ERC721Receiver implementer'
+        );
+    }
+
+    /**
+     * @dev Returns whether `tokenID` exists.
+     *
+     * Tokens can be managed by their owner or approved accounts via {approve} or {setApprovalForAll}.
+     *
+     * Tokens start existing when they are minted (`_mint`),
+     * and stop existing when they are burned (`_burn`).
+     */
+    function _exists(uint256 tokenID) internal view returns (bool) {
+        return _tokenOwners.contains(tokenID);
+    }
+
+    /**
+     * @dev Returns whether `spender` is allowed to manage `tokenID`.
+     *
+     * Requirements:
+     *
+     * - `tokenID` must exist.
+     */
+    function _isApprovedOrOwner(address spender, uint256 tokenID)
+        internal
+        view
+        returns (bool)
+    {
+        require(
+            _exists(tokenID),
+            'ERC721: operator query for nonexistent token'
+        );
+        address owner = ownerOf(tokenID);
+        return (spender == owner ||
+            getApproved(tokenID) == spender ||
+            isApprovedForAll(owner, spender));
+    }
+
+    /**
+     * @dev Public method which returns whether `spender` is allowed to manage `tokenID`.
+     *
+     * Requirements:
+     *
+     * - `tokenID` must exist.
+     */
+    function isApprovedOrOwner(address spender, uint256 tokenID)
+        public
+        view
+        returns (bool)
+    {
+        return _isApprovedOrOwner(spender, tokenID);
+    }
+
+    /**
+     * @dev Safely mints `tokenID` and transfers it to `to`.
+     *
+     * Requirements:
+     d*
+     * - `tokenID` must not exist.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _safeMint(address to, uint256 tokenID) internal virtual {
+        _safeMint(to, tokenID, '');
+    }
+
+    /**
+     * @dev Same as {xref-ERC721-_safeMint-address-uint256-}[`_safeMint`], with an additional `data` parameter which is
+     * forwarded in {IERC721Receiver-onERC721Received} to contract recipients.
+     */
+    function _safeMint(
+        address to,
+        uint256 tokenID,
+        bytes memory _data
+    ) internal virtual {
+        _mint(to, tokenID);
+        require(
+            _checkOnERC721Received(address(0), to, tokenID, _data),
+            'ERC721: transfer to non ERC721Receiver implementer'
+        );
+    }
+
+    /**
+     * @dev Mints `tokenID` and transfers it to `to`.
+     *
+     * WARNING: Usage of this method is discouraged, use {_safeMint} whenever possible
+     *
+     * Requirements:
+     *
+     * - `tokenID` must not exist.
+     * - `to` cannot be the zero address.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _mint(address to, uint256 tokenID) internal virtual {
+        require(to != address(0), 'ERC721: mint to the zero address');
+        require(!_exists(tokenID), 'ERC721: token already minted');
+
+        _beforeTokenTransfer(address(0), to, tokenID);
+
+        _holderTokens[to].add(tokenID);
+
+        _tokenOwners.set(tokenID, to);
+
+        emit Transfer(address(0), to, tokenID);
+    }
+
+    /**
+     * @dev Destroys `tokenID`.
+     * The approval is cleared when the token is burned.
+     *
+     * Requirements:
+     *
+     * - `tokenID` must exist.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _burn(uint256 tokenID) internal virtual {
+        address owner = ownerOf(tokenID);
+
+        _beforeTokenTransfer(owner, address(0), tokenID);
+
+        // Clear approvals
+        _approve(address(0), tokenID);
+
+        // Clear metadata (if any)
+        if (bytes(_tokenURIs[tokenID]).length != 0) {
+            delete _tokenURIs[tokenID];
+        }
+
+        _holderTokens[owner].remove(tokenID);
+
+        _tokenOwners.remove(tokenID);
+
+        emit Transfer(owner, address(0), tokenID);
+    }
+
+    /**
+     * @dev Transfers `tokenID` from `from` to `to`.
+     *  As opposed to {transferFrom}, this imposes no restrictions on msg.sender.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - `tokenID` token must be owned by `from`.
+     *
+     * Emits a {Transfer} event.
+     */
+    function _transfer(
+        address from,
+        address to,
+        uint256 tokenID
+    ) internal virtual {
+        require(
+            ownerOf(tokenID) == from,
+            'ERC721: transfer of token that is not own'
+        );
+        require(to != address(0), 'ERC721: transfer to the zero address');
+
+        _beforeTokenTransfer(from, to, tokenID);
+
+        // Clear approvals from the previous owner
+        _approve(address(0), tokenID);
+
+        _holderTokens[from].remove(tokenID);
+        _holderTokens[to].add(tokenID);
+
+        _tokenOwners.set(tokenID, to);
+
+        emit Transfer(from, to, tokenID);
+    }
+
+    /**
+     * @dev Sets `_tokenURI` as the tokenURI of `tokenID`.
+     *
+     * Requirements:
+     *
+     * - `tokenID` must exist.
+     */
+    function _setTokenURI(uint256 tokenID, string memory _tokenURI)
+        internal
+        virtual
+    {
+        require(
+            _exists(tokenID),
+            'ERC721Metadata: URI set of nonexistent token'
+        );
+        _tokenURIs[tokenID] = _tokenURI;
+    }
+
+    /**
+     * @dev Internal function to set the base URI for all token IDs. It is
+     * automatically added as a prefix to the value returned in {tokenURI},
+     * or to the token ID if {tokenURI} is empty.
+     */
+    function _setBaseURI(string memory baseURI_) internal virtual {
+        _baseURI = baseURI_;
+    }
+
+    /**
+     * @dev Internal function to invoke {IERC721Receiver-onERC721Received} on a target address.
+     * The call is not executed if the target address is not a contract.
+     *
+     * @param from address representing the previous owner of the given token ID
+     * @param to target address that will receive the tokens
+     * @param tokenID uint256 ID of the token to be transferred
+     * @param _data bytes optional data to send along with the call
+     * @return bool whether the call correctly returned the expected magic value
+     */
+    function _checkOnERC721Received(
+        address from,
+        address to,
+        uint256 tokenID,
+        bytes memory _data
+    ) private returns (bool) {
+        if (!to.isContract()) {
+            return true;
+        }
+        bytes memory returndata = to.functionCall(
+            abi.encodeWithSelector(
+                IERC721Receiver(to).onERC721Received.selector,
+                _msgSender(),
+                from,
+                tokenID,
+                _data
+            ),
+            'ERC721: transfer to non ERC721Receiver implementer'
+        );
+        bytes4 retval = abi.decode(returndata, (bytes4));
+        return (retval == _ERC721_RECEIVED);
+    }
+
+    function _approve(address to, uint256 tokenID) internal {
+        _tokenApprovals[tokenID] = to;
+        emit Approval(ownerOf(tokenID), to, tokenID);
+    }
+
+    /**
+     * @dev Hook that is called before any token transfer. This includes minting
+     * and burning.
+     *
+     * Calling conditions:
+     *
+     * - When `from` and `to` are both non-zero, ``from``'s `tokenID` will be
+     * transferred to `to`.
+     * - When `from` is zero, `tokenID` will be minted for `to`.
+     * - When `to` is zero, ``from``'s `tokenID` will be burned.
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenID
+    ) internal virtual {}
+}

--- a/contracts/nft/develop/ERC721Burnable.sol
+++ b/contracts/nft/develop/ERC721Burnable.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * NOTE: This file is a clone of the OpenZeppelin ERC721Burnable.sol contract. It was forked from https://github.com/OpenZeppelin/openzeppelin-contracts
+ * at commit 1ada3b633e5bfd9d4ffe0207d64773a11f5a7c40
+ *
+ * It was cloned in order to ensure it imported from the cloned ERC721.sol file. No other modifications have been made.
+ */
+
+pragma solidity ^0.8.4;
+
+import '@openzeppelin/contracts/utils/Context.sol';
+import './ERC721.sol';
+
+/**
+ * @title ERC721 Burnable Token
+ * @dev ERC721 Token that can be irreversibly burned (destroyed).
+ */
+abstract contract ERC721Burnable is Context, ERC721 {
+    /**
+     * @dev Burns `tokenId`. See {ERC721-_burn}.
+     *
+     * Requirements:
+     *
+     * - The caller must own `tokenId` or be an approved operator.
+     */
+    function burn(uint256 tokenId) public virtual {
+        //solhint-disable-next-line max-line-length
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenId),
+            'ERC721Burnable: caller is not owner nor approved'
+        );
+        _burn(tokenId);
+    }
+}

--- a/contracts/nft/develop/Math.sol
+++ b/contracts/nft/develop/Math.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @title Math
+ *
+ * Library for non-standard Math functions
+ * NOTE: This file is a clone of the dydx protocol's Math.sol contract.
+ * It was forked from https://github.com/dydxprotocol/solo at commit
+ * 2d8454e02702fe5bc455b848556660629c3cad36. It has two modifications
+ *      - uses a newer solidity in the pragma to match the rest of the contract suite of this project.
+ *      - Removed `Require.sol` dependency
+ */
+library Math {
+    // ============ Library Functions ============
+
+    /*
+     * Return target * (numerator / denominator).
+     */
+    function getPartial(
+        uint256 target,
+        uint256 numerator,
+        uint256 denominator
+    ) internal pure returns (uint256) {
+        return target * (numerator / denominator);
+    }
+
+    /*
+     * Return target * (numerator / denominator), but rounded up.
+     */
+    function getPartialRoundUp(
+        uint256 target,
+        uint256 numerator,
+        uint256 denominator
+    ) internal pure returns (uint256) {
+        if (target == 0 || numerator == 0) {
+            // SafeMath will check for zero denominator
+            return 0 / denominator;
+        }
+        return target * ((numerator - 1) / denominator) + 1;
+    }
+
+    function to128(uint256 number) internal pure returns (uint128) {
+        require(number <= type(uint128).max, 'Math: Unsafe cast to uint128');
+        uint128 result = uint128(number);
+        return result;
+    }
+
+    function to96(uint256 number) internal pure returns (uint96) {
+        require(number <= type(uint96).max, 'Math: Unsafe cast to uint96');
+        uint96 result = uint96(number);
+        return result;
+    }
+
+    function to32(uint256 number) internal pure returns (uint32) {
+        require(number <= type(uint32).max, 'Math: Unsafe cast to uint32');
+        uint32 result = uint32(number);
+        return result;
+    }
+
+    function min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a : b;
+    }
+}

--- a/contracts/nft/develop/MediaFactoryOld.sol
+++ b/contracts/nft/develop/MediaFactoryOld.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+
+import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
+import {UpgradeableBeacon} from '@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import {MediaProxy} from './MediaProxy.sol';
+import {IMarket} from './interfaces/IMarket.sol';
+
+interface IERC721Extended {
+    function name() external view returns (string memory);
+
+    function symbol() external view returns (string memory);
+}
+
+/// @title Zap Media Factory Contract
+/// @notice This contract deploys ZapMediaOld and external ERC721 contracts,
+///         registers and then configures them to be used on the Zap NFT Marketplace
+/// @dev It creates instances of ERC1976 MediaProxy and sets their implementation to a deployed ZapMediaOld
+contract MediaFactoryOld is OwnableUpgradeable {
+    event MediaDeployed(address indexed mediaContract);
+    event ExternalTokenDeployed(address indexed extToken);
+
+    IMarket zapMarket;
+    address beacon;
+
+    /// @notice Contract constructor
+    /// @dev utilises the OZ Initializable contract; cannot be called twice
+    /// @param _zapMarket the address of the ZapMarket contract to register and configure each ERC721 on
+    function initialize(address _zapMarket, address zapMediaInterface)
+        external
+        initializer
+    {
+        __Ownable_init();
+        zapMarket = IMarket(_zapMarket);
+        beacon = address(new UpgradeableBeacon(zapMediaInterface));
+        UpgradeableBeacon(beacon).transferOwnership(address(this));
+    }
+
+    /// @notice Upgrades ZapMediaOld contract
+    /// @dev calls `upgrateTo` on the Beacon contract to upgrade/replace the implementation contract
+    function upgradeMedia(address newInterface) external onlyOwner {
+        require(
+            msg.sender != address(0),
+            'The zero address can not make contract calls'
+        );
+        UpgradeableBeacon(beacon).upgradeTo(newInterface);
+    }
+
+    /// @notice Deploys ZapMediaOld ERC721 contracts to be used on ZapMarket
+    /// @dev This is the contract factory function, it deploys a proxy contract, then a ZapMediaOld contract,
+    ///      and then sets the implementation and initializes ZapMediaOld
+    /// @param name name of the collection
+    /// @param symbol collection's symbol
+    /// @param marketContractAddr ZapMarket contract to attach to, this can not be updated
+    /// @param permissive whether or not you would like this contract to be minted by everyone or just the owner
+    /// @param _collectionMetadata the metadata URI of the collection
+    /// @return the address of the deployed ZapMediaOld proxy
+    function deployMedia(
+        string calldata name,
+        string calldata symbol,
+        address marketContractAddr,
+        bool permissive,
+        string calldata _collectionMetadata
+    ) external returns (address) {
+        MediaProxy proxy = new MediaProxy();
+
+        proxy.initialize(
+            beacon,
+            payable(msg.sender),
+            name,
+            symbol,
+            marketContractAddr,
+            permissive,
+            _collectionMetadata
+        );
+        address proxyAddress = address(proxy);
+
+        zapMarket.registerMedia(proxyAddress);
+
+        bytes memory name_b = bytes(name);
+        bytes memory symbol_b = bytes(symbol);
+
+        bytes32 name_b32;
+        bytes32 symbol_b32;
+
+        assembly {
+            name_b32 := mload(add(name_b, 32))
+            symbol_b32 := mload(add(symbol_b, 32))
+        }
+
+        zapMarket.configure(msg.sender, proxyAddress, name_b32, symbol_b32);
+
+        emit MediaDeployed(proxyAddress);
+
+        return proxyAddress;
+    }
+}

--- a/contracts/nft/develop/MediaGetter.sol
+++ b/contracts/nft/develop/MediaGetter.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+import {MediaGettersLib} from './libraries/MediaGettersLib.sol';
+import {MediaStorage} from './libraries/MediaStorage.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+
+/// @title A title that should describe the contract/interface
+/// @author The name of the author
+/// @notice Explain to an end user what this does
+/// @dev Explain to a developer any extra details
+contract MediaGetter is Initializable {
+    using MediaGettersLib for MediaStorage.Tokens;
+
+    MediaStorage.Tokens internal tokens;
+
+    function getTokenCreators(uint256 _tokenId)
+        public
+        view
+        returns (address creator)
+    {
+        creator = tokens.getTokenCreators(_tokenId);
+    }
+
+    function getPreviousTokenOwners(uint256 _tokenId)
+        public
+        view
+        returns (address prevOwner)
+    {
+        prevOwner = tokens.getPreviousTokenOwners(_tokenId);
+    }
+
+    function getTokenContentHashes(uint256 _tokenId)
+        public
+        view
+        returns (bytes32 contentHash)
+    {
+        contentHash = tokens.getTokenContentHashes(_tokenId);
+    }
+
+    function getTokenMetadataHashes(uint256 _tokenId)
+        public
+        view
+        returns (bytes32 metadataHash)
+    {
+        metadataHash = tokens.getTokenMetadataHashes(_tokenId);
+    }
+}

--- a/contracts/nft/develop/MediaProxy.sol
+++ b/contracts/nft/develop/MediaProxy.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+import {ERC1967UpgradeUpgradeable} from '@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol';
+import {IBeacon} from '@openzeppelin/contracts/proxy/beacon/IBeacon.sol';
+
+/// @title Upgradeable proxy contract for a ZapMedia
+/// @notice This contract acts as a proxy that delegates calls for ZapMedia.
+///         it stores the ZapMedia implementation address which can be upgraded by the admin
+/// @dev Implements the OpenZeppelin ERC1967UpgradeUpgradeable contract
+contract MediaProxy is ERC1967UpgradeUpgradeable {
+    modifier onlyAdmin() {
+        require(
+            msg.sender == _getAdmin(),
+            'Only the Admin can call this function'
+        );
+        _;
+    }
+
+    /// @notice Constructor for the ZapMedia proxy and its implementation
+    /// @dev This function is initializable and implements the OZ Initializable contract by inheiritance
+    /// @param beacon the address of the Beacon contract which has the implementation contract address
+    /// @param owner the intended owner of the ZapMedia contract
+    /// @param name name of the collection
+    /// @param symbol collection's symbol
+    /// @param marketContractAddr ZapMarket contract to attach to, this can not be updated
+    /// @param permissive whether or not you would like this contract to be minted by everyone or just the owner
+    /// @param collectionURI the metadata URI of the collection
+    function initialize(
+        address beacon,
+        address payable owner,
+        string calldata name,
+        string calldata symbol,
+        address marketContractAddr,
+        bool permissive,
+        string calldata collectionURI
+    ) public {
+        _upgradeBeaconToAndCall(
+            beacon,
+            abi.encodeWithSignature(
+                'initialize(string,string,address,bool,string)',
+                name,
+                symbol,
+                marketContractAddr,
+                permissive,
+                collectionURI
+            ),
+            false
+        );
+
+        _changeAdmin(msg.sender);
+
+        (bool success, bytes memory returndata) = (
+            IBeacon(beacon).implementation()
+        ).delegatecall(
+                abi.encodeWithSignature('initTransferOwnership(address)', owner)
+            );
+
+        require(
+            success && returndata.length == 0,
+            'Creating ZapMedia proxy: Can not transfer ownership of proxy'
+        );
+    }
+
+    /// @notice Changes the admin contract of this ERC1967 contract
+    /// @dev This is a wrapper function for the ERC1967 _changeAdmin function and uses a modifier
+    ///      to ensure that only the current admin contract can change the admin
+    /// @param newAdmin the address of the new admin contract
+    function changeAdmin(address newAdmin) external onlyAdmin {
+        _changeAdmin(newAdmin);
+    }
+
+    /// @notice Get the owner of the ZapMedia implementation
+    /// @dev This makes a `delegatecall`, which means that __the `owner` is stored in this proxy's state__
+    /// @param _impl address of the implementation which has the getOwner function bytecode
+    /// @return _implOwner address of this ZapMedia's owner
+    function getImplOwner(address _impl)
+        public
+        onlyAdmin
+        returns (address _implOwner)
+    {
+        (bool success, bytes memory returndata) = _impl.delegatecall(
+            abi.encodeWithSignature('getOwner()')
+        );
+
+        require(
+            success && returndata.length > 0,
+            'Can not get the owner of this ZapMedia'
+        );
+        _implOwner = abi.decode(returndata, (address));
+    }
+
+    function _delegate(address _impl) internal virtual {
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+
+            let result := delegatecall(gas(), _impl, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    fallback() external {
+        // ensures that the call is always made to the implementation (ZapMedia)
+        // https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies#transparent-proxies-and-function-clashes
+        if (msg.sender != _getAdmin()) {
+            _delegate(IBeacon(_getBeacon()).implementation());
+        }
+    }
+}

--- a/contracts/nft/develop/Ownable.sol
+++ b/contracts/nft/develop/Ownable.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+import {MediaStorage} from './libraries/MediaStorage.sol';
+import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+
+contract Ownable is Initializable {
+    event OwnershipTransferInitiated(
+        address indexed owner,
+        address indexed appointedOwner
+    );
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+
+    MediaStorage.Access internal access;
+    address public appointedOwner;
+
+    /// @dev The Ownable constructor sets the original `access.owner` of the contract to the sender account.
+    function initialize_ownable() internal initializer {
+        access.owner = msg.sender;
+    }
+
+    function getOwner() external view returns (address) {
+        return access.owner;
+    }
+
+    /// @dev Throws if called by any contract other than latest designated caller
+    modifier onlyOwner() {
+        require(
+            msg.sender == access.owner,
+            'onlyOwner error: Only Owner of the Contract can make this Call'
+        );
+        _;
+    }
+
+    function approveToMint(address toApprove) external onlyOwner {
+        access.approvedToMint[toApprove] = true;
+    }
+
+    function getTokenMetadataURIs(uint256 _tokenId)
+        external
+        view
+        returns (string memory metadataUri)
+    {
+        return access._tokenMetadataURIs[_tokenId];
+    }
+
+    function getSigNonces(address _minter) public view returns (uint256 nonce) {
+        return access.mintWithSigNonces[_minter];
+    }
+
+    function getPermitNonce(address _user, uint256 _tokenId)
+        public
+        view
+        returns (uint256 nonce)
+    {
+        return access.permitNonces[_user][_tokenId];
+    }
+
+    function marketContract() public view returns (address) {
+        return access.marketContract;
+    }
+
+    /// @dev Allows the current owner to intiate the transfer control of the contract to a newOwner.
+    /// @param newOwner The address to transfer ownership to.
+    function initTransferOwnership(address payable newOwner) public onlyOwner {
+        require(
+            newOwner != address(0),
+            'Ownable: Cannot transfer to zero address'
+        );
+        emit OwnershipTransferInitiated(access.owner, newOwner);
+        appointedOwner = newOwner;
+    }
+
+    /// @dev Allows new owner to claim the transfer control of the contract
+    function claimTransferOwnership() public {
+        require(
+            appointedOwner != address(0),
+            'Ownable: No ownership transfer have been initiated'
+        );
+        require(
+            msg.sender == appointedOwner,
+            'Ownable: Caller is not the appointed owner of this contract'
+        );
+
+        emit OwnershipTransferred(access.owner, msg.sender); // where msg.sender == appointedOwner
+        access.owner = appointedOwner;
+        appointedOwner = address(0);
+    }
+
+    /// @dev Revoke transfer and set appointed owner to 0 address
+    function revokeTransferOwnership() public onlyOwner {
+        appointedOwner = address(0);
+    }
+}

--- a/contracts/nft/develop/ZapMarketOld.sol
+++ b/contracts/nft/develop/ZapMarketOld.sol
@@ -1,0 +1,542 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+//import {SafeMathUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol';
+import {IERC721Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol';
+import {IERC20Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol';
+import {SafeERC20Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol';
+import {Initializable} from '@openzeppelin/contracts/proxy/utils/Initializable.sol';
+import {Decimal} from './Decimal.sol';
+import {ZapMediaOld} from './ZapMediaOld.sol';
+import {IMarket} from './interfaces/IMarket.sol';
+import {Ownable} from './access/Ownable.sol';
+
+/**
+ * @title A Market for pieces of media
+ * @notice This contract contains all of the market logic for Media
+ */
+contract ZapMarketOld is IMarket, Ownable {
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    /* *******
+     * Globals
+     * *******
+     */
+
+    // Address of the media contract that can call this market
+    mapping(address => address[]) public mediaContracts;
+
+    // Mapping from media address to a bool showing whether or not
+    // they're registered by the media factory
+    mapping(address => bool) public registeredMedias;
+
+    // registered media factory address
+    address mediaFactory;
+
+    // Mapping from token to mapping from bidder to bid
+    mapping(address => mapping(uint256 => mapping(address => Bid)))
+        private _tokenBidders;
+
+    // Mapping from token to the bid shares for the token
+    mapping(address => mapping(uint256 => BidShares)) private _bidShares;
+
+    // Mapping from token to the current ask for the token
+    mapping(address => mapping(uint256 => Ask)) private _tokenAsks;
+
+    // Mapping from Media address to the Market configuration status
+    mapping(address => bool) public isConfigured;
+
+    // Mapping of token ids of accepted bids to their mutex
+    mapping(uint256 => bool) private bidMutex;
+
+    address platformAddress;
+
+    IMarket.PlatformFee platformFee;
+
+    /* *********
+     * Modifiers
+     * *********
+     */
+
+    /**
+     * @notice require that the msg.sender is the configured media contract
+     */
+    modifier onlyMediaCaller() {
+        require(
+            isConfigured[msg.sender] == true,
+            'Market: Only media contract'
+        );
+
+        _;
+    }
+
+    modifier onlyMediaFactory() {
+        require(
+            msg.sender == mediaFactory,
+            'Market: Only the media factory can do this action'
+        );
+        _;
+    }
+
+    modifier isUnlocked(uint256 tokenId) {
+        require(!bidMutex[tokenId], 'There is a bid transaction in progress');
+        bidMutex[tokenId] = true;
+        _;
+        bidMutex[tokenId] = false;
+    }
+
+    /* ****************
+     * View Functions
+     * ****************
+     */
+    function bidForTokenBidder(
+        address mediaContractAddress,
+        uint256 tokenId,
+        address bidder
+    ) external view override returns (Bid memory) {
+        return _tokenBidders[mediaContractAddress][tokenId][bidder];
+    }
+
+    function currentAskForToken(address mediaContractAddress, uint256 tokenId)
+        external
+        view
+        override
+        returns (Ask memory)
+    {
+        return _tokenAsks[mediaContractAddress][tokenId];
+    }
+
+    function bidSharesForToken(address mediaContractAddress, uint256 tokenId)
+        public
+        view
+        override
+        returns (BidShares memory)
+    {
+        return _bidShares[mediaContractAddress][tokenId];
+    }
+
+    /**
+     * @notice Validates that the bid is valid by ensuring that the bid amount can be split perfectly into all the bid shares.
+     *  We do this by comparing the sum of the individual share values with the amount and ensuring they are equal. Because
+     *  the splitShare function uses integer division, any inconsistencies with the original and split sums would be due to
+     *  a bid splitting that does not perfectly divide the bid amount.
+     */
+    function isValidBid(
+        address mediaContractAddress,
+        uint256 tokenId,
+        uint256 bidAmount
+    ) public view override returns (bool) {
+        BidShares memory bidShares = bidSharesForToken(
+            mediaContractAddress,
+            tokenId
+        );
+
+        require(
+            isValidBidShares(bidShares),
+            'Market: Invalid bid shares for token'
+        );
+
+        uint256 collabShareValue = 0;
+        Decimal.D256 memory thisCollabsShare;
+        thisCollabsShare.value = 0;
+        for (uint256 i = 0; i < bidShares.collaborators.length; i++) {
+            thisCollabsShare.value = bidShares.collabShares[i];
+
+            collabShareValue =
+                collabShareValue +
+                (splitShare(thisCollabsShare, bidAmount));
+        }
+
+        return
+            bidAmount != 0 &&
+            (bidAmount ==
+                splitShare(bidShares.creator, bidAmount) +
+                    (collabShareValue) +
+                    (splitShare(platformFee.fee, bidAmount)) +
+                    (splitShare(bidShares.owner, bidAmount)));
+    }
+
+    /**
+     * @notice Validates that the provided bid shares sum to 100
+     */
+    function isValidBidShares(BidShares memory bidShares)
+        public
+        view
+        override
+        returns (bool)
+    {
+        uint256 collabSharePerc = 0;
+
+        for (uint256 i = 0; i < bidShares.collaborators.length; i++) {
+            collabSharePerc = collabSharePerc + (bidShares.collabShares[i]);
+        }
+
+        return
+            bidShares.creator.value +
+                (collabSharePerc) +
+                (bidShares.owner.value) +
+                (platformFee.fee.value) ==
+            uint256(100) * (Decimal.BASE);
+    }
+
+    /**
+     * @notice return a % of the specified amount. This function is used to split a bid into shares
+     * for a media's shareholders.
+     */
+    function splitShare(Decimal.D256 memory sharePercentage, uint256 amount)
+        public
+        pure
+        override
+        returns (uint256)
+    {
+        return Decimal.mul(amount, sharePercentage) / (100);
+    }
+
+    /* ****************
+     * Public Functions
+     * ****************
+     */
+
+    function initializeMarket(address _platformAddress) public initializer {
+        owner = msg.sender;
+
+        platformAddress = _platformAddress;
+    }
+
+    function isRegistered(address mediaContractAddress)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return (registeredMedias[mediaContractAddress]);
+    }
+
+    function setMediaFactory(address _mediaFactory)
+        external
+        override
+        onlyOwner
+    {
+        mediaFactory = _mediaFactory;
+    }
+
+    function viewFee() public view returns (Decimal.D256 memory) {
+        return platformFee.fee;
+    }
+
+    function setFee(IMarket.PlatformFee memory newFee) public onlyOwner {
+        platformFee = newFee;
+    }
+
+    /**
+     * @notice Sets the media contract address. This address is the only permitted address that
+     * can call the mutable functions. This method can only be called once.
+     */
+
+    function configure(
+        address deployer,
+        address mediaContract,
+        bytes32 name,
+        bytes32 symbol
+    ) external override onlyMediaFactory {
+        require(
+            isConfigured[mediaContract] != true,
+            'Market: Already configured'
+        );
+
+        require(
+            mediaContract != address(0) && deployer != address(0),
+            'Market: cannot set media contract as zero address'
+        );
+
+        isConfigured[mediaContract] = true;
+
+        mediaContracts[deployer].push(mediaContract);
+
+        emit MediaContractCreated(mediaContract, name, symbol);
+    }
+
+    function mintOrBurn(
+        bool isMint,
+        uint256 tokenId,
+        address mediaContract
+    ) external override {
+        require(msg.sender == mediaContract, 'Market: Media only function');
+
+        if (isMint == true) {
+            emit Minted(tokenId, mediaContract);
+        } else {
+            emit Burned(tokenId, mediaContract);
+        }
+    }
+
+    function registerMedia(address mediaContract)
+        external
+        override
+        onlyMediaFactory
+    {
+        registeredMedias[mediaContract] = true;
+    }
+
+    function revokeRegistration(address mediaContract)
+        external
+        override
+        onlyOwner
+    {
+        registeredMedias[mediaContract] = false;
+    }
+
+    /**
+     * @notice Sets bid shares for a particular tokenId. These bid shares must
+     * sum to 100.
+     */
+    function setBidShares(uint256 tokenId, BidShares memory bidShares)
+        public
+        override
+        onlyMediaCaller
+    {
+        require(
+            isValidBidShares(bidShares),
+            'Market: Invalid bid shares, must sum to 100'
+        );
+
+        _bidShares[msg.sender][tokenId] = bidShares;
+        emit BidShareUpdated(tokenId, bidShares, msg.sender);
+    }
+
+    /**
+     * @notice Sets the ask on a particular media. If the ask cannot be evenly split into the media's
+     * bid shares, this reverts.
+     */
+    function setAsk(uint256 tokenId, Ask memory ask)
+        public
+        override
+        onlyMediaCaller
+    {
+        require(
+            isValidBid(msg.sender, tokenId, ask.amount),
+            'Market: Ask invalid for share splitting'
+        );
+
+        _tokenAsks[msg.sender][tokenId] = ask;
+        emit AskCreated(msg.sender, tokenId, ask);
+    }
+
+    /**
+     * @notice removes an ask for a token and emits an AskRemoved event
+     */
+    function removeAsk(uint256 tokenId) external override onlyMediaCaller {
+        emit AskRemoved(tokenId, _tokenAsks[msg.sender][tokenId], msg.sender);
+        delete _tokenAsks[msg.sender][tokenId];
+    }
+
+    /**
+     * @notice Sets the bid on a particular media for a bidder. The token being used to bid
+     * is transferred from the spender to this contract to be held until removed or accepted.
+     * If another bid already exists for the bidder, it is refunded.
+     */
+    function setBid(
+        uint256 tokenId,
+        Bid memory bid,
+        address spender
+    ) public override onlyMediaCaller {
+        BidShares memory bidShares = _bidShares[msg.sender][tokenId];
+
+        require(
+            bidShares.creator.value + (bid.sellOnShare.value) <=
+                uint256(100) * (Decimal.BASE),
+            'Market: Sell on fee invalid for share splitting'
+        );
+        require(bid.bidder != address(0), 'Market: bidder cannot be 0 address');
+        require(bid.amount != 0, 'Market: cannot bid amount of 0');
+        require(
+            bid.currency != address(0),
+            'Market: bid currency cannot be 0 address'
+        );
+        require(
+            bid.recipient != address(0),
+            'Market: bid recipient cannot be 0 address'
+        );
+
+        Bid storage existingBid = _tokenBidders[msg.sender][tokenId][
+            bid.bidder
+        ];
+
+        // If there is an existing bid, refund it before continuing
+        if (existingBid.amount > 0) {
+            removeBid(tokenId, bid.bidder);
+        }
+
+        IERC20Upgradeable token = IERC20Upgradeable(bid.currency);
+
+        // We must check the balance that was actually transferred to the market,
+        // as some tokens impose a transfer fee and would not actually transfer the
+        // full amount to the market, resulting in locked funds for refunds & bid acceptance
+
+        uint256 beforeBalance = token.balanceOf(address(this));
+
+        token.safeTransferFrom(spender, address(this), bid.amount);
+
+        require(
+            token.balanceOf(address(this)) == beforeBalance + bid.amount,
+            'Market: Market balance did not increase from bid'
+        );
+
+        _tokenBidders[msg.sender][tokenId][bid.bidder] = Bid(
+            bid.amount,
+            bid.currency,
+            bid.bidder,
+            bid.recipient,
+            bid.sellOnShare
+        );
+
+        emit BidCreated(msg.sender, tokenId, bid);
+
+        // If a bid meets the criteria for an ask, automatically accept the bid.
+        // If no ask is set or the bid does not meet the requirements, ignore.
+        if (
+            _tokenAsks[msg.sender][tokenId].currency != address(0) &&
+            bid.currency == _tokenAsks[msg.sender][tokenId].currency &&
+            bid.amount >= _tokenAsks[msg.sender][tokenId].amount
+        ) {
+            // Finalize exchange
+            _finalizeNFTTransfer(msg.sender, tokenId, bid.bidder);
+        }
+    }
+
+    /**
+     * @notice Removes the bid on a particular media for a bidder. The bid amount
+     * is transferred from this contract to the bidder, if they have a bid placed.
+     */
+    function removeBid(uint256 tokenId, address bidder)
+        public
+        override
+        onlyMediaCaller
+        isUnlocked(tokenId)
+    {
+        Bid storage bid = _tokenBidders[msg.sender][tokenId][bidder];
+        uint256 bidAmount = bid.amount;
+        address bidCurrency = bid.currency;
+
+        require(bid.amount > 0, 'Market: cannot remove bid amount of 0');
+
+        IERC20Upgradeable token = IERC20Upgradeable(bidCurrency);
+
+        emit BidRemoved(tokenId, bid, msg.sender);
+        delete _tokenBidders[msg.sender][tokenId][bidder];
+        token.safeTransfer(bidder, bidAmount);
+    }
+
+    /**
+     * @notice Accepts a bid from a particular bidder. Can only be called by the media contract.
+     * See {_finalizeNFTTransfer}
+     * Provided bid must match a bid in storage. This is to prevent a race condition
+     * where a bid may change while the acceptBid call is in transit.
+     * A bid cannot be accepted if it cannot be split equally into its shareholders.
+     * This should only revert in rare instances (example, a low bid with a zero-decimal token),
+     * but is necessary to ensure fairness to all shareholders.
+     */
+    function acceptBid(
+        address mediaContractAddress,
+        uint256 tokenId,
+        Bid calldata expectedBid
+    ) external override onlyMediaCaller isUnlocked(tokenId) {
+        Bid memory bid = _tokenBidders[mediaContractAddress][tokenId][
+            expectedBid.bidder
+        ];
+        require(bid.amount > 0, 'Market: cannot accept bid of 0');
+        require(
+            bid.amount == expectedBid.amount &&
+                bid.currency == expectedBid.currency &&
+                bid.sellOnShare.value == expectedBid.sellOnShare.value &&
+                bid.recipient == expectedBid.recipient,
+            'Market: Unexpected bid found.'
+        );
+
+        require(
+            isValidBid(mediaContractAddress, tokenId, bid.amount),
+            'Market: Bid invalid for share splitting'
+        );
+
+        _finalizeNFTTransfer(mediaContractAddress, tokenId, bid.bidder);
+    }
+
+    /**
+     * @notice Given a token ID and a bidder, this method transfers the value of
+     * the bid to the shareholders. It also transfers the ownership of the media
+     * to the bid recipient. Finally, it removes the accepted bid and the current ask.
+     */
+    function _finalizeNFTTransfer(
+        address mediaContractAddress,
+        uint256 tokenId,
+        address bidder
+    ) private {
+        Bid memory bid = _tokenBidders[mediaContractAddress][tokenId][bidder];
+        BidShares storage bidShares = _bidShares[mediaContractAddress][tokenId];
+
+        IERC20Upgradeable token = IERC20Upgradeable(bid.currency);
+
+        // Transfer bid share to owner of media
+        token.safeTransfer(
+            IERC721Upgradeable(mediaContractAddress).ownerOf(tokenId),
+            splitShare(bidShares.owner, bid.amount)
+        );
+
+        // Transfer bid share to creator of media
+        token.safeTransfer(
+            ZapMediaOld(mediaContractAddress).getTokenCreators(tokenId),
+            splitShare(bidShares.creator, bid.amount)
+        );
+
+        uint256 collaboratorShares = 0;
+
+        Decimal.D256 memory thisCollabsShare;
+        thisCollabsShare.value = 0;
+        // Transfer bid share to the remaining media collaborators
+        for (uint256 i = 0; i < bidShares.collaborators.length; i++) {
+            collaboratorShares =
+                collaboratorShares +
+                (bidShares.collabShares[i]);
+
+            thisCollabsShare.value = bidShares.collabShares[i];
+
+            token.safeTransfer(
+                bidShares.collaborators[i],
+                splitShare(thisCollabsShare, bid.amount)
+            );
+        }
+
+        // Transfer bid share to previous owner of media (if applicable)
+        token.safeTransfer(
+            // ZapMediaOld(mediaContractAddress).getPreviousTokenOwners(tokenId),
+            platformAddress,
+            splitShare(platformFee.fee, bid.amount)
+        );
+
+        // Transfer media to bid recipient
+        ZapMediaOld(mediaContractAddress).auctionTransfer(
+            tokenId,
+            bid.recipient
+        );
+
+        // Calculate the bid share for the new owner,
+        // equal to 100 - creatorShare - sellOnShare
+        bidShares.owner = Decimal.D256(
+            uint256(100) *
+                (Decimal.BASE) -
+                (collaboratorShares) -
+                (_bidShares[mediaContractAddress][tokenId].creator.value) -
+                (platformFee.fee.value)
+        );
+        // Set the previous owner share to the accepted bid's sell-on fee
+        // platformFee.fee = bid.sellOnShare;
+
+        // Remove the accepted bid
+        delete _tokenBidders[mediaContractAddress][tokenId][bidder];
+
+        emit BidShareUpdated(tokenId, bidShares, mediaContractAddress);
+        emit BidFinalized(tokenId, bid, mediaContractAddress);
+    }
+}

--- a/contracts/nft/develop/ZapMediaOld.sol
+++ b/contracts/nft/develop/ZapMediaOld.sol
@@ -1,0 +1,706 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+import '@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpgradeable.sol'; // exposes _registerInterface
+import '@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
+import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+
+import {SafeMath} from '@openzeppelin/contracts/utils/math/SafeMath.sol';
+import {Math} from '@openzeppelin/contracts/utils/math/Math.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {Counters} from '@openzeppelin/contracts/utils/Counters.sol';
+import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+import {IMarket} from './interfaces/IMarket.sol';
+import {IMedia} from './interfaces/IMedia.sol';
+import {Ownable} from './Ownable.sol';
+import {MediaGetter} from './MediaGetter.sol';
+import {MediaStorage} from './libraries/MediaStorage.sol';
+import './libraries/Constants.sol';
+
+/**
+ * @title A media value system, with perpetual equity to creators
+ * @notice This contract provides an interface to mint media with a market
+ * owned by the creator.
+ */
+contract ZapMediaOld is
+    IMedia,
+    ERC721BurnableUpgradeable,
+    ReentrancyGuardUpgradeable,
+    Ownable,
+    MediaGetter,
+    ERC721URIStorageUpgradeable,
+    ERC721EnumerableUpgradeable,
+    ERC165StorageUpgradeable
+{
+    using Counters for Counters.Counter;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using SafeMath for uint256;
+
+    /*
+     *     bytes4(keccak256('name()')) == 0x06fdde03
+     *     bytes4(keccak256('symbol()')) == 0x95d89b41
+     *     bytes4(keccak256('tokenURI(uint256)')) == 0xc87b56dd
+     *     DEBUG(need to find the remaining methods that result to the new interfaceId )
+     *
+     *     => 0x06fdde03 ^ 0x95d89b41 ^ 0xc87b56dd == 0x5b5e139f
+     */
+
+    mapping(bytes4 => bool) private _supportedInterfaces;
+
+    bytes internal collectionMetadata;
+
+    bytes32 private constant kecEIP712Domain =
+        keccak256(
+            'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'
+        );
+
+    bytes32 private constant kecOne = keccak256(bytes('1'));
+
+    bytes32 private kecName;
+
+    /* *********
+     * Modifiers
+     * *********
+     */
+
+    /**
+     * @notice Require that the token has not been burned and has been minted
+     */
+    modifier onlyExistingToken(uint256 tokenId) {
+        require(
+            _exists(tokenId),
+            // remove revert string before deployment to mainnet
+            'Media: nonexistent token'
+        );
+        _;
+    }
+
+    /**
+     * @notice Require that the token has had a content hash set
+     */
+    modifier onlyTokenWithContentHash(uint256 tokenId) {
+        require(
+            getTokenContentHashes(tokenId) != 0,
+            // remove revert string before deployment to mainnet
+            'Media: token does not have hash of created content'
+        );
+        _;
+    }
+
+    /**
+     * @notice Require that the token has had a metadata hash set
+     */
+    modifier onlyTokenWithMetadataHash(uint256 tokenId) {
+        require(
+            tokens.tokenMetadataHashes[tokenId] != 0,
+            // remove revert string before deployment to mainnet
+            'Media: token does not have hash of its metadata'
+        );
+        _;
+    }
+
+    /**
+     * @notice Ensure that the provided spender is the approved or the owner of
+     * the media for the specified tokenId
+     */
+    modifier onlyApprovedOrOwner(address spender, uint256 tokenId) {
+        require(
+            _isApprovedOrOwner(spender, tokenId),
+            // remove revert string before deployment to mainnet
+            'Media: Only approved or owner'
+        );
+        _;
+    }
+
+    /**
+     * @notice Ensure the token has been created (even if it has been burned)
+     */
+    modifier onlyTokenCreated(uint256 tokenId) {
+        require(
+            access._tokenIdTracker.current() > tokenId,
+            // remove revert string before deployment to mainnet
+            'Media: token with that id does not exist'
+        );
+        _;
+    }
+
+    /**
+     * @notice Ensure that the provided URI is not empty
+     */
+    modifier onlyValidURI(string memory uri) {
+        require(
+            bytes(uri).length != 0,
+            // remove revert string before deployment to mainnet
+            'Media: specified uri must be non-empty'
+        );
+        _;
+    }
+
+    //geting the contractURI value
+    function contractURI() public view returns (bytes memory) {
+        return collectionMetadata;
+    }
+
+    /**
+     * @notice On deployment, set the market contract address and register the
+     * ERC721 metadata interface
+     */
+
+    function initialize(
+        string calldata name,
+        string calldata symbol,
+        address marketContractAddr,
+        bool permissive,
+        string calldata collectionURI
+    ) external override initializer {
+        __ERC721_init(name, symbol);
+        initialize_ownable();
+
+        access.marketContract = marketContractAddr;
+
+        bytes memory name_b = bytes(name);
+
+        bytes32 name_b32;
+
+        assembly {
+            name_b32 := mload(add(name_b, 32))
+        }
+
+        kecName = keccak256(name_b);
+        _registerInterface(0x80ac58cd); // registers old erc721 interface for AucitonHouse
+        _registerInterface(0x5b5e139f); // registers current metadata upgradeable interface for AuctionHouseOld
+        _registerInterface(type(IMedia).interfaceId);
+
+        access.isPermissive = permissive;
+        collectionMetadata = bytes(collectionURI);
+    }
+
+    /**
+     *  @notice Returns a boolean, showing whether or not the given interfaceId is supported
+     * @dev This function is overriden from the ERC721 and ERC165 contract stack
+     * @param interfaceId a bytes4 formatted representation of a contract interface
+     * @return boolean dipicting whether or not the interface is supported
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(
+            ERC721EnumerableUpgradeable,
+            ERC721Upgradeable,
+            ERC165StorageUpgradeable
+        )
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice return the URI for a particular piece of media with the specified tokenId
+     * @dev This function is an override of the base OZ implementation because we
+     * will return the tokenURI even if the media has been burned. In addition, this
+     * protocol does not support a base URI, so relevant conditionals are removed.
+     * @return the URI for a token
+     */
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        virtual
+        override(ERC721URIStorageUpgradeable, ERC721Upgradeable)
+        onlyTokenCreated(tokenId)
+        returns (string memory)
+    {
+        return ERC721URIStorageUpgradeable.tokenURI(tokenId);
+    }
+
+    function _registerInterface(bytes4 interfaceId) internal virtual override {
+        require(interfaceId != 0xffffffff, 'ERC165: invalid interface id');
+        _supportedInterfaces[interfaceId] = true;
+    }
+
+    /// @notice TokenTransfer hook function
+    /// @dev called from ERC721 Enumerable Upgradeable contract, see here https://docs.openzeppelin.com/contracts/4.x/api/token/erc721#ERC721Enumerable-_beforeTokenTransfer-address-address-uint256-
+    /// @param from the current token owner, if this is the zero address, the token will be minted for `to`
+    /// @param to the receiver's wallet address, if this is the zero address, the token will be burned
+    /// @param tokenId token ID of the ERC721 to be transfered
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    )
+        internal
+        virtual
+        override(ERC721EnumerableUpgradeable, ERC721Upgradeable)
+    {
+        ERC721EnumerableUpgradeable._beforeTokenTransfer(from, to, tokenId);
+    }
+
+    /* *************
+     * View Functions
+     * **************
+     */
+
+    /**
+     * @notice Return the metadata URI for a piece of media given the token URI
+     * @param tokenId the token whose metadata will be attached
+     * @return the metadata URI for the token
+     */
+    function tokenMetadataURI(uint256 tokenId)
+        external
+        view
+        override
+        onlyTokenCreated(tokenId)
+        returns (string memory)
+    {
+        return access._tokenMetadataURIs[tokenId];
+    }
+
+    /* ****************
+     * Public Functions
+     * ****************
+     */
+
+    /**
+     * @notice see IMedia
+     * @dev mints an NFT and sets the bidshares for collaborators
+     * @param data The media's metadata and content data, includes content and metadata hash, and token's URI
+     */
+    function mint(MediaData memory data, IMarket.BidShares memory bidShares)
+        public
+        override
+        nonReentrant
+    {
+        require(
+            access.isPermissive ||
+                access.approvedToMint[msg.sender] ||
+                access.owner == msg.sender,
+            'Media: Only Approved users can mint'
+        );
+        require(
+            bidShares.collaborators.length == bidShares.collabShares.length,
+            'Media: Arrays do not have the same length'
+        );
+        for (uint256 i = 0; i < bidShares.collaborators.length; i++) {
+            require(
+                _hasShares(i, bidShares),
+                'Media: Each collaborator must have a share of the nft'
+            );
+        }
+
+        _mintForCreator(msg.sender, data, bidShares);
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function mintWithSig(
+        address creator,
+        MediaData memory data,
+        IMarket.BidShares memory bidShares,
+        EIP712Signature memory sig
+    ) public override nonReentrant {
+        require(
+            access.isPermissive || access.approvedToMint[msg.sender],
+            'Media: Only Approved users can mint'
+        );
+        require(
+            sig.deadline == 0 || sig.deadline >= block.timestamp,
+            'Media: mintWithSig expired'
+        );
+        require(
+            bidShares.collaborators.length == bidShares.collabShares.length,
+            'Media: Arrays do not have the same length'
+        );
+        for (uint256 i = 0; i < bidShares.collaborators.length; i++) {
+            require(
+                _hasShares(i, bidShares),
+                'Media: Each collaborator must have a share of the nft'
+            );
+        }
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                '\x19\x01',
+                _calculateDomainSeparator(),
+                keccak256(
+                    abi.encode(
+                        Constants.MINT_WITH_SIG_TYPEHASH,
+                        data.contentHash,
+                        data.metadataHash,
+                        bidShares.creator.value,
+                        access.mintWithSigNonces[creator]++,
+                        sig.deadline
+                    )
+                )
+            )
+        );
+
+        address recoveredAddress = ECDSA.recover(digest, sig.v, sig.r, sig.s);
+
+        require(
+            recoveredAddress != address(0) && creator == recoveredAddress,
+            'Media: Signature invalid'
+        );
+
+        _mintForCreator(recoveredAddress, data, bidShares);
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function auctionTransfer(uint256 tokenId, address recipient)
+        external
+        override
+    {
+        require(
+            msg.sender == access.marketContract,
+            // remove revert string before deployment to mainnet
+            'Media: only market contract'
+        );
+        tokens.previousTokenOwners[tokenId] = ownerOf(tokenId);
+        _safeTransfer(ownerOf(tokenId), recipient, tokenId, '');
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function setAsk(uint256 tokenId, IMarket.Ask memory ask)
+        public
+        override
+        nonReentrant
+        onlyApprovedOrOwner(msg.sender, tokenId)
+        onlyExistingToken(tokenId)
+    {
+        IMarket(access.marketContract).setAsk(tokenId, ask);
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function removeAsk(uint256 tokenId)
+        external
+        override
+        nonReentrant
+        onlyApprovedOrOwner(msg.sender, tokenId)
+        onlyExistingToken(tokenId)
+    {
+        IMarket(access.marketContract).removeAsk(tokenId);
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function setBid(uint256 tokenId, IMarket.Bid memory bid)
+        public
+        override
+        nonReentrant
+        onlyExistingToken(tokenId)
+    {
+        require(msg.sender == bid.bidder, 'Market: Bidder must be msg sender');
+        IMarket(access.marketContract).setBid(tokenId, bid, msg.sender);
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function removeBid(uint256 tokenId)
+        external
+        override
+        nonReentrant
+        onlyTokenCreated(tokenId)
+    {
+        IMarket(access.marketContract).removeBid(tokenId, msg.sender);
+    }
+
+    /**
+     * @notice see IMedia
+     */
+    function acceptBid(uint256 tokenId, IMarket.Bid memory bid)
+        public
+        override
+        nonReentrant
+        onlyApprovedOrOwner(msg.sender, tokenId)
+        onlyExistingToken(tokenId)
+    {
+        IMarket(access.marketContract).acceptBid(address(this), tokenId, bid);
+    }
+
+    /**
+     * @notice Burn a token.
+     * @dev Only callable if the media owner is also the creator.
+     * @param tokenId the ID of the token to burn
+     */
+    function burn(uint256 tokenId)
+        public
+        override
+        nonReentrant
+        onlyExistingToken(tokenId)
+        onlyApprovedOrOwner(msg.sender, tokenId)
+    {
+        address owner = ownerOf(tokenId);
+
+        require(
+            tokens.tokenCreators[tokenId] == owner,
+            // remove revert string before deployment to mainnet
+            'Media: owner is not creator of media'
+        );
+
+        _burn(tokenId);
+    }
+
+    /**
+     * @notice Revoke the approvals for a token. The provided `approve` function is not sufficient
+     * for this protocol, as it does not allow an approved address to revoke it's own approval.
+     * In instances where a 3rd party is interacting on a user's behalf via `permit`, they should
+     * revoke their approval once their task is complete as a best practice.
+     */
+    function revokeApproval(uint256 tokenId)
+        external
+        override
+        onlyApprovedOrOwner(msg.sender, tokenId)
+        nonReentrant
+    {
+        _approve(address(0), tokenId);
+    }
+
+    /**
+     * @notice see IMedia
+     * @dev only callable by approved or owner
+     */
+    function updateTokenURI(uint256 tokenId, string calldata tokenURILocal)
+        external
+        override
+        nonReentrant
+        onlyApprovedOrOwner(msg.sender, tokenId)
+        onlyTokenWithContentHash(tokenId)
+        onlyValidURI(tokenURILocal)
+    {
+        _setTokenURI(tokenId, tokenURILocal);
+        emit TokenURIUpdated(tokenId, msg.sender, tokenURILocal);
+    }
+
+    /**
+     * @notice see IMedia
+     * @dev only callable by approved or owner
+     */
+    function updateTokenMetadataURI(
+        uint256 tokenId,
+        string calldata metadataURI
+    )
+        external
+        override
+        nonReentrant
+        onlyApprovedOrOwner(msg.sender, tokenId)
+        onlyTokenWithMetadataHash(tokenId)
+        onlyValidURI(metadataURI)
+    {
+        _setTokenMetadataURI(tokenId, metadataURI);
+        emit TokenMetadataURIUpdated(tokenId, msg.sender, metadataURI);
+    }
+
+    /**
+     * @notice See IMedia
+     * @dev This method is loosely based on the permit for ERC-20 tokens in  EIP-2612, but modified
+     * for ERC-721.
+     */
+    function permit(
+        address spender,
+        uint256 tokenId,
+        EIP712Signature memory sig
+    ) public override nonReentrant onlyExistingToken(tokenId) {
+        require(
+            sig.deadline == 0 || sig.deadline >= block.timestamp,
+            // remove revert string before deployment to mainnet
+            'Media: Permit expired'
+        );
+        require(
+            spender != address(0),
+            // remove revert string before deployment to mainnet
+            'Media: spender cannot be 0x0'
+        );
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                '\x19\x01',
+                _calculateDomainSeparator(),
+                keccak256(
+                    abi.encode(
+                        Constants.PERMIT_TYPEHASH,
+                        spender,
+                        tokenId,
+                        access.permitNonces[ownerOf(tokenId)][tokenId]++,
+                        sig.deadline
+                    )
+                )
+            )
+        );
+
+        address recoveredAddress = ECDSA.recover(digest, sig.v, sig.r, sig.s);
+
+        require(
+            recoveredAddress != address(0) &&
+                ownerOf(tokenId) == recoveredAddress,
+            // remove revert string before deployment to mainnet
+            'Media: Signature invalid'
+        );
+
+        _approve(spender, tokenId);
+    }
+
+    /* *****************
+     * Private Functions
+     * *****************
+     */
+
+    /// @notice Returns a bool depicting whether or not the i'th collaborator has shares
+    /// @dev Explain to a developer any extra details
+    /// @param index the "i'th collaborator"
+    /// @param bidShares the bidshares defined for the Collection's NFTs
+    /// @return Boolean that is true if the i'th collaborator has shares for this collection's NFTs
+    function _hasShares(uint256 index, IMarket.BidShares memory bidShares)
+        internal
+        pure
+        returns (bool)
+    {
+        return (bidShares.collabShares[index] != 0);
+    }
+
+    /**
+     * @notice Creates a new token for `creator`. Its token ID will be automatically
+     * assigned (and available on the emitted {IERC721-Transfer} event), and the token
+     * URI autogenerated based on the base URI passed at construction.
+     *
+     * See {ERC721-_safeMint}.
+     *
+     * On mint, also set the keccak256 hashes of the content and its metadata for integrity
+     * checks, along with the initial URIs to point to the content and metadata. Attribute
+     * the token ID to the creator, mark the content hash as used, and set the bid shares for
+     * the media's market.
+     *
+     * Note that although the content hash must be unique for future mints to prevent duplicate media,
+     * metadata has no such requirement.
+     */
+    function _mintForCreator(
+        address creator,
+        MediaData memory data,
+        IMarket.BidShares memory bidShares
+    ) internal onlyValidURI(data.tokenURI) onlyValidURI(data.metadataURI) {
+        require(data.contentHash != 0, 'Media: content hash must be non-zero');
+
+        require(
+            !access._contentHashes[data.contentHash],
+            'Media: a token has already been created with this content hash'
+        );
+
+        require(
+            data.metadataHash != 0,
+            'Media: metadata hash must be non-zero'
+        );
+
+        uint256 tokenId = access._tokenIdTracker.current();
+
+        access._tokenIdTracker.increment();
+        _safeMint(creator, tokenId);
+        _setTokenContentHash(tokenId, data.contentHash);
+        _setTokenMetadataHash(tokenId, data.metadataHash);
+        _setTokenMetadataURI(tokenId, data.metadataURI);
+        _setTokenURI(tokenId, data.tokenURI);
+        access._creatorTokens[creator].add(tokenId);
+        access._contentHashes[data.contentHash] = true;
+
+        tokens.tokenCreators[tokenId] = creator;
+        tokens.previousTokenOwners[tokenId] = creator;
+
+        IMarket(access.marketContract).setBidShares(
+            // address(this),
+            tokenId,
+            bidShares
+        );
+
+        IMarket(access.marketContract).mintOrBurn(true, tokenId, address(this));
+    }
+
+    function _setTokenContentHash(uint256 tokenId, bytes32 contentHash)
+        internal
+        virtual
+        onlyExistingToken(tokenId)
+    {
+        tokens.tokenContentHashes[tokenId] = contentHash;
+    }
+
+    function _setTokenMetadataHash(uint256 tokenId, bytes32 metadataHash)
+        internal
+        virtual
+        onlyExistingToken(tokenId)
+    {
+        tokens.tokenMetadataHashes[tokenId] = metadataHash;
+    }
+
+    function _setTokenMetadataURI(uint256 tokenId, string memory metadataURI)
+        internal
+        virtual
+        onlyExistingToken(tokenId)
+    {
+        access._tokenMetadataURIs[tokenId] = metadataURI;
+    }
+
+    /**
+     * @notice Destroys `tokenId`.
+     * @dev We modify the OZ _burn implementation to
+     * maintain metadata and to remove the
+     * previous token owner from the piece
+     */
+    function _burn(uint256 tokenId)
+        internal
+        override(ERC721URIStorageUpgradeable, ERC721Upgradeable)
+    {
+        ERC721URIStorageUpgradeable._burn(tokenId);
+
+        delete tokens.previousTokenOwners[tokenId];
+
+        IMarket(access.marketContract).mintOrBurn(
+            false,
+            tokenId,
+            address(this)
+        );
+    }
+
+    /**
+     * @notice transfer a token and remove the ask for it.
+     */
+    function _transfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal override {
+        IMarket(access.marketContract).removeAsk(tokenId);
+
+        ERC721Upgradeable._transfer(from, to, tokenId);
+    }
+
+    /**
+     * @dev Calculates EIP712 DOMAIN_SEPARATOR based on the current contract and chain ID.
+     */
+    function _calculateDomainSeparator() internal view returns (bytes32) {
+        uint256 chainID;
+        /* solium-disable-next-line */
+        assembly {
+            chainID := chainid()
+        }
+
+        return
+            keccak256(
+                abi.encode(
+                    kecEIP712Domain,
+                    kecName,
+                    kecOne,
+                    chainID,
+                    address(this)
+                )
+            );
+    }
+}

--- a/contracts/nft/develop/ZapVaultOld.sol
+++ b/contracts/nft/develop/ZapVaultOld.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+import {SafeMathUpgradeable} from '@openzeppelin/contracts-upgradeable/utils/math/SafeMathUpgradeable.sol';
+import {IERC20Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol';
+import {SafeERC20Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol';
+import {Initializable} from '@openzeppelin/contracts/proxy/utils/Initializable.sol';
+import {Ownable} from './access/Ownable.sol';
+
+contract ZapVaultOld is Initializable, Ownable {
+    using SafeMathUpgradeable for uint256;
+    using SafeERC20Upgradeable for IERC20Upgradeable;
+
+    bool private initialized;
+    IERC20Upgradeable zapToken;
+
+    function initializeVault(address token) public initializer {
+        require(!initialized, 'Vault: Instance has already been initialized');
+
+        owner = msg.sender;
+
+        initialized = true;
+
+        zapToken = IERC20Upgradeable(token);
+    }
+
+    function vaultBalance() public view returns (uint256) {
+        return zapToken.balanceOf(address(this));
+    }
+
+    function withdraw(uint256 value) public onlyOwner {
+        require(
+            zapToken.balanceOf(address(this)) >= value,
+            'Vault: Withdraw amount is insufficient.'
+        );
+
+        zapToken.safeTransfer(msg.sender, value);
+    }
+}

--- a/contracts/nft/develop/access/Ownable.sol
+++ b/contracts/nft/develop/access/Ownable.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+import {Initializable} from '@openzeppelin/contracts/proxy/utils/Initializable.sol';
+
+contract Ownable is Initializable {
+    event OwnershipTransferInitiated(
+        address indexed owner,
+        address indexed appointedOwner
+    );
+    event OwnershipTransferred(
+        address indexed previousOwner,
+        address indexed newOwner
+    );
+    address internal owner;
+    address public appointedOwner;
+
+    /// @dev The Ownable constructor sets the original `owner` of the contract to the sender account.
+
+    function initialize() public virtual initializer {
+        owner = msg.sender;
+    }
+
+    function getOwner() external view returns (address) {
+        return owner;
+    }
+
+    /// @dev Throws if called by any contract other than latest designated caller
+    modifier onlyOwner() {
+        require(
+            msg.sender == owner,
+            'Ownable: Only owner has access to this function'
+        );
+        _;
+    }
+
+    /// @dev Allows the current owner to intiate the transfer control of the contract to a newOwner.
+    /// @param newOwner The address to transfer ownership to.
+    function initTransferOwnership(address payable newOwner) public onlyOwner {
+        require(
+            newOwner != address(0),
+            'Ownable: Cannot transfer to zero address'
+        );
+        emit OwnershipTransferInitiated(msg.sender, newOwner);
+        appointedOwner = newOwner;
+    }
+
+    /// @dev Allows new owner to claim the transfer control of the contract
+    function claimTransferOwnership() public {
+        require(
+            appointedOwner != address(0),
+            'Ownable: No ownership transfer have been initiated'
+        );
+        require(
+            msg.sender == appointedOwner,
+            'Ownable: Caller is not the appointed owner of this contract'
+        );
+
+        emit OwnershipTransferred(owner, msg.sender);
+        owner = appointedOwner;
+        appointedOwner = address(0);
+    }
+
+    /// @dev Revoke transfer and set appointed owner to 0 address
+    function revokeTransferOwnership() public onlyOwner {
+        appointedOwner = address(0);
+    }
+}

--- a/contracts/nft/develop/interfaces/IAuctionHouse.sol
+++ b/contracts/nft/develop/interfaces/IAuctionHouse.sol
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+/**
+ * @title Interface for Auction Houses
+ */
+interface IAuctionHouse {
+    struct TokenDetails {
+        // ID for the ERC721 token
+        uint256 tokenId;
+        // Address for the ERC721 contract
+        // address tokenContract;
+        // Address of the media that minted the token
+        address mediaContract;
+    }
+    struct Auction {
+        TokenDetails token;
+        // Whether or not the auction curator has approved the auction to start
+        bool approved;
+        // The current highest bid amount
+        uint256 amount;
+        // The length of time to run the auction for, after the first bid was made
+        uint256 duration;
+        // The time of the first bid
+        uint256 firstBidTime;
+        // The minimum price of the first bid
+        uint256 reservePrice;
+        // The sale percentage to send to the curator
+        uint8 curatorFeePercentage;
+        // The address that should receive the funds once the NFT is sold.
+        address tokenOwner;
+        // The address of the current highest bid
+        address payable bidder;
+        // The address of the auction's curator.
+        // The curator can reject or approve an auction
+        address payable curator;
+        // The address of the ERC-20 currency to run the auction with.
+        // If set to 0x0, the auction will be run in ETH
+        address auctionCurrency;
+    }
+
+    event AuctionCreated(
+        uint256 indexed auctionId,
+        uint256 tokenId,
+        address indexed mediaContract,
+        uint256 duration,
+        uint256 reservePrice,
+        address tokenOwner,
+        address curator,
+        uint8 curatorFeePercentage,
+        address auctionCurrency
+    );
+
+    event AuctionApprovalUpdated(
+        uint256 indexed auctionId,
+        uint256 indexed tokenId,
+        address indexed mediaContract,
+        bool approved
+    );
+
+    event AuctionReservePriceUpdated(
+        uint256 indexed auctionId,
+        uint256 indexed tokenId,
+        address indexed mediaContract,
+        uint256 reservePrice
+    );
+
+    event AuctionBid(
+        uint256 indexed auctionId,
+        uint256 tokenId,
+        address mediaContract,
+        address sender,
+        uint256 value,
+        bool firstBid,
+        bool extended
+    );
+
+    event AuctionDurationExtended(
+        uint256 indexed auctionId,
+        uint256 tokenId,
+        address indexed mediaContract,
+        uint256 duration
+    );
+
+    event AuctionEnded(
+        uint256 indexed auctionId,
+        uint256 tokenId,
+        address indexed mediaContract,
+        address tokenOwner,
+        address curator,
+        address winner,
+        uint256 amount,
+        uint256 curatorFee,
+        address auctionCurrency
+    );
+
+    event AuctionCanceled(
+        uint256 indexed auctionId,
+        uint256 indexed tokenId,
+        address indexed mediaContract,
+        address tokenOwner
+    );
+
+    function createAuction(
+        uint256 tokenId,
+        address mediaContract,
+        uint256 duration,
+        uint256 reservePrice,
+        address payable curator,
+        uint8 curatorFeePercentages,
+        address auctionCurrency
+    ) external returns (uint256);
+
+    function startAuction(uint256 auctionId, bool approved) external;
+
+    function setAuctionReservePrice(uint256 auctionId, uint256 reservePrice)
+        external;
+
+    function createBid(
+        uint256 auctionId,
+        uint256 amount,
+        address mediaContract
+    ) external payable;
+
+    function endAuction(uint256 auctionId, address mediaContract) external;
+
+    function cancelAuction(uint256 auctionId) external;
+}

--- a/contracts/nft/develop/interfaces/IMarket.sol
+++ b/contracts/nft/develop/interfaces/IMarket.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+import {Decimal} from '../Decimal.sol';
+
+/**
+ * @title Interface for Zap NFT Marketplace Protocol's Market
+ */
+interface IMarket {
+    struct Bid {
+        // Amount of the currency being bid
+        uint256 amount;
+        // Address to the ERC20 token being used to bid
+        address currency;
+        // Address of the bidder
+        address bidder;
+        // Address of the recipient
+        address recipient;
+        // % of the next sale to award the current owner
+        Decimal.D256 sellOnShare;
+    }
+
+    struct Ask {
+        // Amount of the currency being asked
+        uint256 amount;
+        // Address to the ERC20 token being asked
+        address currency;
+    }
+
+    struct BidShares {
+        Decimal.D256 creator;
+        // % of sale value that goes to the seller (current owner) of the nft
+        Decimal.D256 owner;
+        // Array that holds all the collaborators
+        address[] collaborators;
+        // % of sale value that goes to the fourth collaborator of the nft
+        uint256[] collabShares;
+        // Decimal.D256[] collaborators;
+    }
+
+    struct PlatformFee {
+        // % of sale value that goes to the Vault
+        Decimal.D256 fee;
+    }
+
+    event BidCreated(
+        address indexed mediaContract,
+        uint256 indexed tokenId,
+        Bid bid
+    );
+    event BidRemoved(
+        uint256 indexed tokenId,
+        Bid bid,
+        address indexed mediaContract
+    );
+    event BidFinalized(
+        uint256 indexed tokenId,
+        Bid bid,
+        address indexed mediaContract
+    );
+    event AskCreated(
+        address indexed mediaContract,
+        uint256 indexed tokenId,
+        Ask ask
+    );
+    event AskRemoved(
+        uint256 indexed tokenId,
+        Ask ask,
+        address indexed mediaContract
+    );
+    event BidShareUpdated(
+        uint256 indexed tokenId,
+        BidShares bidShares,
+        address indexed mediaContract
+    );
+    event MediaContractCreated(
+        address indexed mediaContract,
+        bytes32 name,
+        bytes32 symbol
+    );
+    event Minted(uint256 indexed token, address indexed mediaContract);
+    event Burned(uint256 indexed token, address indexed mediaContract);
+
+    function bidForTokenBidder(
+        address mediaContractAddress,
+        uint256 tokenId,
+        address bidder
+    ) external view returns (Bid memory);
+
+    function currentAskForToken(address mediaContractAddress, uint256 tokenId)
+        external
+        view
+        returns (Ask memory);
+
+    function bidSharesForToken(address mediaContractAddress, uint256 tokenId)
+        external
+        view
+        returns (BidShares memory);
+
+    function isValidBid(
+        address mediaContractAddress,
+        uint256 tokenId,
+        uint256 bidAmount
+    ) external view returns (bool);
+
+    function isValidBidShares(BidShares calldata bidShares)
+        external
+        view
+        returns (bool);
+
+    function splitShare(Decimal.D256 calldata sharePercentage, uint256 amount)
+        external
+        pure
+        returns (uint256);
+
+    function isRegistered(address mediaContractAddress)
+        external
+        view
+        returns (bool);
+
+    function configure(
+        address deployer,
+        address mediaContract,
+        bytes32 name,
+        bytes32 symbol
+    ) external;
+
+    function revokeRegistration(address mediaContract) external;
+
+    function registerMedia(address mediaContract) external;
+
+    function setMediaFactory(address _mediaFactory) external;
+
+    function mintOrBurn(
+        bool isMint,
+        uint256 tokenId,
+        address mediaContract
+    ) external;
+
+    function setBidShares(uint256 tokenId, BidShares calldata bidShares)
+        external;
+
+    function setAsk(uint256 tokenId, Ask calldata ask) external;
+
+    function removeAsk(uint256 tokenId) external;
+
+    function setBid(
+        uint256 tokenId,
+        Bid calldata bid,
+        address spender
+    ) external;
+
+    function removeBid(uint256 tokenId, address bidder) external;
+
+    function acceptBid(
+        address mediaContractAddress,
+        uint256 tokenId,
+        Bid calldata expectedBid
+    ) external;
+}

--- a/contracts/nft/develop/interfaces/IMedia.sol
+++ b/contracts/nft/develop/interfaces/IMedia.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity ^0.8.4;
+pragma experimental ABIEncoderV2;
+
+import {IMarket} from './IMarket.sol';
+
+/**
+ * @title Interface for Zap NFT Marketplace Protocol's Media
+ */
+interface IMedia {
+    struct EIP712Signature {
+        uint256 deadline;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+    }
+
+    struct MediaData {
+        // A valid URI of the content represented by this token
+        string tokenURI;
+        // A valid URI of the metadata associated with this token
+        string metadataURI;
+        // A KECCAK256 hash of the content pointed to by tokenURI
+        bytes32 contentHash;
+        // A KECCAK256 hash of the content pointed to by metadataURI
+        bytes32 metadataHash;
+    }
+
+    event TokenURIUpdated(uint256 indexed _tokenId, address owner, string _uri);
+    event TokenMetadataURIUpdated(
+        uint256 indexed _tokenId,
+        address owner,
+        string _uri
+    );
+
+    function initialize(
+        string memory name,
+        string memory symbol,
+        address marketContractAddr,
+        bool permissive,
+        string memory collectionMetadata
+    ) external;
+
+    /**
+     * @notice Return the metadata URI for a piece of media given the token URI
+     */
+    function tokenMetadataURI(uint256 tokenId)
+        external
+        view
+        returns (string memory);
+
+    /**
+     * @notice Mint new media for msg.sender.
+     */
+    function mint(MediaData calldata data, IMarket.BidShares calldata bidShares)
+        external;
+
+    /**
+     * @notice EIP-712 mintWithSig method. Mints new media for a creator given a valid signature.
+     */
+    function mintWithSig(
+        address creator,
+        MediaData calldata data,
+        IMarket.BidShares calldata bidShares,
+        EIP712Signature calldata sig
+    ) external;
+
+    /**
+     * @notice Transfer the token with the given ID to a given address.
+     * Save the previous owner before the transfer, in case there is a sell-on fee.
+     * @dev This can only be called by the auction contract specified at deployment
+     */
+    function auctionTransfer(uint256 tokenId, address recipient) external;
+
+    /**
+     * @notice Set the ask on a piece of media
+     */
+    function setAsk(uint256 tokenId, IMarket.Ask calldata ask) external;
+
+    /**
+     * @notice Remove the ask on a piece of media
+     */
+    function removeAsk(uint256 tokenId) external;
+
+    /**
+     * @notice Set the bid on a piece of media
+     */
+    function setBid(uint256 tokenId, IMarket.Bid calldata bid) external;
+
+    /**
+     * @notice Remove the bid on a piece of media
+     */
+    function removeBid(uint256 tokenId) external;
+
+    function acceptBid(uint256 tokenId, IMarket.Bid calldata bid) external;
+
+    /**
+     * @notice Revoke approval for a piece of media
+     */
+    function revokeApproval(uint256 tokenId) external;
+
+    /**
+     * @notice Update the token URI
+     */
+    function updateTokenURI(uint256 tokenId, string calldata tokenURI) external;
+
+    /**
+     * @notice Update the token metadata uri
+     */
+    function updateTokenMetadataURI(
+        uint256 tokenId,
+        string calldata metadataURI
+    ) external;
+
+    /**
+     * @notice EIP-712 permit method. Sets an approved spender given a valid signature.
+     */
+    function permit(
+        address spender,
+        uint256 tokenId,
+        EIP712Signature calldata sig
+    ) external;
+}

--- a/contracts/nft/develop/libraries/Constants.sol
+++ b/contracts/nft/develop/libraries/Constants.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+library Constants {
+    //keccak256("Permit(address spender,uint256 tokenId,uint256 nonce,uint256 deadline)");
+    bytes32 public constant PERMIT_TYPEHASH =
+        keccak256(
+            'Permit(address spender,uint256 tokenId,uint256 nonce,uint256 deadline)'
+        );
+
+    //keccak256("MintWithSig(bytes32 contentHash,bytes32 metadataHash,uint256 creatorShare,uint256 nonce,uint256 deadline)");
+    bytes32 public constant MINT_WITH_SIG_TYPEHASH =
+        keccak256(
+            'MintWithSig(bytes32 contentHash,bytes32 metadataHash,uint256 creatorShare,uint256 nonce,uint256 deadline)'
+        );
+
+    bytes4 internal constant _INTERFACE_ID_ERC721_METADATA = 0x4e222e66;
+}

--- a/contracts/nft/develop/libraries/MediaGettersLib.sol
+++ b/contracts/nft/develop/libraries/MediaGettersLib.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+import {MediaStorage} from './MediaStorage.sol';
+
+library MediaGettersLib {
+    function getTokenCreators(
+        MediaStorage.Tokens storage self,
+        uint256 _tokenId
+    ) internal view returns (address creator) {
+        return self.tokenCreators[_tokenId];
+    }
+
+    function getPreviousTokenOwners(
+        MediaStorage.Tokens storage self,
+        uint256 _tokenId
+    ) internal view returns (address prevOwner) {
+        return self.previousTokenOwners[_tokenId];
+    }
+
+    function getTokenContentHashes(
+        MediaStorage.Tokens storage self,
+        uint256 _tokenId
+    ) internal view returns (bytes32 contentHash) {
+        return self.tokenContentHashes[_tokenId];
+    }
+
+    function getTokenMetadataHashes(
+        MediaStorage.Tokens storage self,
+        uint256 _tokenId
+    ) internal view returns (bytes32 metadataHash) {
+        return self.tokenMetadataHashes[_tokenId];
+    }
+}

--- a/contracts/nft/develop/libraries/MediaStorage.sol
+++ b/contracts/nft/develop/libraries/MediaStorage.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+import {Counters} from '@openzeppelin/contracts/utils/Counters.sol';
+import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+/// @title A title that should describe the contract/interface
+/// @author The name of the author
+/// @notice Explain to an end user what this does
+/// @dev Explain to a developer any extra details
+library MediaStorage {
+    using EnumerableSet for EnumerableSet.UintSet;
+    using Counters for Counters.Counter;
+
+    /* *******
+     * Globals
+     * *******
+     */
+
+    struct Tokens {
+        // Mapping from token to previous owner of the token
+        mapping(uint256 => address) previousTokenOwners;
+        // Mapping from token id to creator address
+        mapping(uint256 => address) tokenCreators;
+        // Mapping from token id to keccak256 hash of content
+        mapping(uint256 => bytes32) tokenContentHashes;
+        // Mapping from token id to keccak256 hash of metadata
+        mapping(uint256 => bytes32) tokenMetadataHashes;
+    }
+
+    struct Access {
+        // Address for the market
+        address marketContract;
+        address owner;
+        // Mapping from Media address to whether or not to allow permissive minting
+        bool isPermissive;
+        // Mapping from creator address to their (enumerable) set of created tokens
+        mapping(address => EnumerableSet.UintSet) _creatorTokens;
+        // Mapping from contentHash to bool
+        mapping(bytes32 => bool) _contentHashes;
+        // Mapping from address to token id to permit nonce
+        mapping(address => mapping(uint256 => uint256)) permitNonces;
+        // Mapping from address to mint with sig nonce
+        mapping(address => uint256) mintWithSigNonces;
+        // Mapping from address to boolean; can this address mint?
+        mapping(address => bool) approvedToMint;
+        // Mapping from token id to metadataURI
+        mapping(uint256 => string) _tokenMetadataURIs;
+        Counters.Counter _tokenIdTracker;
+    }
+}

--- a/test/MediaFactoryTest.ts
+++ b/test/MediaFactoryTest.ts
@@ -54,11 +54,15 @@ describe("MediaFactory", () => {
 
     async function deployMediaFactory(marketAddress: string): Promise<MediaFactory> {
 
+        const unInitMediaFactory = await ethers.getContractFactory('ZapMedia');
+
+        const unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
+
         const MediaFactory = await ethers.getContractFactory("MediaFactory");
 
         const mediaFactory = (await upgrades.deployProxy(
             MediaFactory,
-            [marketAddress],
+            [marketAddress, unInitMedia.address],
             { initializer: 'initialize' }
         ));
 
@@ -81,39 +85,39 @@ describe("MediaFactory", () => {
         const signers = await ethers.getSigners();
 
         let collaborators = {
-          collaboratorTwo: signers[10].address,
-          collaboratorThree: signers[11].address,
-          collaboratorFour: signers[12].address
+            collaboratorTwo: signers[10].address,
+            collaboratorThree: signers[11].address,
+            collaboratorFour: signers[12].address
         }
 
         await media.mint(
-          {
-            tokenURI: "zap.co",
-            metadataURI: "zap.co",
-            contentHash: hash,
-            metadataHash: hash,
-          },
-          {
-            collaborators: [
-              signers[10].address,
-              signers[11].address,
-              signers[12].address
-            ],
-            collabShares: [
-              BigNumber.from('15000000000000000000'),
-              BigNumber.from('15000000000000000000'),
-              BigNumber.from('15000000000000000000')
-            ]
-            ,
-            creator: {
-              value: BigNumber.from('15000000000000000000')
+            {
+                tokenURI: "zap.co",
+                metadataURI: "zap.co",
+                contentHash: hash,
+                metadataHash: hash,
             },
-            owner: {
-              value: BigNumber.from('35000000000000000000')
-            },
-          }
+            {
+                collaborators: [
+                    signers[10].address,
+                    signers[11].address,
+                    signers[12].address
+                ],
+                collabShares: [
+                    BigNumber.from('15000000000000000000'),
+                    BigNumber.from('15000000000000000000'),
+                    BigNumber.from('15000000000000000000')
+                ]
+                ,
+                creator: {
+                    value: BigNumber.from('15000000000000000000')
+                },
+                owner: {
+                    value: BigNumber.from('35000000000000000000')
+                },
+            }
         );
-      };
+    };
 
     async function createAuction(
         media: string,
@@ -122,22 +126,22 @@ describe("MediaFactory", () => {
         currency: string,
         duration?: number,
         token?: BigNumberish
-      ) {
-        if(!token) token = 0;
-        if(!duration) duration = 60 * 60 * 24;
+    ) {
+        if (!token) token = 0;
+        if (!duration) duration = 60 * 60 * 24;
 
         const reservePrice = BigNumber.from(10).pow(18).div(2);
 
         await auctionHouse.createAuction(
-          token,
-          media,
-          duration,
-          reservePrice,
-          curator,
-          5,
-          currency
+            token,
+            media,
+            duration,
+            reservePrice,
+            curator,
+            5,
+            currency
         );
-      }
+    }
 
     let zapTokenBsc: ZapTokenBSC;
     let zapVault: ZapVault;
@@ -159,7 +163,7 @@ describe("MediaFactory", () => {
 
         await zapMarket.setMediaFactory(mediaFactory.address);
 
-        [ deployer, mediaOwner, badActor ] = await ethers.getSigners();
+        [deployer, mediaOwner, badActor] = await ethers.getSigners();
 
         await mediaFactory.connect(mediaOwner).deployMedia(
             'TEST MEDIA 1',
@@ -215,7 +219,7 @@ describe("MediaFactory", () => {
         beforeEach(async () => {
             auctionHouse = await deployAuction(deployer, zapTokenBsc.address, zapMarket.address);
             zapMedia = new ethers.Contract(mediaAddress, zmABI, mediaOwner) as ZapMedia;
-            
+
             const platformFee = {
                 fee: {
                     value: BigNumber.from('5000000000000000000')
@@ -266,13 +270,13 @@ describe("MediaFactory", () => {
                 null, null, null
             );
 
-            const eventLog =  (await auctionHouse.queryFilter(createdfilter))[0];
+            const eventLog = (await auctionHouse.queryFilter(createdfilter))[0];
 
-            expect(eventLog.args?.tokenId).to.be.      eq(0);
-            expect(eventLog.args?.auctionId).to.be.    eq(0);
+            expect(eventLog.args?.tokenId).to.be.eq(0);
+            expect(eventLog.args?.auctionId).to.be.eq(0);
             expect(eventLog.args?.mediaContract).to.be.eq(zapMedia.address);
-            expect(eventLog.args?.curator).to.be.      eq(mediaOwner.address);
-            expect(eventLog.args?.tokenOwner).to.be.   eq(mediaOwner.address);
+            expect(eventLog.args?.curator).to.be.eq(mediaOwner.address);
+            expect(eventLog.args?.tokenOwner).to.be.eq(mediaOwner.address);
         });
     })
 });

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -177,9 +177,15 @@ describe('ZapMarket Test', () => {
 
       await zapMarket.setFee(platformFee);
 
+      const unInitMediaFactory = await ethers.getContractFactory("ZapMedia");
+
+      let unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
+
+      await unInitMedia.deployed();
+
       const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
         initializer: 'initialize'
       })) as MediaFactory;
 
@@ -189,26 +195,26 @@ describe('ZapMarket Test', () => {
 
       const medias = await deployJustMedias(signers, zapMarket, mediaDeployer);
 
-      zapMedia1 = medias[0];
-      zapMedia2 = medias[1];
-      zapMedia3 = medias[2];
+      // zapMedia1 = medias[0];
+      // zapMedia2 = medias[1];
+      // zapMedia3 = medias[2];
 
-      await zapMedia1.claimTransferOwnership();
-      await zapMedia2.claimTransferOwnership();
-      await zapMedia3.claimTransferOwnership();
+      // await zapMedia1.claimTransferOwnership();
+      // await zapMedia2.claimTransferOwnership();
+      // await zapMedia3.claimTransferOwnership();
 
-      ask1.currency = zapTokenBsc.address;
+      // ask1.currency = zapTokenBsc.address;
 
-      let metadataHex = ethers.utils.formatBytes32String('{}');
-      let metadataHash = await keccak256(metadataHex);
-      metadataHashBytes = ethers.utils.arrayify(metadataHash);
+      // let metadataHex = ethers.utils.formatBytes32String('{}');
+      // let metadataHash = await keccak256(metadataHex);
+      // metadataHashBytes = ethers.utils.arrayify(metadataHash);
 
-      let contentHex = ethers.utils.formatBytes32String('invert');
-      let contentHash = await keccak256(contentHex);
-      contentHashBytes = ethers.utils.arrayify(contentHash);
+      // let contentHex = ethers.utils.formatBytes32String('invert');
+      // let contentHash = await keccak256(contentHex);
+      // contentHashBytes = ethers.utils.arrayify(contentHash);
 
-      bidShares1.collaborators = [signers[10].address, signers[11].address, signers[12].address];
-      bidShares2.collaborators = [signers[10].address, signers[11].address, signers[12].address];
+      // bidShares1.collaborators = [signers[10].address, signers[11].address, signers[12].address];
+      // bidShares2.collaborators = [signers[10].address, signers[11].address, signers[12].address];
 
     });
 
@@ -221,7 +227,7 @@ describe('ZapMarket Test', () => {
       })
     })
 
-    it("Should get the market owner", async () => {
+    it.only("Should get the market owner", async () => {
       const owner = await zapMarket.getOwner()
       expect(signers[0].address).to.equal(owner)
     })
@@ -1684,7 +1690,7 @@ describe('ZapMarket Test', () => {
         null, null
       );
 
-      
+
       const event_transferredOwnership: Event = (
         await zapMarket.queryFilter(filter_transfered)
       )[0]

--- a/test/ZapMarketTest.ts
+++ b/test/ZapMarketTest.ts
@@ -63,6 +63,18 @@ let platformFee = {
 
 describe('ZapMarket Test', () => {
   let zapTokenBsc: any;
+  let unInitMedia: ZapMedia;
+
+  before(async () => {
+
+    const unInitMediaFactory = await ethers.getContractFactory("ZapMedia");
+
+    unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
+
+    await unInitMedia.deployed();
+
+  })
+
 
   beforeEach(async () => {
     signers = await ethers.getSigners();
@@ -177,12 +189,6 @@ describe('ZapMarket Test', () => {
 
       await zapMarket.setFee(platformFee);
 
-      const unInitMediaFactory = await ethers.getContractFactory("ZapMedia");
-
-      let unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
-
-      await unInitMedia.deployed();
-
       const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
       mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
@@ -195,26 +201,26 @@ describe('ZapMarket Test', () => {
 
       const medias = await deployJustMedias(signers, zapMarket, mediaDeployer);
 
-      // zapMedia1 = medias[0];
-      // zapMedia2 = medias[1];
-      // zapMedia3 = medias[2];
+      zapMedia1 = medias[0];
+      zapMedia2 = medias[1];
+      zapMedia3 = medias[2];
 
-      // await zapMedia1.claimTransferOwnership();
-      // await zapMedia2.claimTransferOwnership();
-      // await zapMedia3.claimTransferOwnership();
+      await zapMedia1.claimTransferOwnership();
+      await zapMedia2.claimTransferOwnership();
+      await zapMedia3.claimTransferOwnership();
 
-      // ask1.currency = zapTokenBsc.address;
+      ask1.currency = zapTokenBsc.address;
 
-      // let metadataHex = ethers.utils.formatBytes32String('{}');
-      // let metadataHash = await keccak256(metadataHex);
-      // metadataHashBytes = ethers.utils.arrayify(metadataHash);
+      let metadataHex = ethers.utils.formatBytes32String('{}');
+      let metadataHash = await keccak256(metadataHex);
+      metadataHashBytes = ethers.utils.arrayify(metadataHash);
 
-      // let contentHex = ethers.utils.formatBytes32String('invert');
-      // let contentHash = await keccak256(contentHex);
-      // contentHashBytes = ethers.utils.arrayify(contentHash);
+      let contentHex = ethers.utils.formatBytes32String('invert');
+      let contentHash = await keccak256(contentHex);
+      contentHashBytes = ethers.utils.arrayify(contentHash);
 
-      // bidShares1.collaborators = [signers[10].address, signers[11].address, signers[12].address];
-      // bidShares2.collaborators = [signers[10].address, signers[11].address, signers[12].address];
+      bidShares1.collaborators = [signers[10].address, signers[11].address, signers[12].address];
+      bidShares2.collaborators = [signers[10].address, signers[11].address, signers[12].address];
 
     });
 
@@ -227,7 +233,7 @@ describe('ZapMarket Test', () => {
       })
     })
 
-    it.only("Should get the market owner", async () => {
+    it("Should get the market owner", async () => {
       const owner = await zapMarket.getOwner()
       expect(signers[0].address).to.equal(owner)
     })
@@ -397,7 +403,7 @@ describe('ZapMarket Test', () => {
 
       const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory");
 
-      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
         initializer: 'initialize'
       })) as MediaFactory;
 
@@ -654,7 +660,7 @@ describe('ZapMarket Test', () => {
 
       const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory");
 
-      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
         initializer: 'initialize'
       })) as MediaFactory;
 
@@ -893,7 +899,7 @@ describe('ZapMarket Test', () => {
 
       const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory");
 
-      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
         initializer: 'initialize'
       })) as MediaFactory;
 
@@ -1431,7 +1437,7 @@ describe('ZapMarket Test', () => {
 
   });
 
-  describe("Re entrancy", () => {
+  describe("#Re-entrancy", () => {
     let bid1: any;
     let bid2: any;
 
@@ -1469,7 +1475,7 @@ describe('ZapMarket Test', () => {
 
       const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory");
 
-      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+      mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
         initializer: 'initialize'
       })) as MediaFactory;
 

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -33,11 +33,11 @@ describe("ZapMedia Test", async () => {
     let zapMedia1: ZapMedia;
     let zapMedia2: ZapMedia;
     let zapMedia3: ZapMedia;
+    let unInitMedia: ZapMedia;
     let mediaDeployer: MediaFactory;
     let zapVault: ZapVault;
     let zapTokenBsc: any;
     let signers: any;
-
 
     let bidShares = {
         collaborators: ["", "", ""],
@@ -123,6 +123,10 @@ describe("ZapMedia Test", async () => {
             ]
         }
 
+        const unInitMediaFactory = await ethers.getContractFactory('ZapMedia');
+
+        unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
+
     })
 
     describe("Configure", () => {
@@ -162,7 +166,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -258,7 +262,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -463,7 +467,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -873,7 +877,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -986,7 +990,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1107,7 +1111,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1294,7 +1298,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1364,7 +1368,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1502,7 +1506,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1618,7 +1622,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1743,7 +1747,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1827,7 +1831,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 
@@ -1862,7 +1866,7 @@ describe("ZapMedia Test", async () => {
 
                 const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-                mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+                mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                     initializer: 'initialize'
                 })) as MediaFactory;
 
@@ -1945,7 +1949,7 @@ describe("ZapMedia Test", async () => {
 
             const mediaDeployerFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
 
-            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address], {
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, unInitMedia.address], {
                 initializer: 'initialize'
             })) as MediaFactory;
 

--- a/test/ZapMediaTest.ts
+++ b/test/ZapMediaTest.ts
@@ -1,6 +1,6 @@
 import { ethers, upgrades } from "hardhat";
 
-import { EventFilter, Event } from "ethers";
+import { EventFilter, Event, ContractFactory } from "ethers";
 
 import { solidity } from "ethereum-waffle";
 
@@ -2077,6 +2077,189 @@ describe("ZapMedia Test", async () => {
 
         });
 
+    });
+
+    describe("Upgradeability", () => {
+        let mediaContractFactoryV2: ContractFactory;
+        let mediaDeployerFactoryV2: ContractFactory;
+        let marketFactoryV2: ContractFactory;
+        let initData: any[];
+        beforeEach(async () => {
+
+            tokenURI = String('media contract 1 - token 1 uri');
+            metadataURI = String('media contract 1 - metadata 1 uri');
+
+            metadataHex = formatBytes32String("{}");
+            metadataHash = keccak256(metadataHex);
+            metadataHashBytes = arrayify(metadataHash);
+
+            randomString = Date.now().toString();
+            contentHex = formatBytes32String(randomString);
+            contentHash = keccak256(contentHex);
+            contentHashBytes = arrayify(contentHash);
+
+            zeroContentHashBytes = arrayify(ethers.constants.HashZero);
+
+            mediaData = {
+                tokenURI,
+                metadataURI,
+                contentHash: contentHashBytes,
+                metadataHash: metadataHashBytes,
+            };
+
+            const oldVaultArtifact = require('../artifacts/contracts/nft/develop/ZapVaultOld.sol/ZapVaultOld.json');
+            const oldVaultABI = oldVaultArtifact.abi;
+            const oldVaultBytecode = oldVaultArtifact.bytecode;
+            const zapVaultFactory = new ethers.ContractFactory(oldVaultABI, oldVaultBytecode, signers[0]);
+
+            zapVault = (await upgrades.deployProxy(zapVaultFactory, [zapTokenBsc.address], {
+                initializer: 'initializeVault'
+            })) as ZapVault;
+
+            const oldZMArtifact = require('../artifacts/contracts/nft/develop/ZapMarketOld.sol/ZapMarketOld.json');
+            const oldZMABI = oldZMArtifact.abi;
+            const oldZMBytecode = oldZMArtifact.bytecode;
+            const zapMarketFactory = new ethers.ContractFactory(oldZMABI, oldZMBytecode, signers[0]);
+
+            zapMarket = (await upgrades.deployProxy(zapMarketFactory, [zapVault.address], {
+                initializer: 'initializeMarket'
+            })) as ZapMarket;
+
+            await zapMarket.deployed();
+            await zapMarket.setFee(platformFee);
+
+            const zapMediaFactoryV1 = await ethers.getContractFactory("ZapMediaOld", signers[5]);
+            const zapMediaInterface = await zapMediaFactoryV1.deploy();
+
+            const mediaDeployerFactory = await ethers.getContractFactory("MediaFactoryOld", signers[0]);
+            mediaDeployer = (await upgrades.deployProxy(mediaDeployerFactory, [zapMarket.address, zapMediaInterface.address], {
+                initializer: 'initialize'
+            })) as MediaFactory;
+
+            await mediaDeployer.deployed();
+
+            await zapMarket.setMediaFactory(mediaDeployer.address);
+
+            const medias = await deployOneMedia(signers[5], zapMarket, mediaDeployer, 101);
+
+            zapMedia1 = medias;
+            await zapMedia1.connect(signers[5]).claimTransferOwnership();
+
+            initData = [
+                "TEST MEDIA 2",
+                "TM2",
+                zapMarket.address,
+                false,
+                "https://ipfs.io/ipfs/QmTDCTPF6CpUK7DTqcUvRpGysfA1EbgRob5uGsStcCZie6"
+            ];
+
+            const zapMediaFactory = await ethers.getContractFactory("ZapMediaOld", signers[0]);
+            zapMedia2 = await upgrades.deployProxy(zapMediaFactory, [...initData]) as ZapMedia;
+            await zapMedia2.deployed();
+
+            mediaContractFactoryV2 = await ethers.getContractFactory("ZapMedia", signers[0]);
+            mediaDeployerFactoryV2 = await ethers.getContractFactory("MediaFactory", signers[0]);
+
+            await zapMedia1.connect(signers[5]).mint(mediaData, bidShares);
+            expect(await zapMedia1.ownerOf(0)).to.be.eq(signers[5].address);
+
+            marketFactoryV2 = await ethers.getContractFactory("ZapMarket", signers[0]);
+
+        });
+        it("Should be able to upgrade v1 ZapMedia to a version allowing external NFTs", async () => {
+            await expect(
+                upgrades.upgradeProxy(zapMedia2.address, mediaContractFactoryV2),
+                "ensuring that the media contract's storage is fully upgradeable").to.not.be.reverted;
+
+            // upgrading to the new MediaFactory which contains ZapMediaV2
+            mediaDeployer = await upgrades.upgradeProxy(mediaDeployer, mediaDeployerFactoryV2) as MediaFactory;
+            const owner = await zapMedia1.getOwner();
+
+            // ensuring that ZapMedia can be upgraded
+            const zapMediaInterfaceV2 = await mediaContractFactoryV2.deploy();
+            await expect(mediaDeployer.connect(signers[0]).upgradeMedia(zapMediaInterfaceV2.address)).to.not.be.reverted;
+            // ensuring the state of the contracts are transfered
+            expect(await zapMedia1.getOwner()).to.be.eq(owner);
+            expect(await zapMedia1.ownerOf(0)).to.be.eq(owner);
+            expect(await zapMedia1.getTokenMetadataURIs(0)).to.be.eq(metadataURI);
+        });
+
+        it("Should be able to mint once MediaFactory is updated along with ZapMarket", async () => {
+            // upgrading to the new MediaFactory which contains ZapMediaV2
+            mediaDeployer = await upgrades.upgradeProxy(mediaDeployer, mediaDeployerFactoryV2) as MediaFactory;
+            const owner = await zapMedia1.getOwner();
+            const zapMediaInterfaceV2 = await mediaContractFactoryV2.deploy();
+            await mediaDeployer.connect(signers[0]).upgradeMedia(zapMediaInterfaceV2.address);
+
+            //// minting a second token
+            metadataHex = formatBytes32String("{}");
+            metadataHash = keccak256(metadataHex);
+            metadataHashBytes = arrayify(metadataHash);
+
+            randomString = Date.now().toString();
+            contentHex = formatBytes32String(randomString);
+            contentHash = keccak256(contentHex);
+            contentHashBytes = arrayify(contentHash);
+
+            await expect(zapMedia1.connect(signers[5]).mint(
+                {
+                    tokenURI: String('media contract 2 - token 2 uri'),
+                    metadataURI: String('media contract 2 - metadata 2 uri'),
+                    contentHash: contentHashBytes,
+                    metadataHash: metadataHashBytes
+                },
+                bidShares
+            ),
+                "ZapMarket needs to be updated as well before minting"
+            ).to.be.reverted;
+
+            zapMarket = await upgrades.upgradeProxy(zapMarket.address, marketFactoryV2) as ZapMarket;
+
+            await expect(zapMedia1.connect(signers[5]).mint(
+                {
+                    tokenURI: String('media contract 2 - token 2 uri'),
+                    metadataURI: String('media contract 2 - metadata 2 uri'),
+                    contentHash: contentHashBytes,
+                    metadataHash: metadataHashBytes
+                },
+                bidShares
+            ),
+                "ZapMarket needs to be updated as well"
+            ).to.not.be.reverted;
+            expect(await zapMedia1.ownerOf(1)).to.be.eq(owner);
+            expect(await zapMedia1.ownerOf(0), "ensuring that pre-upgrade storage persists").to.be.eq(owner);
+        });
+
+        it("Should not allow a non-owner to upgrade the ZapMedia interface", async () => {
+            mediaDeployer = await upgrades.upgradeProxy(mediaDeployer, mediaDeployerFactoryV2) as MediaFactory;
+            const owner = await zapMedia1.getOwner();
+
+            // owner is signers[5]
+            const zapMediaInterfaceV2 = await mediaContractFactoryV2.deploy();
+            await expect(
+                mediaDeployer.connect(signers[5]).upgradeMedia(zapMediaInterfaceV2.address)
+            ).to.be.revertedWith(
+                "Ownable: caller is not the owner"
+            );
+        });
+
+        it("Should not be able to initialize after being upgraded", async () => {
+            mediaDeployer = await upgrades.upgradeProxy(mediaDeployer, mediaDeployerFactoryV2) as MediaFactory;
+            const zapMediaInterfaceV2 = await mediaContractFactoryV2.deploy();
+            await mediaDeployer.connect(signers[0]).upgradeMedia(zapMediaInterfaceV2.address);
+
+            const [tokenname, symbol, marketContractAddr, permissive, collectionMetadata] = initData;
+
+            await expect(zapMedia1.connect(signers[5]).initialize(
+                tokenname,
+                symbol,
+                marketContractAddr,
+                permissive,
+                collectionMetadata
+            )).to.be.revertedWith(
+                "Initializable: contract is already initialized"
+            );
+        });
     });
 
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -196,8 +196,12 @@ export const deployZapNFTMarketplace = async () => {
 
   await market.setFee(platformFee);
 
+  const unInitMediaFactory = await ethers.getContractFactory('ZapMedia');
+
+  const unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
+
   const mediaFactoryFactory = await ethers.getContractFactory("MediaFactory", deployer0);
-  mediaFactory = (await upgrades.deployProxy(mediaFactoryFactory, [market.address], { initializer: "initialize" })) as MediaFactory;
+  mediaFactory = (await upgrades.deployProxy(mediaFactoryFactory, [market.address, unInitMedia.address], { initializer: "initialize" })) as MediaFactory;
   await market.setMediaFactory(mediaFactory.address);
 
   const mediaArgs = [

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -65,7 +65,7 @@ export const deployOtherNFTs = async () => {
 
 export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: ZapMarket, mediaDeploy: MediaFactory) => {
   await zapMarket.setMediaFactory(mediaDeploy.address);
-  console.log("DEPLOY")
+
   const mediaArgs = [
     {
       name: "TEST MEDIA 1",
@@ -104,7 +104,9 @@ export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: 
   const zmABI = require("../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json").abi;
 
   for (let i = 0; i < mediaArgs.length; i++) {
+
     const args = mediaArgs[i];
+
     await mediaDeploy.connect(mediaDeployers[i]).deployMedia(
       args.name, args.symbol, args.marketContractAddr, args.permissive, args.collectionURI
     );
@@ -117,7 +119,6 @@ export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: 
       new ethers.Contract(mediaAddress, zmABI, mediaDeployers[i]) as ZapMedia
     );
 
-    console.log("DEPLOY2")
   }
 
   return medias

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -65,7 +65,7 @@ export const deployOtherNFTs = async () => {
 
 export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: ZapMarket, mediaDeploy: MediaFactory) => {
   await zapMarket.setMediaFactory(mediaDeploy.address);
-
+  console.log("DEPLOY")
   const mediaArgs = [
     {
       name: "TEST MEDIA 1",
@@ -116,6 +116,8 @@ export const deployJustMedias = async (signers: SignerWithAddress[], zapMarket: 
     medias.push(
       new ethers.Contract(mediaAddress, zmABI, mediaDeployers[i]) as ZapMedia
     );
+
+    console.log("DEPLOY2")
   }
 
   return medias
@@ -145,7 +147,7 @@ export const deployOneMedia = async (signer: SignerWithAddress, zapMarket: ZapMa
   filter = fact.filters.MediaDeployed(null);
   eventLog = (await fact.queryFilter(filter))[0];
   mediaAddress = eventLog.args?.mediaContract;
-  
+
   media = new ethers.Contract(mediaAddress, zmABI, signer) as ZapMedia;
 
   return media;


### PR DESCRIPTION
## Summary
The upgradeability had to be updated in a different branch from #231 
Using changes from #270 

## Implementation
- [x]  MediaProxy updated to for Beacon Proxy pattern
- [x] MediaFactory Updated Beacon Proxy pattern
- [x] Added the uninitialized zapMedia address for media factory deployment in all NFT tests allowing the tests to pass

## Files
```contracts/nft/MediaProxy.sol```
```contracts/nft/MediaFactory.sol```
```test/ZapMarketTest.ts```
```test/ZapMediaTest.ts```
```test/AuctionHouseTest.ts```
```test/MediaFactoryTest.ts```



