### PR TITLE
Update NFT contract deploy script

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -69,13 +69,17 @@ const config = {
     coinmarketcap: process.env.COINMARKETCAP_API_KEY
   },
   networks: {
-    localhost: {
-      url: 'http://127.0.0.1:8545/'
-    },
-    ethMainnet: {
+    mainnet: {
       url: `https://mainnet.infura.io/v3/${INFURA_API_KEY}`,
-      chainId: 1,
-      accounts: [process.env.MAINNET_PRIVATE_KEY]
+      accounts: { mnemonic: process.env.MNEMONIC }
+    },
+    rinkeby: {
+      url: `https://rinkeby.infura.io/v3/${INFURA_API_KEY}`,
+      accounts: [RINKEBY_PRIVATE_KEY]
+    },
+    kovan: {
+      url: `https://kovan.infura.io/v3/${INFURA_API_KEY}`,
+      accounts: [KOVAN_PRIVATE_KEY]
     },
     binanceMainnet: {
       url: 'https://bsc-dataseed.binance.org/',
@@ -95,13 +99,8 @@ const config = {
       blockGasLimit: 0x1fffffffffffff,
       allowUnlimitedContractSize: true,
     },
-    rinkeby: {
-      url: `https://rinkeby.infura.io/v3/${INFURA_API_KEY}`,
-      accounts: [RINKEBY_PRIVATE_KEY]
-    },
-    kovan: {
-      url: `https://kovan.infura.io/v3/${INFURA_API_KEY}`,
-      accounts: [KOVAN_PRIVATE_KEY]
+    localhost: {
+      url: 'http://127.0.0.1:8545/'
     },
     coverage: {
       url: 'http://127.0.0.1:8555' // Coverage launches its own ganache-cli client

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -79,7 +79,7 @@ const config = {
       accounts: { mnemonic: process.env.MNEMONIC }
     },
     testnet: {
-      url: 'https://data-seed-prebsc-1-s2.binance.org:8545',
+      url: 'https://data-seed-prebsc-1-s1.binance.org:8545/',
       chainId: 97,
       gasPrice: 20000000000,
       accounts: { mnemonic: process.env.MNEMONIC }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -75,14 +75,14 @@ const config = {
     binanceMainnet: {
       url: 'https://bsc-dataseed.binance.org/',
       chainId: 56,
-      gasPrice: 20000000000
-      // accounts: { mnemonic: process.env.MNEMONIC }
+      gasPrice: 20000000000,
+      accounts: { mnemonic: process.env.MNEMONIC }
     },
     testnet: {
       url: 'https://data-seed-prebsc-1-s2.binance.org:8545',
       chainId: 97,
       gasPrice: 20000000000,
-      // accounts: { mnemonic: process.env.MNEMONIC }
+      accounts: { mnemonic: process.env.MNEMONIC }
     },
     hardhat: {
       gas: 12000000,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -72,6 +72,11 @@ const config = {
     localhost: {
       url: 'http://127.0.0.1:8545/'
     },
+    ethMainnet: {
+      url: `https://mainnet.infura.io/v3/${INFURA_API_KEY}`,
+      chainId: 1,
+      accounts: [process.env.MAINNET_PRIVATE_KEY]
+    },
     binanceMainnet: {
       url: 'https://bsc-dataseed.binance.org/',
       chainId: 56,

--- a/nft_bsc_mainnet.sh
+++ b/nft_bsc_mainnet.sh
@@ -1,0 +1,1 @@
+npx hardhat run --network binanceMainnet scripts/deploy_nft_contracts.ts

--- a/nft_bsc_test.sh
+++ b/nft_bsc_test.sh
@@ -1,0 +1,1 @@
+npx hardhat run --network testnet scripts/deploy_nft_contracts.ts

--- a/nft_local.sh
+++ b/nft_local.sh
@@ -1,0 +1,4 @@
+npx hardhat node --hostname 0.0.0.0 &
+sleep 10
+npx hardhat run --network localhost scripts/deploy_nft_contracts.ts
+while true; do sleep 1; done

--- a/nft_mainnet.sh
+++ b/nft_mainnet.sh
@@ -1,0 +1,1 @@
+npx hardhat run --network mainnet scripts/deploy_nft_contracts.ts

--- a/nft_rink.sh
+++ b/nft_rink.sh
@@ -1,0 +1,1 @@
+npx hardhat run --network rinkeby scripts/deploy_nft_contracts.ts

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -12,11 +12,13 @@ async function main() {
     // Deployed ZapToken on BSC Testnet
     const bscTestAddress = '0x09d8AF358636D9BCC9a3e177B66EB30381a4b1a8';
 
+    const name = 'ZapMedia';
+
     // Will store the ZapToken address depending on the network
     let tokenAddress = '';
     let localhostAddress = '';
-    let symbol: string;
-    let contractURI: string;
+    let symbol = '';
+    let contractURI = '';
 
     try {
 
@@ -36,7 +38,8 @@ async function main() {
         // Localhost deployment
         case 31337:
             tokenAddress = localhostAddress
-            symbol = "ZAPLCL"
+            symbol = "ZAPLCL";
+            contractURI = ''
             console.log("Localhost")
             break;
 
@@ -44,6 +47,7 @@ async function main() {
         case 4:
             tokenAddress = rinkebyAddress;
             symbol = "ZAPRKBY"
+            contractURI = 'https://bafybeiev76hwk2gu7xmy5h3dn2f6iquxkhu4dhwpjgmt6ookrn6ykbtfi4.ipfs.dweb.link/rinkeby';
             console.log("Rinkeby");
             break;
 
@@ -51,12 +55,14 @@ async function main() {
         case 97:
             tokenAddress = bscTestAddress
             symbol = "ZAPBSC"
+            contractURI = 'https://bafybeiev76hwk2gu7xmy5h3dn2f6iquxkhu4dhwpjgmt6ookrn6ykbtfi4.ipfs.dweb.link/bscTest'
             console.log("BSC TESTNET");
             break;
     }
 
     const signers = await ethers.getSigners();
 
+    // Sets the fee at to 5%
     const platformFee = {
         fee: {
             value: BigNumber.from('5000000000000000000')
@@ -72,8 +78,6 @@ async function main() {
     );
     await zapVault.deployed();
     console.log("ZapVault deployed to:", zapVault.address);
-    const zapVaultImplAddress = await getImplementationAddress(ethers.provider, zapVault.address);
-    console.log("ZapVault implementation:", zapVaultImplAddress);
 
     // Deploy ZapMarket
     const ZapMarket = await ethers.getContractFactory('ZapMarket', signers[0]);
@@ -84,11 +88,12 @@ async function main() {
     );
     await zapMarket.deployed();
     console.log('ZapMarket deployed to:', zapMarket.address);
-    const zapMarketImplAddress = await getImplementationAddress(ethers.provider, zapMarket.address);
-    console.log("ZapMarket implementation:", zapMarketImplAddress);
+
+    // Gas estimation for setFee()
+    const setFeeGas = await zapMarket.estimateGas.setFee(platformFee);
 
     // Sets the platform fee
-    await zapMarket.setFee(platformFee);
+    await zapMarket.setFee(platformFee, { gasLimit: setFeeGas });
 
     // Deploys the Media Interface
     const unInitMediaFactory = await ethers.getContractFactory("ZapMedia");
@@ -103,41 +108,44 @@ async function main() {
         [zapMarket.address, unInitMedia.address],
         { initializer: 'initialize' }
     ) as MediaFactory;
+
     await mediaFactory.deployed();
     console.log('MediaFactory deployed to:', mediaFactory.address);
-    await zapMarket.setMediaFactory(mediaFactory.address);
+
+    // Gas estimation for setMediaFactory()
+    const setFactoryGas = await zapMarket.estimateGas.setMediaFactory(mediaFactory.address)
+
+    await zapMarket.setMediaFactory(mediaFactory.address, { gasLimit: setFactoryGas });
     console.log("MediaFactory set to ZapMarket");
-    const factoryImplAddress = await getImplementationAddress(ethers.provider, mediaFactory.address);
-    console.log("MediaFactory implementation:", factoryImplAddress);
 
     await mediaFactory.deployMedia(
-        "ZapMedia",
-        "ZAPBSC",
+        name,
+        symbol,
         zapMarket.address,
         true,
-        'https://ipfs.moralis.io:2053/ipfs/Qmb6X5bYB3J6jq9JPmd5FLx4fa4JviXfV11yN42i96Q5Xt'
+        contractURI
     );
-    // const mediaDeployedFilter = mediaFactory.filters.MediaDeployed(null);
-    // const mediaDeployedEvent: Event = (await mediaFactory.queryFilter(mediaDeployedFilter))[0];
-    // const zapMediaAddress = mediaDeployedEvent.args?.mediaContract;
-    // const zapMediaABI = require('../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json').abi;
-    // const zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
-    // await zapMedia.deployed();
-    // await zapMedia.connect(signers[0]).claimTransferOwnership();
 
-    // console.log('ZapMedia deployed to:', zapMedia.address);
-    // const mediaImplAddress = await getImplementationAddress(ethers.provider, zapMedia.address);
-    // console.log("ZapMedia implementation:", mediaImplAddress);
+    const mediaDeployedFilter = mediaFactory.filters.MediaDeployed(null);
+    const mediaDeployedEvent: Event = (await mediaFactory.queryFilter(mediaDeployedFilter))[0];
+    const zapMediaAddress = mediaDeployedEvent.args?.mediaContract;
+    const zapMediaABI = require('../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json').abi;
+    const zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
+    await zapMedia.deployed();
 
-    // const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
-    // const auctionHouse = await upgrades.deployProxy(AuctionHouse,
-    //     [tokenAddress, zapMarket.address],
-    //     { initializer: 'initialize' }
-    // );
-    // await auctionHouse.deployed();
-    // console.log('AuctionHouse deployed to:', auctionHouse.address);
-    // const auctionImplAddress = await getImplementationAddress(ethers.provider, auctionHouse.address);
-    // console.log("AuctionHouse implementation:", auctionImplAddress);
+    const claimGas = await zapMedia.estimateGas.claimTransferOwnership();
+    await zapMedia.connect(signers[0]).claimTransferOwnership({ gasLimit: claimGas });
+
+    console.log('ZapMedia ownership claimed by', signers[0].address)
+    console.log('ZapMedia deployed to:', zapMedia.address);
+
+    const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
+    const auctionHouse = await upgrades.deployProxy(AuctionHouse,
+        [tokenAddress, zapMarket.address],
+        { initializer: 'initialize' }
+    );
+    await auctionHouse.deployed();
+    console.log('AuctionHouse deployed to:', auctionHouse.address);
 
 }
 

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -2,13 +2,60 @@ import { ethers, upgrades } from "hardhat";
 import { BigNumber, Event } from 'ethers';
 import { getImplementationAddress } from '@openzeppelin/upgrades-core';
 import { MediaFactory, ZapMedia } from "../typechain";
+import hre from 'hardhat';
 
 async function main() {
 
-    const signers = await ethers.getSigners();
+    // Deployed ZapToken on Rinkeby
+    const rinkebyAddress = '0x5877451904f0484cc49DAFdfb8f9b33C8C31Ee2F';
 
-    // ZapTokenBSC testnet address used for the Faucet
-    const tokenAddress = '0x09d8AF358636D9BCC9a3e177B66EB30381a4b1a8';
+    // Deployed ZapToken on BSC Testnet
+    const bscTestAddress = '0x09d8AF358636D9BCC9a3e177B66EB30381a4b1a8';
+
+    // Will store the ZapToken address depending on the network
+    let tokenAddress = '';
+    let localhostAddress = '';
+    let symbol: string;
+    let contractURI: string;
+
+    try {
+
+        localhostAddress = (await hre.deployments.get('ZapTokenBSC')).address;
+
+    } catch (err) {
+
+        console.log("Localhost ZapTokenBSC deployment not detected")
+
+    }
+
+    // Gets the chainID of the network the contracts are deploying to
+    const chainId = await (await ethers.provider.getNetwork()).chainId;
+
+    switch (chainId) {
+
+        // Localhost deployment
+        case 31337:
+            tokenAddress = localhostAddress
+            symbol = "ZAPLCL"
+            console.log("Localhost")
+            break;
+
+        // Rinkeby deployment
+        case 4:
+            tokenAddress = rinkebyAddress;
+            symbol = "ZAPRKBY"
+            console.log("Rinkeby");
+            break;
+
+        // BSC Testnet deployment
+        case 97:
+            tokenAddress = bscTestAddress
+            symbol = "ZAPBSC"
+            console.log("BSC TESTNET");
+            break;
+    }
+
+    const signers = await ethers.getSigners();
 
     const platformFee = {
         fee: {
@@ -16,6 +63,7 @@ async function main() {
         },
     };
 
+    // Deploy ZapVault
     const ZapVault = await ethers.getContractFactory("ZapVault", signers[0]);
     const zapVault = await upgrades.deployProxy(
         ZapVault,
@@ -27,6 +75,7 @@ async function main() {
     const zapVaultImplAddress = await getImplementationAddress(ethers.provider, zapVault.address);
     console.log("ZapVault implementation:", zapVaultImplAddress);
 
+    // Deploy ZapMarket
     const ZapMarket = await ethers.getContractFactory('ZapMarket', signers[0]);
     const zapMarket = await upgrades.deployProxy(
         ZapMarket,
@@ -38,12 +87,20 @@ async function main() {
     const zapMarketImplAddress = await getImplementationAddress(ethers.provider, zapMarket.address);
     console.log("ZapMarket implementation:", zapMarketImplAddress);
 
+    // Sets the platform fee
     await zapMarket.setFee(platformFee);
 
+    // Deploys the Media Interface
+    const unInitMediaFactory = await ethers.getContractFactory("ZapMedia");
+    const unInitMedia = (await unInitMediaFactory.deploy()) as ZapMedia;
+    await unInitMedia.deployed();
+    console.log("Media Interface deployed to:", unInitMedia.address);
+
+    // Deploys the MediaFactory
     const MediaFactory = await ethers.getContractFactory("MediaFactory", signers[0]);
     const mediaFactory = await upgrades.deployProxy(
         MediaFactory,
-        [zapMarket.address],
+        [zapMarket.address, unInitMedia.address],
         { initializer: 'initialize' }
     ) as MediaFactory;
     await mediaFactory.deployed();
@@ -60,27 +117,27 @@ async function main() {
         true,
         'https://ipfs.moralis.io:2053/ipfs/Qmb6X5bYB3J6jq9JPmd5FLx4fa4JviXfV11yN42i96Q5Xt'
     );
-    const mediaDeployedFilter = mediaFactory.filters.MediaDeployed(null);
-    const mediaDeployedEvent: Event = (await mediaFactory.queryFilter(mediaDeployedFilter))[0];
-    const zapMediaAddress = mediaDeployedEvent.args?.mediaContract;
-    const zapMediaABI = require('../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json').abi;
-    const zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
-    await zapMedia.deployed();
-    await zapMedia.connect(signers[0]).claimTransferOwnership();
+    // const mediaDeployedFilter = mediaFactory.filters.MediaDeployed(null);
+    // const mediaDeployedEvent: Event = (await mediaFactory.queryFilter(mediaDeployedFilter))[0];
+    // const zapMediaAddress = mediaDeployedEvent.args?.mediaContract;
+    // const zapMediaABI = require('../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json').abi;
+    // const zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
+    // await zapMedia.deployed();
+    // await zapMedia.connect(signers[0]).claimTransferOwnership();
 
-    console.log('ZapMedia deployed to:', zapMedia.address);
-    const mediaImplAddress = await getImplementationAddress(ethers.provider, zapMedia.address);
-    console.log("ZapMedia implementation:", mediaImplAddress);
+    // console.log('ZapMedia deployed to:', zapMedia.address);
+    // const mediaImplAddress = await getImplementationAddress(ethers.provider, zapMedia.address);
+    // console.log("ZapMedia implementation:", mediaImplAddress);
 
-    const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
-    const auctionHouse = await upgrades.deployProxy(AuctionHouse,
-        [tokenAddress, zapMarket.address],
-        { initializer: 'initialize' }
-    );
-    await auctionHouse.deployed();
-    console.log('AuctionHouse deployed to:', auctionHouse.address);
-    const auctionImplAddress = await getImplementationAddress(ethers.provider, auctionHouse.address);
-    console.log("AuctionHouse implementation:", auctionImplAddress);
+    // const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
+    // const auctionHouse = await upgrades.deployProxy(AuctionHouse,
+    //     [tokenAddress, zapMarket.address],
+    //     { initializer: 'initialize' }
+    // );
+    // await auctionHouse.deployed();
+    // console.log('AuctionHouse deployed to:', auctionHouse.address);
+    // const auctionImplAddress = await getImplementationAddress(ethers.provider, auctionHouse.address);
+    // console.log("AuctionHouse implementation:", auctionImplAddress);
 
 }
 

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -152,8 +152,17 @@ async function main() {
     );
 
     const receipt = await tx.wait();
+    const mediaDeployedEvents = receipt.events as Event[];
+    const mediaDeployedEvent = mediaDeployedEvents.slice(-1);
+    const zapMediaAddress = mediaDeployedEvent[0].args?.mediaContract;
 
-    console.log(receipt)
+    let zapMedia: ZapMedia;
+    zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
+    await zapMedia.connect(signers[0]).claimTransferOwnership();
+    await zapMedia.deployed();
+    console.log("ZapMedia deployed to:", zapMedia.address)
+    await zapMedia.claimTransferOwnership()
+
 
     // Creates the instance of ZapMedia
     // const zapMedia = new ethers.Contract(
@@ -161,22 +170,20 @@ async function main() {
     //     zapMediaABI,
     //     signers[0]) as ZapMedia;
 
-    // await zapMedia.claimTransferOwnership()
 
     // await zapMedia.deployed();
-    // console.log("ZapMedia deployed to:", zapMedia.address)
 
     // ************************************************************** //
     // deploy AuctionHouse
     // ************************************************************** //
 
-    // const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
-    // const auctionHouse = await upgrades.deployProxy(AuctionHouse,
-    //     [tokenAddress, zapMarket.address],
-    //     { initializer: 'initialize' }
-    // );
-    // await auctionHouse.deployed();
-    // console.log('AuctionHouse deployed to:', auctionHouse.address);
+    const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
+    const auctionHouse = await upgrades.deployProxy(AuctionHouse,
+        [tokenAddress, zapMarket.address],
+        { initializer: 'initialize' }
+    );
+    await auctionHouse.deployed();
+    console.log('AuctionHouse deployed to:', auctionHouse.address);
 
 }
 

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -12,6 +12,9 @@ async function main() {
     // Deployed ZapToken on BSC Testnet
     const bscTestAddress = '0x09d8AF358636D9BCC9a3e177B66EB30381a4b1a8';
 
+    // ABI for ZapMedia
+    const zapMediaABI = require('../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json').abi;
+
     // Collection name
     const name = 'ZapMedia';
 
@@ -149,33 +152,31 @@ async function main() {
     );
 
     const receipt = await tx.wait();
+
     console.log(receipt)
 
-    // ABI for ZapMedia
-    const zapMediaABI = require('../artifacts/contracts/nft/ZapMedia.sol/ZapMedia.json').abi;
-
     // Creates the instance of ZapMedia
-    const zapMedia = new ethers.Contract(
-        '0x314D0A56B2bd8229a18A3B9f0875E4fE7A963375',
-        zapMediaABI,
-        signers[0]) as ZapMedia;
+    // const zapMedia = new ethers.Contract(
+    //     '0x314D0A56B2bd8229a18A3B9f0875E4fE7A963375',
+    //     zapMediaABI,
+    //     signers[0]) as ZapMedia;
 
-    await zapMedia.claimTransferOwnership()
+    // await zapMedia.claimTransferOwnership()
 
-    await zapMedia.deployed();
-    console.log("ZapMedia deployed to:", zapMedia.address)
+    // await zapMedia.deployed();
+    // console.log("ZapMedia deployed to:", zapMedia.address)
 
     // ************************************************************** //
     // deploy AuctionHouse
     // ************************************************************** //
 
-    const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
-    const auctionHouse = await upgrades.deployProxy(AuctionHouse,
-        [tokenAddress, '0x1630800181A705aeBd645066Ee2c91e5CD37D1cB'],
-        { initializer: 'initialize' }
-    );
-    await auctionHouse.deployed();
-    console.log('AuctionHouse deployed to:', auctionHouse.address);
+    // const AuctionHouse = await ethers.getContractFactory('AuctionHouse', signers[0]);
+    // const auctionHouse = await upgrades.deployProxy(AuctionHouse,
+    //     [tokenAddress, zapMarket.address],
+    //     { initializer: 'initialize' }
+    // );
+    // await auctionHouse.deployed();
+    // console.log('AuctionHouse deployed to:', auctionHouse.address);
 
 }
 

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -6,11 +6,11 @@ import hre from 'hardhat';
 
 async function main() {
 
-    // Deployed ZapToken on Rinkeby
-    const rinkebyAddress = '0x5877451904f0484cc49DAFdfb8f9b33C8C31Ee2F';
-
     // Deployed ZapToken on Ethereum Mainnet
     const ethMainAddress = '0x6781a0f84c7e9e846dcb84a9a5bd49333067b104';
+
+    // Deployed ZapToken on Rinkeby
+    const rinkebyAddress = '0x5877451904f0484cc49DAFdfb8f9b33C8C31Ee2F';
 
     // Deployed ZapToken on BSC Testnet
     const bscTestAddress = '0x09d8AF358636D9BCC9a3e177B66EB30381a4b1a8';
@@ -51,6 +51,7 @@ async function main() {
 
     switch (chainId) {
 
+        // Ethereum mainnet deployment
         case 1:
             tokenAddress = ethMainAddress
             symbol = 'ZAPETH'

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -156,22 +156,15 @@ async function main() {
     const mediaDeployedEvent = mediaDeployedEvents.slice(-1);
     const zapMediaAddress = mediaDeployedEvent[0].args?.mediaContract;
 
-    let zapMedia: ZapMedia;
-    zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
+    const zapMedia = new ethers.Contract(zapMediaAddress, zapMediaABI, signers[0]) as ZapMedia;
     await zapMedia.connect(signers[0]).claimTransferOwnership();
     await zapMedia.deployed();
-    console.log("ZapMedia deployed to:", zapMedia.address)
-    await zapMedia.claimTransferOwnership()
 
+    console.log("ZapMedia deployed to:", zapMedia.address);
 
-    // Creates the instance of ZapMedia
-    // const zapMedia = new ethers.Contract(
-    //     '0x314D0A56B2bd8229a18A3B9f0875E4fE7A963375',
-    //     zapMediaABI,
-    //     signers[0]) as ZapMedia;
+    const claimGas = await zapMedia.estimateGas.claimTransferOwnership();
 
-
-    // await zapMedia.deployed();
+    await zapMedia.claimTransferOwnership({ gasLimit: claimGas });
 
     // ************************************************************** //
     // deploy AuctionHouse

--- a/scripts/deploy_nft_contracts.ts
+++ b/scripts/deploy_nft_contracts.ts
@@ -125,13 +125,23 @@ async function main() {
     await zapMarket.setMediaFactory(mediaFactory.address, { gasLimit: setFactoryGas });
     console.log("MediaFactory set to ZapMarket");
 
+    // Gas estimation for deployMedia()
+    const deployMediaGas = await mediaFactory.estimateGas.deployMedia(
+        name,
+        symbol,
+        zapMarket.address,
+        true,
+        contractURI
+    );
+
     // Deploys ZapMedia
     await mediaFactory.deployMedia(
         name,
         symbol,
         zapMarket.address,
         true,
-        contractURI
+        contractURI,
+        { gasLimit: deployMediaGas }
     );
 
     // Filter for MediaDeployed event


### PR DESCRIPTION
## Summary
@jpkim921 @acemasterjb @kimanikelly 
Closes #272 
Updated the deploy script for ETH Mainnet, BSC Mainnet, Rinkeby Testnet, BSC Testnet 

## Implementation
- [x] Able to retrieve ZapMedia address from the MediaDeployed event after deployMedia is invoked
- [x] Shell scripts for each network deployment to shorten the CLI input
- [x] Network chainID detection for deployment
- [x] The contracts are able to be deployed to each network except for Mainnet 
- [x] Configured each network for deployment 

## Files
```hardhat.config.ts```
```scripts/deploy_nft_contracts.ts```
```nft_bsc_mainnet.sh```
```nft_bsc_test.sh```
```nft_local.sh```
```nft_mainnet.sh```
```nft_rink.sh```
