### PR TITLE
Fetch the Current Bid #303

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -211,7 +211,7 @@ class ZapMedia {
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
       );
-    }
+    } // Create a an (else if) statement on this line to check if the bidder is a zero address
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -204,10 +204,8 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
-    // HERE
-    // Create a try/catch using the await this.ownerOf function to check if the tokenId exist
     try {
-      await this.fetchOwnerOf(mediaId)
+      await this.fetchOwnerOf(mediaId);
     } catch (err: any) {
       return Promise.reject(err.message);
     }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -208,8 +208,8 @@ class ZapMedia {
     // Create a try/catch using the await this.ownerOf function to check if the tokenId exist
     try {
       await this.fetchOwnerOf(mediaId)
-    } catch (err) {
-      invariant(false, "ZapMedia (updateContentURI): TokenId does not exist.");
+    } catch (err: any) {
+      return Promise.reject(err.message);
     }
 
     if (mediaContractAddress === ethers.constants.AddressZero) {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -86,7 +86,7 @@ class ZapMedia {
    */
   public async fetchOwnerOf(mediaId: BigNumberish): Promise<string> {
     try {
-      return this.media.ownerOf(mediaId);
+      return await this.media.ownerOf(mediaId);
     } catch {
       invariant(false, "ZapMedia (fetchOwnerOf): The token id does not exist.");
     }
@@ -204,11 +204,7 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
-    try {
-      await this.fetchOwnerOf(mediaId);
-    } catch (err: any) {
-      return Promise.reject(err.message);
-    }
+    await this.fetchOwnerOf(mediaId);
 
     if (mediaContractAddress === ethers.constants.AddressZero) {
       invariant(

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -203,7 +203,10 @@ class ZapMedia {
     // Create an if statement checking if the media contract is a  zero address
     if (mediaContractAddress === ethers.constants.AddressZero) {
       // Create an invariant that will throw if the media contract is a zero address
-      console.log("this works");
+      invariant(
+        false,
+        "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
+      );
     }
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -211,7 +211,12 @@ class ZapMedia {
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
       );
-    } // Create a an (else if) statement on this line to check if the bidder is a zero address
+    } else if (bidder === ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
+      );
+    }
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -202,6 +202,11 @@ class ZapMedia {
   ): Promise<Bid> {
     // HERE
     // Create a try/catch using the await this.ownerOf function to check if the tokenId exist
+    try {
+      await this.fetchOwnerOf(mediaId)
+    } catch (err) {
+      invariant(false, "ZapMedia (updateContentURI): TokenId does not exist.");
+    }
 
     if (mediaContractAddress === ethers.constants.AddressZero) {
       invariant(

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -202,7 +202,8 @@ class ZapMedia {
   ): Promise<Bid> {
     // Create an if statement checking if the media contract is a  zero address
     if (mediaContractAddress === ethers.constants.AddressZero) {
-      console.log('this works')
+      // Create an invariant that will throw if the media contract is a zero address
+      console.log("this works");
     }
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -200,9 +200,7 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
-    // Create an if statement checking if the media contract is a  zero address
     if (mediaContractAddress === ethers.constants.AddressZero) {
-      // Create an invariant that will throw if the media contract is a zero address
       invariant(
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -200,6 +200,10 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
+    // Create an if statement checking if the media contract is a  zero address
+    if () {
+      
+    }
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -201,8 +201,8 @@ class ZapMedia {
     bidder: string
   ): Promise<Bid> {
     // Create an if statement checking if the media contract is a  zero address
-    if () {
-      
+    if (mediaContractAddress === ethers.constants.AddressZero) {
+      console.log('this works')
     }
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -200,6 +200,9 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
+    // HERE
+    // Create a try/catch using the await this.ownerOf function to check if the tokenId exist
+
     if (mediaContractAddress === ethers.constants.AddressZero) {
       invariant(
         false,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -936,6 +936,10 @@ describe("ZapMedia", () => {
                 );
               });
           });
+
+          it("Should reject if the bidder is a zero address", async () => {
+            // Call the fetchCurrentBidForBidder function with the bidder as a zero address
+          });
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -922,6 +922,10 @@ describe("ZapMedia", () => {
                 );
               });
           });
+
+          it("Should reject if the token id does not exist", async () => {
+            // Allow the fetchCurrentBidForBidder function to fail if the token id does not exist
+          });
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -938,6 +938,7 @@ describe("ZapMedia", () => {
           });
 
           it.only("Should reject if the bidder is a zero address", async () => {
+            // Add an assertion by expecting the function to throw the invariant with a bidder as the zero address
             await ownerConnected.fetchCurrentBidForBidder(
               zapMedia.address,
               0,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -924,13 +924,13 @@ describe("ZapMedia", () => {
           });
 
           it.only("Should reject if the token id does not exist", async () => {
-            // Allow the fetchCurrentBidForBidder function to fail if the token id does not exist
-            await ownerConnected
-              .fetchCurrentBidForBidder(
-                zapMedia.address,
-                10,
-                await bidder.getAddress()
-              )
+            // Step 1 - Verify the function called with throw the invariant
+            // Step 2 - Add an assertion by expecting the invariany to throw
+            await ownerConnected.fetchCurrentBidForBidder(
+              zapMedia.address,
+              10,
+              await bidder.getAddress()
+            );
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -938,13 +938,11 @@ describe("ZapMedia", () => {
           });
 
           it.only("Should reject if the bidder is a zero address", async () => {
-            // Call the fetchCurrentBidForBidder function with the bidder as a zero address
-            await ownerConnected
-              .fetchCurrentBidForBidder(
-                zapMedia.address,
-                0,
-                ethers.constants.AddressZero
-              );
+            await ownerConnected.fetchCurrentBidForBidder(
+              zapMedia.address,
+              0,
+              ethers.constants.AddressZero
+            );
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -924,13 +924,17 @@ describe("ZapMedia", () => {
           });
 
           it.only("Should reject if the token id does not exist", async () => {
-            // Step 1 - Verify the function called with throw the invariant
-            // Step 2 - Add an assertion by expecting the invariany to throw
+        
             await ownerConnected.fetchCurrentBidForBidder(
               zapMedia.address,
               10,
               await bidder.getAddress()
-            );
+            )
+            .catch((err) => {
+              expect(err.message).to.equal(
+                "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
+              );
+            });
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -909,8 +909,15 @@ describe("ZapMedia", () => {
         });
 
         describe("#bidForTokenBidder", () => {
-          it("Should reject if the media contract is a zero address", async () => {
+          it.only("Should reject if the media contract is a zero address", async () => {
             // Make the fetchCurrentBidForBidder function fail by passing in a zero address for the media
+            const zero = await ownerConnected.fetchCurrentBidForBidder(
+              ethers.constants.AddressZero,
+              0,
+              await bidder.getAddress()
+            );
+            console.log(zero);
+
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -923,7 +923,7 @@ describe("ZapMedia", () => {
               });
           });
 
-          it.only("Should reject if the token id does not exist", async () => {
+          it("Should reject if the token id does not exist", async () => {
             await ownerConnected
               .fetchCurrentBidForBidder(
                 zapMedia.address,
@@ -937,8 +937,14 @@ describe("ZapMedia", () => {
               });
           });
 
-          it("Should reject if the bidder is a zero address", async () => {
+          it.only("Should reject if the bidder is a zero address", async () => {
             // Call the fetchCurrentBidForBidder function with the bidder as a zero address
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                zapMedia.address,
+                0,
+                ethers.constants.AddressZero
+              );
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -923,8 +923,14 @@ describe("ZapMedia", () => {
               });
           });
 
-          it("Should reject if the token id does not exist", async () => {
+          it.only("Should reject if the token id does not exist", async () => {
             // Allow the fetchCurrentBidForBidder function to fail if the token id does not exist
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                zapMedia.address,
+                10,
+                await bidder.getAddress()
+              )
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -909,18 +909,18 @@ describe("ZapMedia", () => {
         });
 
         describe("#bidForTokenBidder", () => {
-          it.only("Should reject if the media contract is a zero address", async () => {
-            // Add an assertion that will exepct the fetchCurrentBidForBidder to fail and throw the invariant
-            // message
-            await ownerConnected.fetchCurrentBidForBidder(
-              ethers.constants.AddressZero,
-              0,
-              await bidder.getAddress()
-            ).catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
+          it("Should reject if the media contract is a zero address", async () => {
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                ethers.constants.AddressZero,
+                0,
+                await bidder.getAddress()
               )
-            });
+              .catch((err) => {
+                expect(err.message).to.equal(
+                  "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
+                );
+              });
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -924,17 +924,17 @@ describe("ZapMedia", () => {
           });
 
           it.only("Should reject if the token id does not exist", async () => {
-        
-            await ownerConnected.fetchCurrentBidForBidder(
-              zapMedia.address,
-              10,
-              await bidder.getAddress()
-            )
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
-              );
-            });
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                zapMedia.address,
+                10,
+                await bidder.getAddress()
+              )
+              .catch((err) => {
+                expect(err.message).to.equal(
+                  "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
+                );
+              });
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -943,7 +943,12 @@ describe("ZapMedia", () => {
               zapMedia.address,
               0,
               ethers.constants.AddressZero
-            );
+            )
+            .catch((err) => {
+              expect(err.message).to.equal(
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
+              );
+            });
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -907,6 +907,12 @@ describe("ZapMedia", () => {
 
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
+
+        describe("#bidForTokenBidder", () => {
+          it("Should reject if the media contract is a zero address", async () => {
+            // Make the fetchCurrentBidForBidder function fail by passing in a zero address for the media
+          });
+        });
       });
 
       describe("#removeAsk", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -910,14 +910,13 @@ describe("ZapMedia", () => {
 
         describe("#bidForTokenBidder", () => {
           it.only("Should reject if the media contract is a zero address", async () => {
-            // Make the fetchCurrentBidForBidder function fail by passing in a zero address for the media
-            const zero = await ownerConnected.fetchCurrentBidForBidder(
+            // Add an assertion that will exepct the fetchCurrentBidForBidder to fail and throw the invariant
+            // message
+            await ownerConnected.fetchCurrentBidForBidder(
               ethers.constants.AddressZero,
               0,
               await bidder.getAddress()
             );
-            console.log(zero);
-
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -937,18 +937,19 @@ describe("ZapMedia", () => {
               });
           });
 
-          it.only("Should reject if the bidder is a zero address", async () => {
+          it("Should reject if the bidder is a zero address", async () => {
             // Add an assertion by expecting the function to throw the invariant with a bidder as the zero address
-            await ownerConnected.fetchCurrentBidForBidder(
-              zapMedia.address,
-              0,
-              ethers.constants.AddressZero
-            )
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
-              );
-            });
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                zapMedia.address,
+                0,
+                ethers.constants.AddressZero
+              )
+              .catch((err) => {
+                expect(err.message).to.equal(
+                  "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
+                );
+              });
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -916,7 +916,11 @@ describe("ZapMedia", () => {
               ethers.constants.AddressZero,
               0,
               await bidder.getAddress()
-            );
+            ).catch((err) => {
+              expect(err.message).to.equal(
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
+              )
+            });
           });
         });
       });


### PR DESCRIPTION
## Summary
@aidnii @kimanikelly 
Closes #303

## Implementation
 - [x] Added error handling if media contract is a zero address
 - [x] Added error handling if the token id does not exist
 - [x] Added error handling if the bidder is a zero address
 - [x] Added tests for successful ```fetchCurrentBidForBidder``` functionality and error handling

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="703" alt="Screen Shot 2022-01-21 at 5 14 14 PM" src="https://user-images.githubusercontent.com/58867896/150611941-9383c536-51fc-41f7-9c5c-3eac263d1c2f.png">
