### PR TITLE
Added access rights to tallyVote()

### DIFF
--- a/hardhat/contracts/zap-miner/Zap.sol
+++ b/hardhat/contracts/zap-miner/Zap.sol
@@ -215,6 +215,7 @@ contract Zap {
      * @param _disputeId is the dispute id
      */
     function tallyVotes(uint256 _disputeId) external {
+        require(zap.stakerDetails[msg.sender].currentStatus == 1, "Caller must be staked");
 
         address currentVault = zap.addressVars[keccak256('_vault')];
         (address _from, address _to, uint256 _disputeFee) = zap.tallyVotes(_disputeId);


### PR DESCRIPTION
### Summary
closes #275 

### Implementation
- Added require so only staked users can call `tallyVote()`
- Added test to check access rights

### Visuals
![image](https://user-images.githubusercontent.com/18056516/147508802-c9547768-49b0-41eb-9e0e-b8a76948c737.png)
