### PR TITLE
Nft Sdk: TokenOfOwnerByIndex functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -66,6 +66,15 @@ class ZapMedia {
   }
 
   /**
+   * Fetches the mediaId of the specified owner by index on an instance of the Zap Media Contract
+   * @param owner
+   * @param index
+   */
+  public async fetchMediaOfOwnerByIndex(owner: string, index: BigNumberish): Promise<BigNumber> {
+    return this.media.tokenOfOwnerByIndex(owner, index);
+  }
+
+  /**
    * Fetches the content uri for the specified media on an instance of the Zap Media Contract
    * @param mediaId
    */

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -71,6 +71,12 @@ class ZapMedia {
    * @param index
    */
   public async fetchMediaOfOwnerByIndex(owner: string, index: BigNumberish): Promise<BigNumber> {
+    if (owner === ethers.constants.AddressZero) {
+      invariant(
+        false,
+        'ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address.',
+      );
+    }
     return this.media.tokenOfOwnerByIndex(owner, index);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -284,6 +284,14 @@ describe('ZapMedia', () => {
       });
 
       describe.only('#tokenOfOwnerByIndex', () => {
+        it('Should throw an error if the (owner) is a zero address', async () => {
+          const media = new ZapMedia(1337, signer);
+
+          await media.mint(mediaData, bidShares);
+
+          await media.fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0);
+        });
+
         it('Should return the token of the owner by index', async () => {
           const media = new ZapMedia(1337, signer);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -283,13 +283,22 @@ describe('ZapMedia', () => {
         });
       });
 
-      describe.only('#tokenOfOwnerByIndex', () => {
+      describe('#tokenOfOwnerByIndex', () => {
         it('Should throw an error if the (owner) is a zero address', async () => {
           const media = new ZapMedia(1337, signer);
 
           await media.mint(mediaData, bidShares);
 
-          await media.fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0);
+          await media
+            .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
+            .then((res) => {
+              console.log(res);
+            })
+            .catch((err) => {
+              expect(err.message).to.equal(
+                'Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address.',
+              );
+            });
         });
 
         it('Should return the token of the owner by index', async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -283,6 +283,18 @@ describe('ZapMedia', () => {
         });
       });
 
+      describe.only('#tokenOfOwnerByIndex', () => {
+        it('Should return the token of the owner by index', async () => {
+          const media = new ZapMedia(1337, signer);
+
+          await media.mint(mediaData, bidShares);
+
+          const tokenId = await media.fetchMediaOfOwnerByIndex(await signer.getAddress(), 0);
+
+          expect(parseInt(tokenId._hex)).to.equal(0);
+        });
+      });
+
       describe('#setAsk', () => {
         it('Should throw an error if the signer is not approved nor the owner', async () => {
           ask = constructAsk(zapMedia.address, 100);


### PR DESCRIPTION
## Summary
Closes #307 

## Implementation
- [x]  Added the TypeScript interpretation for the ```tokenOfOwnerByIndex``` function
- [x]  Added error handling if the owner is a zero address
- [x]  Added tests for successful ```tokenOfOwnerByIndex``` functionality and error handling

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Added the  ```tokenOfOwnerByIndex``` function  to the zapMedia.ts included with error handling

<img width="894" alt="Screen Shot 2022-01-11 at 12 43 34 PM" src="https://user-images.githubusercontent.com/42893948/148994168-53b9e410-ad01-43c8-a378-52b8a9d8d6c8.png">


```tokenOfOwnerByIndex``` functions passing in test

<img width="702" alt="Screen Shot 2022-01-11 at 12 58 02 PM" src="https://user-images.githubusercontent.com/42893948/148996326-a33be03c-01a3-43e9-95a9-dd3a7f47a58d.png">

