### PR TITLE
Nft Sdk: SafeTransfrom functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -197,6 +197,10 @@ class ZapMedia {
       invariant(false, 'ZapMedia (safeTransferFrom): The (from) address cannot be a zero address.');
     }
 
+    if (to === ethers.constants.AddressZero) {
+      invariant(false, 'ZapMedia (safeTransferFrom): The (to) address cannot be a zero address.');
+    }
+
     return this.media['safeTransferFrom(address,address,uint256)'](from, to, mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -177,6 +177,26 @@ class ZapMedia {
   }
 
   /**
+   * Executes a SafeTransfer of the specified media to the specified address if and only if it adheres to the ERC721-Receiver Interface
+   * @param from
+   * @param to
+   * @param mediaId
+   */
+  public async safeTransferFrom(
+    from: string,
+    to: string,
+    mediaId: BigNumberish,
+  ): Promise<ContractTransaction> {
+    try {
+      await this.media.ownerOf(mediaId);
+    } catch (err: any) {
+      invariant(false, 'ZapMedia (safeTransferFrom): TokenId does not exist.');
+    }
+
+    return this.media['safeTransferFrom(address,address,uint256)'](from, to, mediaId);
+  }
+
+  /**
    * Mints a new piece of media on an instance of the Zap Media Contract
    * @param mintData
    * @param bidShares

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -193,6 +193,10 @@ class ZapMedia {
       invariant(false, 'ZapMedia (safeTransferFrom): TokenId does not exist.');
     }
 
+    if (from === ethers.constants.AddressZero) {
+      invariant(false, 'ZapMedia (safeTransferFrom): The (from) address cannot be a zero address.');
+    }
+
     return this.media['safeTransferFrom(address,address,uint256)'](from, to, mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -529,6 +529,25 @@ describe('ZapMedia', () => {
             });
         });
 
+        it('Should revert if the from is a zero address', async () => {
+          const recipient = await provider.getSigner(1).getAddress();
+
+          const media = new ZapMedia(1337, signer);
+
+          await media.mint(mediaData, bidShares);
+
+          await media
+            .safeTransferFrom(ethers.constants.AddressZero, recipient, 0)
+            .then((res) => {
+              console.log(res);
+            })
+            .catch((err) => {
+              expect(err.message).to.equal(
+                'Invariant failed: ZapMedia (safeTransferFrom): The (from) address cannot be a zero address.',
+              );
+            });
+        });
+
         it('Should safe transfer a token to an address', async () => {
           const recipient = await provider.getSigner(1).getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -495,7 +495,7 @@ describe('ZapMedia', () => {
 
       describe('#transferFrom', () => {
         it('Should transfer token to another address', async () => {
-          const recipient = await provider.getSigner().getAddress();
+          const recipient = await provider.getSigner(1).getAddress();
           const media = new ZapMedia(1337, signer);
           await media.mint(mediaData, bidShares);
 
@@ -508,6 +508,35 @@ describe('ZapMedia', () => {
           const newOwner = await media.fetchOwnerOf(0);
 
           expect(newOwner).to.equal(recipient);
+        });
+      });
+
+      describe.only('#safeTransferFrom', () => {
+        it('Should revert if the tokenId does not exist', async () => {
+          const recipient = await provider.getSigner(1).getAddress();
+
+          const media = new ZapMedia(1337, signer);
+
+          await media
+            .safeTransferFrom(await signer.getAddress(), recipient, 0)
+            .then((res) => {
+              console.log(res);
+            })
+            .catch((err) => {
+              expect(err.message).to.equal(
+                'Invariant failed: ZapMedia (safeTransferFrom): TokenId does not exist.',
+              );
+            });
+        });
+
+        it('Should safe transfer a token to an address', async () => {
+          const recipient = await provider.getSigner(1).getAddress();
+
+          const media = new ZapMedia(1337, signer);
+
+          await media.mint(mediaData, bidShares);
+
+          await media.safeTransferFrom(await signer.getAddress(), recipient, 0);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -511,7 +511,7 @@ describe('ZapMedia', () => {
         });
       });
 
-      describe.only('#safeTransferFrom', () => {
+      describe('#safeTransferFrom', () => {
         it('Should revert if the tokenId does not exist', async () => {
           const recipient = await provider.getSigner(1).getAddress();
 
@@ -529,7 +529,7 @@ describe('ZapMedia', () => {
             });
         });
 
-        it('Should revert if the from is a zero address', async () => {
+        it('Should revert if the (from) is a zero address', async () => {
           const recipient = await provider.getSigner(1).getAddress();
 
           const media = new ZapMedia(1337, signer);
@@ -544,6 +544,23 @@ describe('ZapMedia', () => {
             .catch((err) => {
               expect(err.message).to.equal(
                 'Invariant failed: ZapMedia (safeTransferFrom): The (from) address cannot be a zero address.',
+              );
+            });
+        });
+
+        it('Should revert if the (to) is a zero address', async () => {
+          const media = new ZapMedia(1337, signer);
+
+          await media.mint(mediaData, bidShares);
+
+          await media
+            .safeTransferFrom(await signer.getAddress(), ethers.constants.AddressZero, 0)
+            .then((res) => {
+              console.log(res);
+            })
+            .catch((err) => {
+              expect(err.message).to.equal(
+                'Invariant failed: ZapMedia (safeTransferFrom): The (to) address cannot be a zero address.',
               );
             });
         });


### PR DESCRIPTION
## Summary
Closes #315

## Implementation
- [x] Added the TypeScript interpretation for the ``` safeTransferFrom``` function
- [x] Added error handling if the tokenId does not exist
- [x] Added error handling if the ``` from``` is a zero address
- [x] Added  error handling if the ```to``` is a zero address
- [x] Added tests for successful ```safeTransferFrom``` functionality and error handling

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Added the ```safeTransferFrom``` function to the ```zapMedia.ts``` included with error handling
<img width="896" alt="Screen Shot 2022-01-10 at 5 59 17 PM" src="https://user-images.githubusercontent.com/42893948/148852157-113e2ef8-b6a5-4f76-aaa9-7d3fc3bac740.png">


```safeTransferFrom``` functions passing in test
<img width="691" alt="Screen Shot 2022-01-10 at 6 07 31 PM" src="https://user-images.githubusercontent.com/42893948/148852912-be6fb961-1dd2-4c7b-901b-d13c96bd2b48.png">


