### PR TITLE
SetAuctionReservePrice Functionality

### DIFF
--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -129,6 +129,8 @@ class AuctionHouse {
     // If the fetched media returns a zero address this means the auction does not exist and throw an error
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
       invariant(false, 'AuctionHouse (setAuctionReservePrice): AuctionId does not exist.');
+
+      // If the caller does not equal the curator address and does not equal the token owner address throw an error
     } else if (
       (await this.signer.getAddress()) !== auctionInfo.curator &&
       (await this.signer.getAddress()) !== auctionInfo.tokenOwner
@@ -137,6 +139,8 @@ class AuctionHouse {
         false,
         'AuctionHouse (setAuctionReservePrice): Caller must be the curator or token owner',
       );
+
+      // If the fetched firstBidTime is not 0 throw an error
     } else if (parseInt(auctionInfo.firstBidTime._hex) !== 0) {
       invariant(false, 'AuctionHouse (setAuctionReservePrice): Auction has already started.');
     } else {

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -129,8 +129,17 @@ class AuctionHouse {
     // If the fetched media returns a zero address this means the auction does not exist and throw an error
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
       invariant(false, 'AuctionHouse (setAuctionReservePrice): AuctionId does not exist.');
+    } else if (
+      (await this.signer.getAddress()) !== auctionInfo.curator &&
+      (await this.signer.getAddress()) !== auctionInfo.tokenOwner
+    ) {
+      invariant(
+        false,
+        'AuctionHouse (setAuctionReservePrice): Caller must be the curator or token owner',
+      );
+    } else {
+      return this.auctionHouse.setAuctionReservePrice(auctionId, reservePrice);
     }
-    return this.auctionHouse.setAuctionReservePrice(auctionId, reservePrice);
   }
 }
 

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -137,6 +137,8 @@ class AuctionHouse {
         false,
         'AuctionHouse (setAuctionReservePrice): Caller must be the curator or token owner',
       );
+    } else if (parseInt(auctionInfo.firstBidTime._hex) !== 0) {
+      invariant(false, 'AuctionHouse (setAuctionReservePrice): Auction has already started.');
     } else {
       return this.auctionHouse.setAuctionReservePrice(auctionId, reservePrice);
     }

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -123,6 +123,13 @@ class AuctionHouse {
   }
 
   public async setAuctionReservePrice(auctionId: BigNumberish, reservePrice: BigNumberish) {
+    // Fetches the auction details
+    const auctionInfo = await this.fetchAuction(auctionId);
+
+    // If the fetched media returns a zero address this means the auction does not exist and throw an error
+    if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
+      invariant(false, 'AuctionHouse (setAuctionReservePrice): AuctionId does not exist.');
+    }
     return this.auctionHouse.setAuctionReservePrice(auctionId, reservePrice);
   }
 }

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -121,6 +121,10 @@ class AuctionHouse {
     // If the auctionId exists and the curator is the caller invoke startCreation
     return this.auctionHouse.startAuction(auctionId, approved);
   }
+
+  public async setAuctionReservePrice(auctionId: BigNumberish, reservePrice: BigNumberish) {
+    return this.auctionHouse.setAuctionReservePrice(auctionId, reservePrice);
+  }
 }
 
 export default AuctionHouse;

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -364,7 +364,7 @@ describe('AuctionHouse', () => {
         });
       });
 
-      describe.only('#setAuctionReservePrice', () => {
+      describe('#setAuctionReservePrice', () => {
         const duration = 60 * 60 * 24;
         const reservePrice = BigNumber.from(10).pow(18).div(2);
 
@@ -434,6 +434,22 @@ describe('AuctionHouse', () => {
           await badSignerConnected.setAuctionReservePrice(0, 200).catch((err) => {
             expect(err.message).to.equal(
               'Invariant failed: AuctionHouse (setAuctionReservePrice): Caller must be the curator or token owner',
+            );
+          });
+        });
+
+        it('Should reject if the auction already started', async () => {
+          // The owner(signer[0]) connected to the AuctionHouse class
+          // The owner invokes the setAuctionReservePrice
+          await auctionHouse.setAuctionReservePrice(0, 200);
+
+          // The curator invokes startAuction
+          await curatorConnected.startAuction(0, true);
+
+          // The owner attempts to invoke the setAuctionReserverPrice after the auction has already started
+          await auctionHouse.setAuctionReservePrice(0, 200).catch((err) => {
+            expect(err.message).to.equal(
+              'Invariant failed: AuctionHouse (setAuctionReservePrice): Auction has already started.',
             );
           });
         });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -427,6 +427,25 @@ describe('AuctionHouse', () => {
           await token.mint(await bidder.getAddress(), 1000);
         });
 
+        it('Should revert if the auction id does not exist', async () => {
+          // The owner(signer[0]) connected to the AuctionHouse class
+          // The owner attempts invoke the setAuctionReservePrice on a non existent auction id
+          await auctionHouse.setAuctionReservePrice(1, 200).catch((err) => {
+            expect(err.message).to.equal(
+              'Invariant failed: AuctionHouse (setAuctionReservePrice): AuctionId does not exist.',
+            );
+          });
+        });
+
+        it('Should set the auction reserve price when called by the token owner', async () => {
+          // The owner(signer[0]) connected to the AuctionHouse class
+          // The owner invokes the setAuctionReservePrice
+          await auctionHouse.setAuctionReservePrice(0, 200);
+
+          // The curator invokes startAuction
+          await curatorConnected.startAuction(0, true);
+        });
+
         it('Should set the auction reserve price when called by the curator', async () => {
           // The curator(signer[4]) connected to the AuctionHouse class
           // The curator invokes the setAuctionReservePrice
@@ -464,15 +483,6 @@ describe('AuctionHouse', () => {
 
           // The returned currency should equal the currency set on createAuction
           expect(createdAuction.auctionCurrency).to.equal(token.address);
-        });
-
-        it('Should set the auction reserve price when called by the token owner', async () => {
-          // The owner(signer[0]) connected to the AuctionHouse class
-          // The owner invokes the setAuctionReservePrice
-          await auctionHouse.setAuctionReservePrice(0, 200);
-
-          // The curator invokes startAuction
-          await curatorConnected.startAuction(0, true);
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -126,9 +126,6 @@ describe('AuctionHouse', () => {
               0,
               token.address,
             )
-            .then((res) => {
-              return res;
-            })
             .catch((err) => {
               expect(err.message).to.equal(
                 'Invariant failed: AuctionHouse (createAuction): Transfer caller is not owner nor approved.',
@@ -157,9 +154,6 @@ describe('AuctionHouse', () => {
               0,
               token.address,
             )
-            .then((res) => {
-              return res;
-            })
             .catch((err) => {
               expect(err.message).to.equal(
                 'Invariant failed: AuctionHouse (createAuction): Caller is not approved or token owner.',
@@ -185,9 +179,6 @@ describe('AuctionHouse', () => {
               100,
               token.address,
             )
-            .then((res) => {
-              return res;
-            })
             .catch((err) => {
               expect(err.message).to.equal(
                 'Invariant failed: AuctionHouse (createAuction): CuratorFeePercentage must be less than 100.',
@@ -213,9 +204,6 @@ describe('AuctionHouse', () => {
               0,
               token.address,
             )
-            .then((res) => {
-              return res;
-            })
             .catch((err) => {
               expect(err.message).to.equal(
                 'Invariant failed: AuctionHouse (createAuction): TokenId does not exist.',
@@ -241,9 +229,6 @@ describe('AuctionHouse', () => {
               0,
               token.address,
             )
-            .then((res) => {
-              return res;
-            })
             .catch((err) => {
               expect(err.message).to.equal(
                 'Invariant failed: AuctionHouse (createAuction): Media cannot be a zero address.',

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -427,12 +427,28 @@ describe('AuctionHouse', () => {
           await token.mint(await bidder.getAddress(), 1000);
         });
 
-        it('Should revert if the auction id does not exist', async () => {
+        it('Should reject if the auction id does not exist', async () => {
           // The owner(signer[0]) connected to the AuctionHouse class
           // The owner attempts invoke the setAuctionReservePrice on a non existent auction id
           await auctionHouse.setAuctionReservePrice(1, 200).catch((err) => {
             expect(err.message).to.equal(
               'Invariant failed: AuctionHouse (setAuctionReservePrice): AuctionId does not exist.',
+            );
+          });
+        });
+
+        it('Should reject if not called by the curator or owner', async () => {
+          // Bad signer
+          const badSigner = signers[8];
+
+          // AuctionHouse class instance
+          const badSignerConnected = new AuctionHouse(1337, badSigner);
+
+          // The badSigner(signer[8]) connected to the AuctionHouse class
+          // The badSigner attempts invoke the setAuctionReservePrice when its not the curator or token owner
+          await badSignerConnected.setAuctionReservePrice(0, 200).catch((err) => {
+            expect(err.message).to.equal(
+              'Invariant failed: AuctionHouse (setAuctionReservePrice): Caller must be the curator or token owner',
             );
           });
         });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -465,6 +465,15 @@ describe('AuctionHouse', () => {
           // The returned currency should equal the currency set on createAuction
           expect(createdAuction.auctionCurrency).to.equal(token.address);
         });
+
+        it('Should set the auction reserve price when called by the token owner', async () => {
+          // The owner(signer[0]) connected to the AuctionHouse class
+          // The owner invokes the setAuctionReservePrice
+          await auctionHouse.setAuctionReservePrice(0, 200);
+
+          // The curator invokes startAuction
+          await curatorConnected.startAuction(0, true);
+        });
       });
     });
   });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -382,19 +382,37 @@ describe('AuctionHouse', () => {
       describe.only('#setAuctionReservePrice', () => {
         const duration = 60 * 60 * 24;
         const reservePrice = BigNumber.from(10).pow(18).div(2);
+
+        // An instance of the AuctionHouse class that will be connected to signer[0]
         let auctionHouse: AuctionHouse;
+
+        // An instance of the AuctionHouse class that will be connected to signer[9]
         let curatorConnected: AuctionHouse;
+
+        // Will be set to signers[9]
         let curator: Signer;
+
+        // Will be set to signers[4]
         let bidder: Signer;
 
         beforeEach(async () => {
+          // Assign the curator to signer[9]
           curator = signers[9];
+
+          // Assign the bidder to signer[4]
           bidder = signers[4];
+
+          // The owner(signers[0]) connected to the AuctionHouse class as a signer
           auctionHouse = new AuctionHouse(1337, signer);
+
+          // The curator(signers[9]) connected to the AuctionHouse class as a signer
           curatorConnected = new AuctionHouse(1337, curator);
 
+          // The owner(signer[0]) of tokenId 0 approves the auctionHouse
           await media.approve(auctionHouse.auctionHouse.address, 0);
 
+          // The owner(signer[0]) creates the auction
+          // The curator is neither a zero address or token owner so the curator has to invoke startAuction
           await auctionHouse.createAuction(
             0,
             mediaAddress,
@@ -405,6 +423,7 @@ describe('AuctionHouse', () => {
             token.address,
           );
 
+          // Transfer 1000 tokens to the bidder
           await token.mint(await bidder.getAddress(), 1000);
         });
 


### PR DESCRIPTION
## Summary  
closes #320

## Implementation
 - [x] Added the TypeScript interpretation for the setAuctionReservePrice function
 - [x] Added error handling if the auction id does not exist
 - [x] Added error handling if caller is not the curator or token owner
 - [x] Added error handling if auction has already started
 - [x] Added tests for successful setAuctionReservePrice functionality and error handling

## Files
```sdk/nft/src/auctionHouse.ts```
```sdk/nft/test/auctionHouse.test.ts```

## Visual Preview

setAuctionReservePrice function passing in test

<img width="694" alt="Screen Shot 2022-01-19 at 3 56 25 PM" src="https://user-images.githubusercontent.com/42893948/150212439-0a922b1d-e620-49c4-bae9-6f3530b78b62.png">