### PR TITLE
Nft Sdk: GetTokenCreators functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -86,6 +86,14 @@ class ZapMedia {
   }
 
   /**
+   * Fetches the creator for the specified media on an instance of the Zap Media Contract
+   * @param mediaId
+   */
+  public async fetchCreator(mediaId: BigNumberish): Promise<string> {
+    return this.media.getTokenCreators(mediaId);
+  }
+
+  /**
    * Fetches the current bid shares for the specified media on an instance of the Zap Media Contract
    * @param mediaId
    */

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -90,6 +90,11 @@ class ZapMedia {
    * @param mediaId
    */
   public async fetchCreator(mediaId: BigNumberish): Promise<string> {
+    try {
+      await this.media.ownerOf(mediaId);
+    } catch (err: any) {
+      invariant(false, 'ZapMedia (fetchCreator): TokenId does not exist.');
+    }
     return this.media.getTokenCreators(mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -256,7 +256,7 @@ describe('ZapMedia', () => {
         });
       });
 
-      describe.only('#getTokenCreators', () => {
+      describe('#getTokenCreators', () => {
         it('Should throw an error if the tokenId does not exist', async () => {
           const media = new ZapMedia(1337, signer);
 
@@ -270,6 +270,16 @@ describe('ZapMedia', () => {
                 'Invariant failed: ZapMedia (fetchCreator): TokenId does not exist.',
               );
             });
+        });
+
+        it('Should return the token creator', async () => {
+          const media = new ZapMedia(1337, signer);
+
+          await media.mint(mediaData, bidShares);
+
+          const creator = await media.fetchCreator(0);
+
+          expect(creator).to.equal(await signer.getAddress());
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -225,9 +225,7 @@ describe('ZapMedia', () => {
             });
         });
 
-        it('Should be able to mint', async () => {
-          // require('@zapsdk')
-
+        it.only('Should be able to mint', async () => {
           const media = new ZapMedia(1337, signer);
 
           const preTotalSupply = (await media.fetchTotalMedia()).toNumber();
@@ -237,11 +235,14 @@ describe('ZapMedia', () => {
           await media.mint(mediaData, bidShares);
 
           const owner = await media.fetchOwnerOf(0);
+          const creator = await media.fetchCreator(0);
+
           const onChainBidShares = await media.fetchCurrentBidShares(zapMedia.address, 0);
           const onChainContentURI = await media.fetchContentURI(0);
           const onChainMetadataURI = await media.fetchMetadataURI(0);
 
           expect(owner).to.equal(await signer.getAddress());
+          expect(creator).to.equal(await signer.getAddress());
           expect(onChainContentURI).to.equal(mediaData.tokenURI);
           expect(onChainMetadataURI).to.equal(mediaData.metadataURI);
           expect(parseInt(onChainBidShares.creator.value)).to.equal(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -225,7 +225,7 @@ describe('ZapMedia', () => {
             });
         });
 
-        it.only('Should be able to mint', async () => {
+        it('Should be able to mint', async () => {
           const media = new ZapMedia(1337, signer);
 
           const preTotalSupply = (await media.fetchTotalMedia()).toNumber();
@@ -253,6 +253,23 @@ describe('ZapMedia', () => {
           );
           expect(onChainBidShares.collaborators).to.eql(bidShares.collaborators);
           expect(onChainBidShares.collabShares).to.eql(bidShares.collabShares);
+        });
+      });
+
+      describe.only('#getTokenCreators', () => {
+        it('Should throw an error if the tokenId does not exist', async () => {
+          const media = new ZapMedia(1337, signer);
+
+          await media
+            .fetchCreator(0)
+            .then((res) => {
+              console.log(res);
+            })
+            .catch((err) => {
+              expect(err.message).to.equal(
+                'Invariant failed: ZapMedia (fetchCreator): TokenId does not exist.',
+              );
+            });
         });
       });
 


### PR DESCRIPTION
## Summary
Closes #302 

## Implementation
- [x]  Added the TypeScript interpretation for the ```getTokenCreators``` function
- [x]  Added error handling if the tokenId does not exist
- [x]  Added tests for successful ```getTokenCreators``` functionality and error handling

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Added the ```getTokenCreators``` function to the zapMedia.ts included with error handling

<img width="801" alt="Screen Shot 2022-01-10 at 6 58 54 PM" src="https://user-images.githubusercontent.com/42893948/148857964-6c53b52d-61e3-4ff8-8ebc-baaff7c9648b.png">


```getTokenCreators```  functions passing in test

<img width="682" alt="Screen Shot 2022-01-10 at 7 00 51 PM" src="https://user-images.githubusercontent.com/42893948/148858121-42357b81-dfe4-4395-8eb4-925f4e34894d.png">


