### PR TITLE
Custom Media FetchMediaOfOwnerByIndex Functionality

### DIFF
--- a/sdk/nft/src/mediaFactory.ts
+++ b/sdk/nft/src/mediaFactory.ts
@@ -1,10 +1,10 @@
-import { Contract, ethers, Signer } from 'ethers';
+import { Contract, ethers, Signer } from "ethers";
 
-import { contractAddresses } from './utils';
+import { contractAddresses } from "./utils";
 
-import { mediaFactoryAbi, zapMediaAbi } from './contract/abi';
+import { mediaFactoryAbi, zapMediaAbi } from "./contract/abi";
 
-import { Address } from 'cluster';
+import { Address } from "cluster";
 
 class MediaFactory {
   contract: Contract;
@@ -17,7 +17,7 @@ class MediaFactory {
     this.contract = new ethers.Contract(
       contractAddresses(networkId).mediaFactoryAddress,
       mediaFactoryAbi,
-      signer,
+      signer
     );
   }
 
@@ -32,14 +32,14 @@ class MediaFactory {
     collectionName: string,
     collectionSymbol: string,
     permissive: boolean,
-    collectionMetadta: string,
-  ): Promise<void> {
+    collectionMetadta: string
+  ): Promise<any> {
     const tx = await this.contract.deployMedia(
       collectionName,
       collectionSymbol,
       contractAddresses(this.networkId).zapMarketAddress,
       permissive,
-      collectionMetadta,
+      collectionMetadta
     );
 
     const receipt = await tx.wait();

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -126,12 +126,13 @@ class ZapMedia {
     owner: string,
     index: BigNumberish
   ): Promise<BigNumber> {
-    if (owner === ethers.constants.AddressZero) {
+    if (owner == ethers.constants.AddressZero) {
       invariant(
         false,
         "ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
       );
     }
+
     return this.media.tokenOfOwnerByIndex(owner, index);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -422,9 +422,18 @@ class ZapMedia {
       return Promise.reject(err.message);
     }
 
-    const gasEstimate = await this.media.estimateGas.mint(mediaData, bidShares);
+    if (mediaIndex !== undefined) {
+      return this.media
+        .attach(await this.customMedia(mediaIndex))
+        .mint(mediaData, bidShares);
+    } else {
+      const gasEstimate = await this.media.estimateGas.mint(
+        mediaData,
+        bidShares
+      );
 
-    return this.media.mint(mediaData, bidShares, { gasLimit: gasEstimate });
+      return this.media.mint(mediaData, bidShares, { gasLimit: gasEstimate });
+    }
   }
 
   /**

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -117,6 +117,14 @@ class ZapMedia {
     }
   }
 
+  private async customMedia(mediaIndex?: BigNumberish) {
+    const customMediaAddress = await this.market.mediaContracts(
+      await this.signer.getAddress(),
+      BigNumber.from(mediaIndex)
+    );
+    return customMediaAddress;
+  }
+
   /**
    * Fetches the mediaId of the specified owner by index on an instance of the Zap Media Contract
    * @param owner
@@ -124,8 +132,9 @@ class ZapMedia {
    */
   public async fetchMediaOfOwnerByIndex(
     owner: string,
-    index: BigNumberish
-  ): Promise<BigNumber> {
+    index: BigNumberish,
+    mediaIndex?: BigNumberish
+  ): Promise<any> {
     if (owner == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -133,7 +142,11 @@ class ZapMedia {
       );
     }
 
-    return this.media.tokenOfOwnerByIndex(owner, index);
+    if (mediaIndex !== undefined) {
+      return await this.customMedia(mediaIndex);
+    } else {
+      return this.media.tokenOfOwnerByIndex(owner, index);
+    }
   }
 
   /**

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -407,7 +407,8 @@ class ZapMedia {
    */
   public async mint(
     mediaData: MediaData,
-    bidShares: BidShares
+    bidShares: BidShares,
+    mediaIndex?: BigNumberish
   ): Promise<ContractTransaction> {
     try {
       validateURI(mediaData.tokenURI);

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -130,14 +130,11 @@ class ZapMedia {
       );
     }
 
-    // If the mediaIndex is not undefined return the custom media address
-    // attach the address to this.media and invoke tokenOfOwnerByIndex on the custom media
-    if (mediaIndex !== undefined) {
+    if (customMediaAddress !== undefined) {
       return this.media
-        .attach(await this.customMedia(mediaIndex))
+        .attach(customMediaAddress)
         .tokenOfOwnerByIndex(owner, index);
-
-      // If the mediaIndex is undefined invoke tokenOfOwnerByIndex on the main media
+      // If the customMediaAddress is undefined invoke tokenOfOwnerByIndex on the main media
     } else {
       return this.media.tokenOfOwnerByIndex(owner, index);
     }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -408,7 +408,7 @@ class ZapMedia {
   public async mint(
     mediaData: MediaData,
     bidShares: BidShares,
-    mediaIndex?: BigNumberish
+    customMediaAddress?: string
   ): Promise<ContractTransaction> {
     try {
       validateURI(mediaData.tokenURI);
@@ -422,10 +422,8 @@ class ZapMedia {
       return Promise.reject(err.message);
     }
 
-    if (mediaIndex !== undefined) {
-      return this.media
-        .attach(await this.customMedia(mediaIndex))
-        .mint(mediaData, bidShares);
+    if (customMediaAddress !== undefined) {
+      return this.media.attach(customMediaAddress).mint(mediaData, bidShares);
     } else {
       const gasEstimate = await this.media.estimateGas.mint(
         mediaData,

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -118,11 +118,15 @@ class ZapMedia {
   }
 
   private async customMedia(mediaIndex?: BigNumberish) {
-    const customMediaAddress = await this.market.mediaContracts(
-      await this.signer.getAddress(),
-      BigNumber.from(mediaIndex)
-    );
-    return customMediaAddress;
+    try {
+      const fetchMediaAddress: string = await this.market.mediaContracts(
+        await this.signer.getAddress(),
+        BigNumber.from(mediaIndex)
+      );
+      return fetchMediaAddress;
+    } catch {
+      invariant(false, "Media Index out of range");
+    }
   }
 
   /**
@@ -134,7 +138,7 @@ class ZapMedia {
     owner: string,
     index: BigNumberish,
     mediaIndex?: BigNumberish
-  ): Promise<any> {
+  ): Promise<BigNumber> {
     if (owner == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -143,7 +147,9 @@ class ZapMedia {
     }
 
     if (mediaIndex !== undefined) {
-      return await this.customMedia(mediaIndex);
+      return this.media
+        .attach(await this.customMedia(mediaIndex))
+        .tokenOfOwnerByIndex(owner, index);
     } else {
       return this.media.tokenOfOwnerByIndex(owner, index);
     }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -78,7 +78,7 @@ class ZapMedia {
    */
   public async fetchBalanceOf(
     owner: string,
-    mediaIndex?: BigNumberish
+    customMediaAddress?: BigNumberish
   ): Promise<BigNumber> {
     if (owner == ethers.constants.AddressZero) {
       invariant(
@@ -87,14 +87,8 @@ class ZapMedia {
       );
     }
 
-    // If the mediaIndex is not undefined return the custom media address and
-    // attach the address to this.media and invoke balanceOf on the custom media
-    if (mediaIndex !== undefined) {
-      return this.media
-        .attach(await this.customMedia(mediaIndex))
-        .balanceOf(owner);
-
-      // If the mediaIndex is undefined invoke balanceOf on the main media
+    if (customMediaAddress !== undefined) {
+      return this.media.attach(customMediaAddress).balanceOf(owner);
     } else {
       return this.media.balanceOf(owner);
     }
@@ -656,18 +650,6 @@ class ZapMedia {
    * Private Methods
    ******************
    */
-
-  private async customMedia(mediaIndex?: BigNumberish) {
-    try {
-      const fetchMediaAddress: string = await this.market.mediaContracts(
-        await this.signer.getAddress(),
-        BigNumber.from(mediaIndex)
-      );
-      return fetchMediaAddress;
-    } catch {
-      invariant(false, "Media Index out of range");
-    }
-  }
 
   // /**
   //  * Throws an error if called on a readOnly == true instance of Zap Sdk

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -108,15 +108,16 @@ class ZapMedia {
 
   /**
    * Fetches the mediaId of the specified owner by index on an instance of the Zap Media Contract
-   * @param owner
-   * @param index
+   * @param owner Address of who the tokenId belongs to.
+   * @param index The position of a tokenId that an address owns.
+   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchMediaOfOwnerByIndex(
     owner: string,
     index: BigNumberish,
     customMediaAddress?: string
   ): Promise<BigNumber> {
-    // If the owner is a zero address thrown an error
+    // If the owner is a zero address throw an error
     if (owner == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -124,6 +125,8 @@ class ZapMedia {
       );
     }
 
+    // If customMediaAddress is not undefined attach the address to the main media contract
+    // create a custom media contract instance and invoke tokenOfOwnerByIndex
     if (customMediaAddress !== undefined) {
       return this.media
         .attach(customMediaAddress)

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -120,7 +120,7 @@ class ZapMedia {
   public async fetchMediaOfOwnerByIndex(
     owner: string,
     index: BigNumberish,
-    mediaIndex?: BigNumberish
+    customMediaAddress?: string
   ): Promise<BigNumber> {
     // If the owner is a zero address thrown an error
     if (owner == ethers.constants.AddressZero) {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -411,8 +411,11 @@ describe("ZapMedia", () => {
         it("Should return the token of an owner by index from a custom media", async () => {
           const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
             await signerOne.getAddress(),
-            0
+            0,
+            customMediaAddress
           );
+
+          console.log(fetchToken);
         });
       });
     });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -339,14 +339,24 @@ describe("ZapMedia", () => {
         let signerOne: Signer;
         let ownerConnected: ZapMedia;
         let signerOneConnected: ZapMedia;
+        let mediaFactory: MediaFactory;
 
         beforeEach(async () => {
           signerOne = signers[1];
 
           ownerConnected = new ZapMedia(1337, signer);
           signerOneConnected = new ZapMedia(1337, signerOne);
+
+          mediaFactory = new MediaFactory(1337, signerOne);
           await ownerConnected.mint(mediaDataOne, bidShares);
           await signerOneConnected.mint(mediaDataTwo, bidShares);
+
+          await mediaFactory.deployMedia(
+            "TEST COLLECTION 2",
+            "TC2",
+            true,
+            "www.example.com"
+          );
         });
 
         it("Should throw an error if the (owner) is a zero address", async () => {
@@ -372,7 +382,13 @@ describe("ZapMedia", () => {
           expect(parseInt(fetchTokenOne._hex)).to.equal(1);
         });
 
-        it("Should return the token of the owner by index from a custom media", async () => {});
+        it("Should return the token of an owner by index from a custom media", async () => {
+          const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
+            await signerOne.getAddress(),
+            0,
+            0
+          );
+        });
       });
     });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -675,7 +675,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#tokenOfOwnerByIndex", () => {
+      describe.only("#tokenOfOwnerByIndex", () => {
         it("Should throw an error if the (owner) is a zero address", async () => {
           const media = new ZapMedia(1337, signer);
 
@@ -683,11 +683,9 @@ describe("ZapMedia", () => {
 
           await media
             .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
-              );
-            });
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
+            );
         });
 
         it("Should return the token of the owner by index", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -38,9 +38,6 @@ import {
   signMintWithSigMessage,
 } from "./test_utils";
 import { EIP712Signature, Bid } from "../src/types";
-import exp from "constants";
-import { typedSignatureHash } from "eth-sig-util";
-import { sign } from "crypto";
 
 const provider = new ethers.providers.JsonRpcProvider("http://localhost:8545");
 
@@ -60,16 +57,11 @@ describe("ZapMedia", () => {
   let signer: any;
   let zapMedia: any;
   let eipSig: any;
-  let address: string;
-  let sig: any;
-  let fetchMediaByIndex: any;
-  let bid: any;
 
   const signers = getSigners(provider);
 
   beforeEach(async () => {
     signer = signers[0];
-    // signer = provider.getSigner(0);
 
     token = await deployZapToken();
     zapVault = await deployZapVault();
@@ -95,8 +87,10 @@ describe("ZapMedia", () => {
     describe("View Functions", () => {
       let tokenURI =
         "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
+
       let metadataURI =
         "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
+
       beforeEach(async () => {
         let metadataHex = ethers.utils.formatBytes32String("Test");
         let metadataHashRaw = ethers.utils.keccak256(metadataHex);
@@ -677,14 +671,20 @@ describe("ZapMedia", () => {
 
       describe.only("#tokenOfOwnerByIndex", () => {
         let ownerConnected: ZapMedia;
+        let signerOneConnected: ZapMedia;
+        let signerOne = signers[1];
 
         beforeEach(async () => {
           ownerConnected = new ZapMedia(1337, signer);
 
+          signerOneConnected = new ZapMedia(1337, signerOne);
+
           await ownerConnected.mint(mediaData, bidShares);
+
+          await signerOneConnected.mint(mediaData, bidShares);
         });
 
-        it("Should throw an error if the (owner) is a zero address", async () => {
+        it("Should reject if the (owner) is a zero address", async () => {
           await ownerConnected
             .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
             .should.be.rejectedWith(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -693,17 +693,6 @@ describe("ZapMedia", () => {
 
           await media.mint(mediaData, bidShares);
 
-          const signerOne = signers[1];
-
-          const mediaFactory = new MediaFactory(1337, signerOne);
-
-          await mediaFactory.deployMedia(
-            "Signer One Collection",
-            "SOC",
-            true,
-            "www.example.com"
-          );
-
           const tokenId = await media.fetchMediaOfOwnerByIndex(
             await signer.getAddress(),
             0,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -688,17 +688,31 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should return the token of the owner by index", async () => {
+        it.only("Should return the token of the owner by index", async () => {
           const media = new ZapMedia(1337, signer);
 
           await media.mint(mediaData, bidShares);
 
+          const signerOne = signers[1];
+
+          const mediaFactory = new MediaFactory(1337, signerOne);
+
+          await mediaFactory.deployMedia(
+            "Signer One Collection",
+            "SOC",
+            true,
+            "www.example.com"
+          );
+
           const tokenId = await media.fetchMediaOfOwnerByIndex(
             await signer.getAddress(),
+            0,
             0
           );
 
-          expect(parseInt(tokenId._hex)).to.equal(0);
+          console.log(tokenId);
+
+          // expect(parseInt(tokenId._hex)).to.equal(0);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -48,11 +48,11 @@ chai.should();
 describe("ZapMedia", () => {
   let bidShares: any;
   let ask: any;
-  let mediaData: any;
+  let mediaDataOne: any;
+  let mediaDataTwo: any;
   let token: any;
   let zapVault: any;
   let zapMarket: any;
-  let zapMediaImpl: any;
   let mediaFactory: any;
   let signer: any;
   let zapMedia: any;
@@ -66,7 +66,7 @@ describe("ZapMedia", () => {
     token = await deployZapToken();
     zapVault = await deployZapVault();
     zapMarket = await deployZapMarket();
-    zapMediaImpl = await deployZapMediaImpl();
+    await deployZapMediaImpl();
     mediaFactory = await deployMediaFactory();
     zapMedia = await deployZapMedia();
 
@@ -92,22 +92,49 @@ describe("ZapMedia", () => {
         "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
 
       beforeEach(async () => {
-        let metadataHex = ethers.utils.formatBytes32String("Test");
-        let metadataHashRaw = ethers.utils.keccak256(metadataHex);
-        let metadataHashBytes = ethers.utils.arrayify(metadataHashRaw);
+        // MetadataHex
+        let metadataHexOne = ethers.utils.formatBytes32String("Test1");
+        let metadataHexTwo = ethers.utils.formatBytes32String("Test2");
 
-        let contentHex = ethers.utils.formatBytes32String("Test Car");
-        let contentHashRaw = ethers.utils.keccak256(contentHex);
-        let contentHashBytes = ethers.utils.arrayify(contentHashRaw);
+        // MetadataHashRaw
+        let metadataHashRawOne = ethers.utils.keccak256(metadataHexOne);
+        let metadataHashRawTwo = ethers.utils.keccak256(metadataHexTwo);
 
-        let contentHash = contentHashBytes;
-        let metadataHash = metadataHashBytes;
+        // MetadataHashBytes
+        let metadataHashBytesOne = ethers.utils.arrayify(metadataHashRawOne);
+        let metadataHashBytesTwo = ethers.utils.arrayify(metadataHashRawTwo);
 
-        mediaData = constructMediaData(
+        // ContextHex
+        let contentHexOne = ethers.utils.formatBytes32String("Testing1");
+        let contentHexTwo = ethers.utils.formatBytes32String("Testing2");
+
+        // ContentHashRaw
+        let contentHashRawOne = ethers.utils.keccak256(contentHexOne);
+        let contentHashRawTwo = ethers.utils.keccak256(contentHexTwo);
+
+        // ContentHashBytes
+        let contentHashBytesOne = ethers.utils.arrayify(contentHashRawOne);
+        let contentHashBytesTwo = ethers.utils.arrayify(contentHashRawTwo);
+
+        // ContentHash
+        let contentHashOne = contentHashBytesOne;
+        let contentHashTwo = contentHashBytesTwo;
+
+        let metadataHashOne = metadataHashBytesOne;
+        let metadataHashTwo = metadataHashBytesTwo;
+
+        mediaDataOne = constructMediaData(
           tokenURI,
           metadataURI,
-          contentHash,
-          metadataHash
+          contentHashOne,
+          metadataHashOne
+        );
+
+        mediaDataTwo = constructMediaData(
+          tokenURI,
+          metadataURI,
+          contentHashTwo,
+          metadataHashTwo
         );
 
         bidShares = constructBidShares(
@@ -120,6 +147,7 @@ describe("ZapMedia", () => {
           15,
           35
         );
+
         eipSig = {
           deadline: 1000,
           v: 0,
@@ -182,19 +210,19 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("test fetchContentHash, fetchMetadataHash, fetchPermitNonce", () => {
+      describe("#fetchContentHash, fetchMetadataHash, fetchPermitNonce", () => {
         it("Should be able to fetch contentHash", async () => {
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
           const onChainContentHash = await media.fetchContentHash(0);
           expect(onChainContentHash).eq(
-            ethers.utils.hexlify(mediaData.contentHash)
+            ethers.utils.hexlify(mediaDataOne.contentHash)
           );
         });
 
         it("fetchContentHash should get 0x0 if tokenId doesn't exist", async () => {
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
           const onChainContentHash = await media.fetchContentHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
@@ -203,16 +231,16 @@ describe("ZapMedia", () => {
 
         it("Should be able to fetch metadataHash", async () => {
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
           const onChainMetadataHash = await media.fetchMetadataHash(0);
           expect(onChainMetadataHash).eq(
-            ethers.utils.hexlify(mediaData.metadataHash)
+            ethers.utils.hexlify(mediaDataOne.metadataHash)
           );
         });
 
         it("fetchMetadataHash should get 0x0 if tokenId doesn't exist", async () => {
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
           const onChainMetadataHash = await media.fetchMetadataHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
@@ -233,7 +261,7 @@ describe("ZapMedia", () => {
           const zapMedia1 = new ZapMedia(1337, signers[1]);
 
           // mint a token by zapMedia1 in preparation to give permit to accounts 9 and 8
-          await zapMedia1.mint(mediaData, bidShares);
+          await zapMedia1.mint(mediaDataOne, bidShares);
 
           // get the arguments needed for EIP712 signature standard
           const deadline =
@@ -325,7 +353,14 @@ describe("ZapMedia", () => {
         let contentHash = contentHashBytes;
         let metadataHash = metadataHashBytes;
 
-        mediaData = constructMediaData(
+        mediaDataOne = constructMediaData(
+          tokenURI,
+          metadataURI,
+          contentHash,
+          metadataHash
+        );
+
+        mediaDataTwo = constructMediaData(
           tokenURI,
           metadataURI,
           contentHash,
@@ -349,9 +384,9 @@ describe("ZapMedia", () => {
           //   Instantiates the ZapMedia class
           const media = new ZapMedia(1337, signer);
 
-          mediaData.tokenURI = "http://example.com";
+          mediaDataOne.tokenURI = "http://example.com";
 
-          await media.mint(mediaData, bidShares).catch((err) => {
+          await media.mint(mediaDataOne, bidShares).catch((err) => {
             expect(err).to.equal(
               "Invariant failed: http://example.com must begin with `https://`"
             );
@@ -385,13 +420,13 @@ describe("ZapMedia", () => {
           const media = new ZapMedia(1337, signer);
 
           // Mints tokenId 0
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           // Returns tokenId 0's tokenURI
           const fetchTokenURI = await media.fetchContentURI(0);
 
-          // The returned tokenURI should equal the tokenURI configured in the mediaData
-          expect(fetchTokenURI).to.equal(mediaData.tokenURI);
+          // The returned tokenURI should equal the tokenURI configured in the mediaDataOne
+          expect(fetchTokenURI).to.equal(mediaDataOne.tokenURI);
 
           // Updates tokenId 0's tokenURI
           await media.updateContentURI(0, "https://newURI.com");
@@ -409,9 +444,9 @@ describe("ZapMedia", () => {
           //   Instantiates the ZapMedia class
           const media = new ZapMedia(1337, signer);
 
-          mediaData.metadataURI = "http://example.com";
+          mediaDataOne.metadataURI = "http://example.com";
 
-          await media.mint(mediaData, bidShares).catch((err) => {
+          await media.mint(mediaDataOne, bidShares).catch((err) => {
             expect(err).to.equal(
               "Invariant failed: http://example.com must begin with `https://`"
             );
@@ -421,10 +456,10 @@ describe("ZapMedia", () => {
         it("Should update the metadata uri", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const fetchMetadataURI = await media.fetchMetadataURI(0);
-          expect(fetchMetadataURI).to.equal(mediaData.metadataURI);
+          expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);
 
           await media.updateMetadataURI(0, "https://newMetadataURI.com");
 
@@ -449,7 +484,7 @@ describe("ZapMedia", () => {
             parseInt(bidShares.owner.value) +
             5e18;
 
-          await media.mint(mediaData, bidShares).catch((err) => {
+          await media.mint(mediaDataOne, bidShares).catch((err) => {
             expect(err).to.equal(
               `Invariant failed: The BidShares sum to ${bidShareSum}, but they must sum to 100000000000000000000`
             );
@@ -463,7 +498,7 @@ describe("ZapMedia", () => {
 
           expect(preTotalSupply).to.equal(0);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const owner = await media.fetchOwnerOf(0);
           const creator = await media.fetchCreator(0);
@@ -477,8 +512,8 @@ describe("ZapMedia", () => {
 
           expect(owner).to.equal(await signer.getAddress());
           expect(creator).to.equal(await signer.getAddress());
-          expect(onChainContentURI).to.equal(mediaData.tokenURI);
-          expect(onChainMetadataURI).to.equal(mediaData.metadataURI);
+          expect(onChainContentURI).to.equal(mediaDataOne.tokenURI);
+          expect(onChainMetadataURI).to.equal(mediaDataOne.metadataURI);
           expect(parseInt(onChainBidShares.creator.value)).to.equal(
             parseInt(bidShares.creator.value)
           );
@@ -513,7 +548,7 @@ describe("ZapMedia", () => {
           );
 
           await media
-            .mintWithSig(otherWallet.address, mediaData, bidShares, eipSig)
+            .mintWithSig(otherWallet.address, mediaDataOne, bidShares, eipSig)
             .catch((err) => {
               expect(err).to.eq(
                 `Invariant failed: The BidShares sum to ${bidShareSum}, but they must sum to 100000000000000000000`
@@ -564,8 +599,8 @@ describe("ZapMedia", () => {
           const invalidMediaData = {
             tokenURI: "https://example.com",
             metadataURI: "http://metadata.com",
-            contentHash: mediaData.contentHash,
-            metadataHash: mediaData.metadataHash,
+            contentHash: mediaDataOne.contentHash,
+            metadataHash: mediaDataOne.metadataHash,
           };
 
           await media
@@ -591,9 +626,11 @@ describe("ZapMedia", () => {
             Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24; // 24 hours
           const domain = media.eip712Domain();
           const nonce = await media.fetchMintWithSigNonce(mainWallet.address);
-          const media1ContentHash = ethers.utils.hexlify(mediaData.contentHash);
+          const media1ContentHash = ethers.utils.hexlify(
+            mediaDataOne.contentHash
+          );
           const media1MetadataHash = ethers.utils.hexlify(
-            mediaData.metadataHash
+            mediaDataOne.metadataHash
           );
           const eipSig = await signMintWithSigMessage(
             mainWallet,
@@ -610,7 +647,7 @@ describe("ZapMedia", () => {
 
           await media.mintWithSig(
             mainWallet.address,
-            mediaData,
+            mediaDataOne,
             bidShares,
             eipSig
           );
@@ -619,9 +656,11 @@ describe("ZapMedia", () => {
           const creator = await media.fetchCreator(0);
           const onChainContentHash = await media.fetchContentHash(0);
           const onChainMetadataHash = await media.fetchMetadataHash(0);
-          const mediaContentHash = ethers.utils.hexlify(mediaData.contentHash);
+          const mediaContentHash = ethers.utils.hexlify(
+            mediaDataOne.contentHash
+          );
           const mediaMetadataHash = ethers.utils.hexlify(
-            mediaData.metadataHash
+            mediaDataOne.metadataHash
           );
 
           const onChainBidShares = await media.fetchCurrentBidShares(
@@ -634,8 +673,8 @@ describe("ZapMedia", () => {
           expect(owner.toLowerCase()).to.eq(mainWallet.address.toLowerCase());
           expect(creator.toLowerCase()).to.eq(mainWallet.address.toLowerCase());
           expect(onChainContentHash).to.eq(mediaContentHash);
-          expect(onChainContentURI).to.eq(mediaData.tokenURI);
-          expect(onChainMetadataURI).to.eq(mediaData.metadataURI);
+          expect(onChainContentURI).to.eq(mediaDataOne.tokenURI);
+          expect(onChainMetadataURI).to.eq(mediaDataOne.metadataURI);
           expect(onChainMetadataHash).to.eq(mediaMetadataHash);
           expect(parseInt(onChainBidShares.creator.value)).to.eq(
             parseInt(bidShares.creator.value)
@@ -661,44 +700,11 @@ describe("ZapMedia", () => {
         it("Should return the token creator", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const creator = await media.fetchCreator(0);
 
           expect(creator).to.equal(await signer.getAddress());
-        });
-      });
-
-      describe.only("#tokenOfOwnerByIndex", () => {
-        let ownerConnected: ZapMedia;
-        let signerOneConnected: ZapMedia;
-        let signerOne = signers[1];
-
-        beforeEach(async () => {
-          ownerConnected = new ZapMedia(1337, signer);
-
-          signerOneConnected = new ZapMedia(1337, signerOne);
-
-          await ownerConnected.mint(mediaData, bidShares);
-
-          await signerOneConnected.mint(mediaData, bidShares);
-        });
-
-        it("Should reject if the (owner) is a zero address", async () => {
-          await ownerConnected
-            .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
-            .should.be.rejectedWith(
-              "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
-            );
-        });
-
-        it("Should return the token of the owner by index", async () => {
-          const tokenId = await ownerConnected.fetchMediaOfOwnerByIndex(
-            await signer.getAddress(),
-            0
-          );
-
-          expect(parseInt(tokenId._hex)).to.equal(0);
         });
       });
 
@@ -710,7 +716,7 @@ describe("ZapMedia", () => {
           const media = new ZapMedia(1337, signer);
           const media1 = new ZapMedia(1337, signer1);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const owner = await media.fetchOwnerOf(0);
           const getApproved = await media.fetchApproved(0);
@@ -731,7 +737,7 @@ describe("ZapMedia", () => {
           ask = constructAsk(zapMedia.address, 100);
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const owner = await media.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
@@ -754,7 +760,7 @@ describe("ZapMedia", () => {
           const media = new ZapMedia(1337, signer);
           const media1 = new ZapMedia(1337, signer1);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media.approve(await signer1.getAddress(), 0);
 
@@ -796,7 +802,7 @@ describe("ZapMedia", () => {
           bidderConnected = new ZapMedia(1337, bidder);
 
           // Mint a token
-          await ownerConnected.mint(mediaData, bidShares);
+          await ownerConnected.mint(mediaDataOne, bidShares);
 
           // Transfer tokens to the bidder
           await token.mint(await bidder.getAddress(), 1000);
@@ -1024,7 +1030,7 @@ describe("ZapMedia", () => {
         beforeEach(async () => {
           media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
         });
 
         it("Should throw an error if the removeAsk tokenId does not exist", async () => {
@@ -1080,7 +1086,7 @@ describe("ZapMedia", () => {
 
           // expect(nullApproved).toBe(AddressZero)
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media.approve(await signer1.getAddress(), 0);
 
@@ -1099,7 +1105,7 @@ describe("ZapMedia", () => {
       describe("#burn", () => {
         it("Should burn a token", async () => {
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
           const owner = await media.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
@@ -1119,7 +1125,7 @@ describe("ZapMedia", () => {
 
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const preApprovedStatus = await media.fetchApproved(0);
           expect(preApprovedStatus).to.equal(ethers.constants.AddressZero);
@@ -1137,7 +1143,7 @@ describe("ZapMedia", () => {
 
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const preApprovalStatus = await media.fetchIsApprovedForAll(
             await signer.getAddress(),
@@ -1170,7 +1176,7 @@ describe("ZapMedia", () => {
         it("Should transfer token to another address", async () => {
           const recipient = await signers[1].getAddress();
           const media = new ZapMedia(1337, signer);
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const owner = await media.fetchOwnerOf(0);
 
@@ -1204,7 +1210,7 @@ describe("ZapMedia", () => {
 
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media
             .safeTransferFrom(ethers.constants.AddressZero, recipient, 0)
@@ -1218,7 +1224,7 @@ describe("ZapMedia", () => {
         it("Should revert if the (to) is a zero address", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media
             .safeTransferFrom(
@@ -1238,7 +1244,7 @@ describe("ZapMedia", () => {
 
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media.safeTransferFrom(await signer.getAddress(), recipient, 0);
         });
@@ -1248,14 +1254,14 @@ describe("ZapMedia", () => {
         it("Should return true if the bid amount can be evenly split by current bidShares", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
         });
       });
 
       describe("#permit", () => {
         it("should allow a wallet to set themselves to approved with a valid signature", async () => {
           const zap_media = new ZapMedia(1337, signer);
-          await zap_media.mint(mediaData, bidShares);
+          await zap_media.mint(mediaDataOne, bidShares);
 
           // created wallets using privateKey because we need a wallet instance when creating a signature
           const mainWallet: Wallet = new ethers.Wallet(
@@ -1302,7 +1308,7 @@ describe("ZapMedia", () => {
         it("Should get media instance by index in the media contract", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const tokenId = await media.fetchMediaByIndex(0);
 
@@ -1312,7 +1318,7 @@ describe("ZapMedia", () => {
         it("Should throw an error index out of range", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media.fetchMediaByIndex(1).catch((err) => {
             expect(err.message).to.equal(
@@ -1326,7 +1332,7 @@ describe("ZapMedia", () => {
         it("Should fetch the signature of the newly minted nonce", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           const sigNonce = await media.fetchMintWithSigNonce(
             await signer.getAddress()
@@ -1338,7 +1344,7 @@ describe("ZapMedia", () => {
         it("Should Revert if address does not exist", async () => {
           const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaData, bidShares);
+          await media.mint(mediaDataOne, bidShares);
 
           await media
             .fetchMintWithSigNonce("0x9b713D5416884d12a5BbF13Ee08B6038E74CDe")

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -391,6 +391,7 @@ describe("ZapMedia", () => {
             "www.example.com"
           );
 
+          // The custom media address
           customMediaAddress = args.mediaContract;
 
           // The owner (signers[0]) mints on their own media contract
@@ -409,6 +410,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should throw an error if the (owner) is a zero address", async () => {
+          // fetchMediaOfOwnerByIndex will fail due to a zero address passed in as the owner
           await ownerConnected
             .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
             .should.be.rejectedWith(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -369,7 +369,7 @@ describe("ZapMedia", () => {
           await signerOneConnected.mint(mediaDataTwo, bidShares);
 
           // The signerOne (signers[1]) mints on their own media contract by passing in the
-          // address of their media address as optional argument
+          // their media address as optional argument
           await signerOneConnected.mint(
             mediaDataOne,
             bidShares,
@@ -386,26 +386,31 @@ describe("ZapMedia", () => {
         });
 
         it("Should return the token of the owner by index", async () => {
+          // Returns the tokenId owner (signers[0]) minted on the main media contract
           const fetchToken = await ownerConnected.fetchMediaOfOwnerByIndex(
             await signer.getAddress(),
             0
           );
 
+          // Returns the tokenId signerOne (signers[1]) minted on the main media contract
           const fetchTokenOne = await ownerConnected.fetchMediaOfOwnerByIndex(
             await signerOne.getAddress(),
             0
           );
 
+          // Expect owner (signers[0]) to own tokenId 0 on the main media contract
           expect(parseInt(fetchToken._hex)).to.equal(0);
+
+          // Expect signerOne (signers[1]) to own tokenId 1 on the main media contract
           expect(parseInt(fetchTokenOne._hex)).to.equal(1);
         });
 
         it("Should return the token of an owner by index from a custom media", async () => {
-          // const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
-          //   await signerOne.getAddress(),
-          //   0,
-          //   0
-          // );
+          const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
+            await signerOne.getAddress(),
+            0,
+            0
+          );
         });
       });
     });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -350,25 +350,29 @@ describe("ZapMedia", () => {
         });
 
         it("Should throw an error if the (owner) is a zero address", async () => {
-          // await ownerConnected
-          //   .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
-          //   .should.be.rejectedWith(
-          //     "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
-          //   );
+          await ownerConnected
+            .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
+            );
         });
 
-        // it("Should return the token of the owner by index", async () => {
-        //   const media = new ZapMedia(1337, signer);
+        it("Should return the token of the owner by index", async () => {
+          const fetchToken = await ownerConnected.fetchMediaOfOwnerByIndex(
+            await signer.getAddress(),
+            0
+          );
 
-        //   await media.mint(mediaData, bidShares);
+          const fetchTokenOne = await ownerConnected.fetchMediaOfOwnerByIndex(
+            await signerOne.getAddress(),
+            0
+          );
 
-        //   const tokenId = await media.fetchMediaOfOwnerByIndex(
-        //     await signer.getAddress(),
-        //     0
-        //   );
+          expect(parseInt(fetchToken._hex)).to.equal(0);
+          expect(parseInt(fetchTokenOne._hex)).to.equal(1);
+        });
 
-        //   expect(parseInt(tokenId._hex)).to.equal(0);
-        // });
+        it("Should return the token of the owner by index from a custom media", async () => {});
       });
     });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -675,7 +675,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#tokenOfOwnerByIndex", () => {
+      describe("#tokenOfOwnerByIndex", () => {
         it("Should throw an error if the (owner) is a zero address", async () => {
           const media = new ZapMedia(1337, signer);
 
@@ -688,7 +688,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should return the token of the owner by index", async () => {
+        it("Should return the token of the owner by index", async () => {
           const media = new ZapMedia(1337, signer);
 
           await media.mint(mediaData, bidShares);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -348,8 +348,6 @@ describe("ZapMedia", () => {
           signerOneConnected = new ZapMedia(1337, signerOne);
 
           mediaFactory = new MediaFactory(1337, signerOne);
-          await ownerConnected.mint(mediaDataOne, bidShares);
-          await signerOneConnected.mint(mediaDataTwo, bidShares);
 
           await mediaFactory.deployMedia(
             "TEST COLLECTION 2",
@@ -357,6 +355,10 @@ describe("ZapMedia", () => {
             true,
             "www.example.com"
           );
+
+          await ownerConnected.mint(mediaDataOne, bidShares);
+          await signerOneConnected.mint(mediaDataTwo, bidShares);
+          await signerOneConnected.mint(mediaDataOne, bidShares, 0);
         });
 
         it("Should throw an error if the (owner) is a zero address", async () => {
@@ -382,13 +384,7 @@ describe("ZapMedia", () => {
           expect(parseInt(fetchTokenOne._hex)).to.equal(1);
         });
 
-        it("Should return the token of an owner by index from a custom media", async () => {
-          const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
-            await signerOne.getAddress(),
-            0,
-            0
-          );
-        });
+        it("Should return the token of an owner by index from a custom media", async () => {});
       });
     });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -334,6 +334,42 @@ describe("ZapMedia", () => {
           expect(nonceForTokenThatDoesntExist).to.equal(0);
         });
       });
+
+      describe.only("#tokenOfOwnerByIndex", () => {
+        let signerOne: Signer;
+        let ownerConnected: ZapMedia;
+        let signerOneConnected: ZapMedia;
+
+        beforeEach(async () => {
+          signerOne = signers[1];
+
+          ownerConnected = new ZapMedia(1337, signer);
+          signerOneConnected = new ZapMedia(1337, signerOne);
+          await ownerConnected.mint(mediaDataOne, bidShares);
+          await signerOneConnected.mint(mediaDataTwo, bidShares);
+        });
+
+        it("Should throw an error if the (owner) is a zero address", async () => {
+          // await ownerConnected
+          //   .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
+          //   .should.be.rejectedWith(
+          //     "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
+          //   );
+        });
+
+        // it("Should return the token of the owner by index", async () => {
+        //   const media = new ZapMedia(1337, signer);
+
+        //   await media.mint(mediaData, bidShares);
+
+        //   const tokenId = await media.fetchMediaOfOwnerByIndex(
+        //     await signer.getAddress(),
+        //     0
+        //   );
+
+        //   expect(parseInt(tokenId._hex)).to.equal(0);
+        // });
+      });
     });
 
     describe("Write Functions", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -342,23 +342,39 @@ describe("ZapMedia", () => {
         let mediaFactory: MediaFactory;
 
         beforeEach(async () => {
+          // Set signerOne to equal signers[1]
           signerOne = signers[1];
 
+          // owner (signers[0]) creates an instance of the main ZapMedia class
           ownerConnected = new ZapMedia(1337, signer);
+
+          // signerOne (signers[1]) creates an instance of the main ZapMedia class
           signerOneConnected = new ZapMedia(1337, signerOne);
 
+          // signerOne (signers[1]) creates an instance of the MediaFactory class
           mediaFactory = new MediaFactory(1337, signerOne);
 
-          await mediaFactory.deployMedia(
+          // signerOne (signers[1]) deploys their own media contract
+          const { args } = await mediaFactory.deployMedia(
             "TEST COLLECTION 2",
             "TC2",
             true,
             "www.example.com"
           );
 
+          // The owner (signers[0]) mints on their own media contract
           await ownerConnected.mint(mediaDataOne, bidShares);
+
+          // The signerOne (signers[1]) mints on the owners (signers[0]) media contract
           await signerOneConnected.mint(mediaDataTwo, bidShares);
-          await signerOneConnected.mint(mediaDataOne, bidShares, 0);
+
+          // The signerOne (signers[1]) mints on their own media contract by passing in the
+          // address of their media address as optional argument
+          await signerOneConnected.mint(
+            mediaDataOne,
+            bidShares,
+            args.mediaContract
+          );
         });
 
         it("Should throw an error if the (owner) is a zero address", async () => {
@@ -384,7 +400,13 @@ describe("ZapMedia", () => {
           expect(parseInt(fetchTokenOne._hex)).to.equal(1);
         });
 
-        it("Should return the token of an owner by index from a custom media", async () => {});
+        it("Should return the token of an owner by index from a custom media", async () => {
+          // const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
+          //   await signerOne.getAddress(),
+          //   0,
+          //   0
+          // );
+        });
       });
     });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -340,6 +340,7 @@ describe("ZapMedia", () => {
         let ownerConnected: ZapMedia;
         let signerOneConnected: ZapMedia;
         let mediaFactory: MediaFactory;
+        let customMediaAddress: string;
 
         beforeEach(async () => {
           // Set signerOne to equal signers[1]
@@ -362,6 +363,8 @@ describe("ZapMedia", () => {
             "www.example.com"
           );
 
+          customMediaAddress = args.mediaContract;
+
           // The owner (signers[0]) mints on their own media contract
           await ownerConnected.mint(mediaDataOne, bidShares);
 
@@ -373,7 +376,7 @@ describe("ZapMedia", () => {
           await signerOneConnected.mint(
             mediaDataOne,
             bidShares,
-            args.mediaContract
+            customMediaAddress
           );
         });
 
@@ -408,7 +411,6 @@ describe("ZapMedia", () => {
         it("Should return the token of an owner by index from a custom media", async () => {
           const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
             await signerOne.getAddress(),
-            0,
             0
           );
         });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -675,13 +675,17 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#tokenOfOwnerByIndex", () => {
+      describe.only("#tokenOfOwnerByIndex", () => {
+        let ownerConnected: ZapMedia;
+
+        beforeEach(async () => {
+          ownerConnected = new ZapMedia(1337, signer);
+
+          await ownerConnected.mint(mediaData, bidShares);
+        });
+
         it("Should throw an error if the (owner) is a zero address", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaData, bidShares);
-
-          await media
+          await ownerConnected
             .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
@@ -689,19 +693,12 @@ describe("ZapMedia", () => {
         });
 
         it("Should return the token of the owner by index", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaData, bidShares);
-
-          const tokenId = await media.fetchMediaOfOwnerByIndex(
+          const tokenId = await ownerConnected.fetchMediaOfOwnerByIndex(
             await signer.getAddress(),
-            0,
             0
           );
 
-          console.log(tokenId);
-
-          // expect(parseInt(tokenId._hex)).to.equal(0);
+          expect(parseInt(tokenId._hex)).to.equal(0);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -409,13 +409,15 @@ describe("ZapMedia", () => {
         });
 
         it("Should return the token of an owner by index from a custom media", async () => {
+          // Returns the tokenId signerOne (signers[1]) minted on their media contract
           const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
             await signerOne.getAddress(),
             0,
             customMediaAddress
           );
 
-          console.log(fetchToken);
+          // Expect signerOne (signers[1]) to own tokenId 0 on their own media contract
+          expect(parseInt(fetchToken._hex)).to.equal(0);
         });
       });
     });


### PR DESCRIPTION
## Summary
Closes #363 

## Implementation
 - [x] Added the optional ```customMediaAddress``` argument to the ```fetchMediaOfOwnerByIndex``` function
 - [x] Added an if/else statement to check whether the ```customMediaAddress``` is undefined or not
 - [x] If ```customMediaAddress``` is not undefined attach the value to the main ZapMedia class contract to create a custom media contract instance and invoke the ```fetchMediaOfOwnerByIndex``` on that contract
 - [x] If ```customMediaAddress``` is undefined invoke the ```fetchMediaOfOwnerByIndex``` function on the main ZapMedia class contract
 - [x] Refactored the ```fetchbalanceOf``` function from #361 so both allow the optional ```customMediaContract``` argument. This refactor was less intrusive and simply allows an address to pass into the function.
 - [x] Added passing tests for the ```fetchMediaOfOwnerByIndex``` function and refactored the ```fetchBalanceOf``` tests that are also passing.

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
Passing tests refactored from #361 

<img width="677" alt="Screen Shot 2022-01-28 at 4 23 32 PM" src="https://user-images.githubusercontent.com/42893948/151623364-19d1d2ca-91a5-4ede-bb24-04ab298d816a.png">

Passing tests for ```fetchMediaOfOwnerByIndex```
<img width="734" alt="Screen Shot 2022-01-28 at 4 24 31 PM" src="https://user-images.githubusercontent.com/42893948/151623462-f7048f29-1ed0-46f4-8db0-3a699eb6ed81.png">

