### PR TITLE
FetchApproved & Approve Custom Media Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -273,7 +273,8 @@ class ZapMedia {
 
   /**
    * Fetches the approved account for the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
+   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchApproved(
     mediaId: BigNumberish,
@@ -339,8 +340,9 @@ class ZapMedia {
 
   /**
    * Grants approval to the specified address for the specified media on an instance of the Zap Media Contract
-   * @param to
-   * @param mediaId
+   * @param to The address to be approved
+   * @param mediaId Numerical identifier for a minted token
+   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async approve(
     to: string,
@@ -375,6 +377,7 @@ class ZapMedia {
         );
       }
 
+      // Appr
       return this.media.attach(customMediaAddress).approve(to, mediaId);
     }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -335,10 +335,24 @@ class ZapMedia {
     to: string,
     mediaId: BigNumberish
   ): Promise<ContractTransaction> {
+    let owner: string;
     try {
-      await this.media.ownerOf(mediaId);
+      // Sets the owner if the tokenId exists
+      owner = await this.media.ownerOf(mediaId);
     } catch (err: any) {
       invariant(false, "ZapMedia (approve): TokenId does not exist.");
+    }
+
+    const approvalStatus = await this.media.isApprovedForAll(
+      owner,
+      await this.signer.getAddress()
+    );
+
+    if ((await this.signer.getAddress()) !== owner && approvalStatus == false) {
+      invariant(
+        false,
+        "ZapMedia (approve): Caller is not the owner nor approved for all."
+      );
     }
 
     return this.media.approve(to, mediaId);

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -333,7 +333,8 @@ class ZapMedia {
    */
   public async approve(
     to: string,
-    mediaId: BigNumberish
+    mediaId: BigNumberish,
+    customMediaAddress?: string
   ): Promise<ContractTransaction> {
     let owner: string;
     try {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -282,14 +282,14 @@ class ZapMedia {
     if (customMediaAddress !== undefined) {
       try {
         return await this.media.attach(customMediaAddress).getApproved(mediaId);
-      } catch (err) {
+      } catch {
         invariant(false, "ZapMedia (fetchApproved): TokenId does not exist.");
       }
     }
 
     try {
       return await this.media.getApproved(mediaId);
-    } catch (err) {
+    } catch {
       invariant(false, "ZapMedia (fetchApproved): TokenId does not exist.");
     }
   }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -275,7 +275,18 @@ class ZapMedia {
    * Fetches the approved account for the specified media on an instance of the Zap Media Contract
    * @param mediaId
    */
-  public async fetchApproved(mediaId: BigNumberish): Promise<string> {
+  public async fetchApproved(
+    mediaId: BigNumberish,
+    customMediaAddress?: string
+  ): Promise<string> {
+    if (customMediaAddress !== undefined) {
+      try {
+        return await this.media.attach(customMediaAddress).getApproved(mediaId);
+      } catch (err) {
+        invariant(false, "ZapMedia (fetchApproved): TokenId does not exist.");
+      }
+    }
+
     try {
       return await this.media.getApproved(mediaId);
     } catch (err) {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -336,11 +336,40 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<ContractTransaction> {
+    // Will be assigned the address of the token owner
     let owner: string;
+
+    // Checks if the customMediaAddress argument is not undefined
+    if (customMediaAddress !== undefined) {
+      // Checks if the tokenId exists
+      try {
+        owner = await this.media.attach(customMediaAddress).ownerOf(mediaId);
+      } catch {
+        invariant(false, "ZapMedia (approve): TokenId does not exist.");
+      }
+
+      // Returns the approval for all status
+      const approvalStatus: boolean = await this.media
+        .attach(customMediaAddress)
+        .isApprovedForAll(owner, await this.signer.getAddress());
+
+      // If the signer is not the owner nor approved for all they cannot invoke this function
+      if (
+        (await this.signer.getAddress()) !== owner &&
+        approvalStatus == false
+      ) {
+        invariant(
+          false,
+          "ZapMedia (approve): Caller is not the owner nor approved for all."
+        );
+      }
+
+      return this.media.attach(customMediaAddress).approve(to, mediaId);
+    }
+
     try {
-      // Sets the owner if the tokenId exists
       owner = await this.media.ownerOf(mediaId);
-    } catch (err: any) {
+    } catch {
       invariant(false, "ZapMedia (approve): TokenId does not exist.");
     }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -343,7 +343,7 @@ class ZapMedia {
       invariant(false, "ZapMedia (approve): TokenId does not exist.");
     }
 
-    const approvalStatus = await this.media.isApprovedForAll(
+    const approvalStatus: boolean = await this.media.isApprovedForAll(
       owner,
       await this.signer.getAddress()
     );

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -335,6 +335,12 @@ class ZapMedia {
     to: string,
     mediaId: BigNumberish
   ): Promise<ContractTransaction> {
+    try {
+      await this.media.ownerOf(mediaId);
+    } catch (err: any) {
+      invariant(false, "ZapMedia (approve): TokenId does not exist.");
+    }
+
     return this.media.approve(to, mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1159,11 +1159,23 @@ describe("ZapMedia", () => {
         });
 
         it.only("Should approve another address for a token on a custom media", async () => {
+          const preApprovedAddr = await signerOneConnected.fetchApproved(
+            0,
+            customMediaAddress
+          );
+          expect(preApprovedAddr).to.equal(ethers.constants.AddressZero);
+
           await signerOneConnected.approve(
             await signer.getAddress(),
             0,
             customMediaAddress
           );
+
+          const postApprovedAddr = await signerOneConnected.fetchApproved(
+            0,
+            customMediaAddress
+          );
+          expect(postApprovedAddr).to.equal(await signer.getAddress());
         });
 
         it("Should approve another address for a token by a caller who is approved for all", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1115,11 +1115,19 @@ describe.only("ZapMedia", () => {
       });
 
       describe.only("#approve", () => {
-        it.only("Should reject if the token id does not exist", async () => {
+        it("Should reject if the token id does not exist", async () => {
           await ownerConnected
             .approve(await signerOne.getAddress(), 400)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (approve): TokenId does not exist."
+            );
+        });
+
+        it("Should reject if the caller is not the owner nor approved for all", async () => {
+          await signerOneConnected
+            .approve(await signerOne.getAddress(), 0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (approve): Caller is not the owner nor approved for all."
             );
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1114,7 +1114,15 @@ describe.only("ZapMedia", () => {
         });
       });
 
-      describe("#approve", () => {
+      describe.only("#approve", () => {
+        it.only("Should reject if the token id does not exist", async () => {
+          await ownerConnected
+            .approve(await signerOne.getAddress(), 400)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (approve): TokenId does not exist."
+            );
+        });
+
         it("Should approve another address for a token", async () => {
           const preApprovedStatus = await ownerConnected.fetchApproved(0);
           expect(preApprovedStatus).to.equal(ethers.constants.AddressZero);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from "chai";
 
 import chaiAsPromised from "chai-as-promised";
 
-import { ethers, Wallet, Signer } from "ethers";
+import { ethers, Wallet, Signer, Contract } from "ethers";
 
 import { formatUnits } from "ethers/lib/utils";
 
@@ -45,160 +45,152 @@ chai.use(chaiAsPromised);
 
 chai.should();
 
-describe("ZapMedia", () => {
+describe.only("ZapMedia", () => {
   let bidShares: any;
   let ask: any;
   let mediaDataOne: any;
   let mediaDataTwo: any;
-  let token: any;
-  let zapVault: any;
-  let zapMarket: any;
-  let mediaFactory: any;
-  let signer: any;
-  let zapMedia: any;
+  let token: Contract;
+  let zapVault: Contract;
+  let zapMarket: Contract;
+  let mediaFactoryDeployed: Contract;
+  let zapMedia: Contract;
+
+  let signer: Signer;
+  let signerOne: Signer;
+
+  let mediaFactory: MediaFactory;
+  let signerOneConnected: ZapMedia;
+  let ownerConnected: ZapMedia;
+  let customMediaAddress: string;
+
   let eipSig: any;
 
   const signers = getSigners(provider);
 
+  let tokenURI =
+    "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
+
+  let metadataURI =
+    "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
+
   beforeEach(async () => {
     signer = signers[0];
+    signerOne = signers[1];
 
     token = await deployZapToken();
     zapVault = await deployZapVault();
     zapMarket = await deployZapMarket();
     await deployZapMediaImpl();
-    mediaFactory = await deployMediaFactory();
+    mediaFactoryDeployed = await deployMediaFactory();
     zapMedia = await deployZapMedia();
 
     zapMarketAddresses["1337"] = zapMarket.address;
-    mediaFactoryAddresses["1337"] = mediaFactory.address;
+    mediaFactoryAddresses["1337"] = mediaFactoryDeployed.address;
     zapMediaAddresses["1337"] = zapMedia.address;
-  });
 
-  describe("#constructor", () => {
-    it("Should throw an error if the networkId is invalid", async () => {
-      expect(() => {
-        new ZapMedia(300, signer);
-      }).to.throw("Constructor: Network Id is not supported.");
-    });
+    // MetadataHex
+    let metadataHexOne = ethers.utils.formatBytes32String("Test1");
+    let metadataHexTwo = ethers.utils.formatBytes32String("Test2");
+
+    // MetadataHashRaw
+    let metadataHashRawOne = ethers.utils.keccak256(metadataHexOne);
+    let metadataHashRawTwo = ethers.utils.keccak256(metadataHexTwo);
+
+    // MetadataHashBytes
+    let metadataHashBytesOne = ethers.utils.arrayify(metadataHashRawOne);
+    let metadataHashBytesTwo = ethers.utils.arrayify(metadataHashRawTwo);
+
+    // ContextHex
+    let contentHexOne = ethers.utils.formatBytes32String("Testing1");
+    let contentHexTwo = ethers.utils.formatBytes32String("Testing2");
+
+    // ContentHashRaw
+    let contentHashRawOne = ethers.utils.keccak256(contentHexOne);
+    let contentHashRawTwo = ethers.utils.keccak256(contentHexTwo);
+
+    // ContentHashBytes
+    let contentHashBytesOne = ethers.utils.arrayify(contentHashRawOne);
+    let contentHashBytesTwo = ethers.utils.arrayify(contentHashRawTwo);
+
+    // ContentHash
+    let contentHashOne = contentHashBytesOne;
+    let contentHashTwo = contentHashBytesTwo;
+
+    let metadataHashOne = metadataHashBytesOne;
+    let metadataHashTwo = metadataHashBytesTwo;
+
+    mediaDataOne = constructMediaData(
+      tokenURI,
+      metadataURI,
+      contentHashOne,
+      metadataHashOne
+    );
+
+    mediaDataTwo = constructMediaData(
+      tokenURI,
+      metadataURI,
+      contentHashTwo,
+      metadataHashTwo
+    );
+
+    bidShares = constructBidShares(
+      [
+        await provider.getSigner(1).getAddress(),
+        await provider.getSigner(2).getAddress(),
+        await provider.getSigner(3).getAddress(),
+      ],
+      [15, 15, 15],
+      15,
+      35
+    );
+
+    eipSig = {
+      deadline: 1000,
+      v: 0,
+      r: "0x00",
+      s: "0x00",
+    };
+
+    // signerOne (signers[1]) creates an instance of the MediaFactory class
+    mediaFactory = new MediaFactory(1337, signerOne);
+
+    // signerOne (signers[1]) deploys their own media contract
+    const { args } = await mediaFactory.deployMedia(
+      "TEST COLLECTION 2",
+      "TC2",
+      true,
+      "www.example.com"
+    );
+
+    customMediaAddress = args.mediaContract;
+
+    ownerConnected = new ZapMedia(1337, signer);
+
+    signerOneConnected = new ZapMedia(1337, signerOne);
+
+    // The owner (signers[0]) mints on their own media contract
+    await ownerConnected.mint(mediaDataOne, bidShares);
+
+    // The signerOne (signers[1]) mints on the owners (signers[0]) media contract
+    await signerOneConnected.mint(mediaDataTwo, bidShares);
+
+    // The signerOne (signers[1]) mints on their own media contract by passing in the
+    // their media address as optional argument
+    await signerOneConnected.mint(mediaDataOne, bidShares, customMediaAddress);
   });
 
   describe("Contract Functions", () => {
-    describe("View Functions", () => {
-      let tokenURI =
-        "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
-
-      let metadataURI =
-        "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
-
-      beforeEach(async () => {
-        // MetadataHex
-        let metadataHexOne = ethers.utils.formatBytes32String("Test1");
-        let metadataHexTwo = ethers.utils.formatBytes32String("Test2");
-
-        // MetadataHashRaw
-        let metadataHashRawOne = ethers.utils.keccak256(metadataHexOne);
-        let metadataHashRawTwo = ethers.utils.keccak256(metadataHexTwo);
-
-        // MetadataHashBytes
-        let metadataHashBytesOne = ethers.utils.arrayify(metadataHashRawOne);
-        let metadataHashBytesTwo = ethers.utils.arrayify(metadataHashRawTwo);
-
-        // ContextHex
-        let contentHexOne = ethers.utils.formatBytes32String("Testing1");
-        let contentHexTwo = ethers.utils.formatBytes32String("Testing2");
-
-        // ContentHashRaw
-        let contentHashRawOne = ethers.utils.keccak256(contentHexOne);
-        let contentHashRawTwo = ethers.utils.keccak256(contentHexTwo);
-
-        // ContentHashBytes
-        let contentHashBytesOne = ethers.utils.arrayify(contentHashRawOne);
-        let contentHashBytesTwo = ethers.utils.arrayify(contentHashRawTwo);
-
-        // ContentHash
-        let contentHashOne = contentHashBytesOne;
-        let contentHashTwo = contentHashBytesTwo;
-
-        let metadataHashOne = metadataHashBytesOne;
-        let metadataHashTwo = metadataHashBytesTwo;
-
-        mediaDataOne = constructMediaData(
-          tokenURI,
-          metadataURI,
-          contentHashOne,
-          metadataHashOne
-        );
-
-        mediaDataTwo = constructMediaData(
-          tokenURI,
-          metadataURI,
-          contentHashTwo,
-          metadataHashTwo
-        );
-
-        bidShares = constructBidShares(
-          [
-            await provider.getSigner(1).getAddress(),
-            await provider.getSigner(2).getAddress(),
-            await provider.getSigner(3).getAddress(),
-          ],
-          [15, 15, 15],
-          15,
-          35
-        );
-
-        eipSig = {
-          deadline: 1000,
-          v: 0,
-          r: "0x00",
-          s: "0x00",
-        };
+    describe("#constructor", () => {
+      it("Should throw an error if the networkId is invalid", async () => {
+        expect(() => {
+          new ZapMedia(300, signer);
+        }).to.throw("Constructor: Network Id is not supported.");
       });
+    });
 
+    describe("View Functions", () => {
       describe("#fetchBalanceOf", () => {
-        let signerOne: Signer;
-        let mediaFactory: MediaFactory;
-        let signerOneConnected: ZapMedia;
-        let ownerConnected: ZapMedia;
-        let customMediaAddress: string;
-
-        beforeEach(async () => {
-          // Set signerOne to equal signers[1]
-          signerOne = signers[1];
-
-          // signerOne (signers[1]) creates an instance of the MediaFactory class
-          mediaFactory = new MediaFactory(1337, signerOne);
-
-          // signerOne (signers[1]) deploys their own media contract
-          const { args } = await mediaFactory.deployMedia(
-            "TEST COLLECTION 2",
-            "TC2",
-            true,
-            "www.example.com"
-          );
-
-          customMediaAddress = args.mediaContract;
-
-          ownerConnected = new ZapMedia(1337, signer);
-
-          signerOneConnected = new ZapMedia(1337, signerOne);
-
-          // The owner (signers[0]) mints on their own media contract
-          await ownerConnected.mint(mediaDataOne, bidShares);
-
-          // The signerOne (signers[1]) mints on the owners (signers[0]) media contract
-          await signerOneConnected.mint(mediaDataTwo, bidShares);
-
-          // The signerOne (signers[1]) mints on their own media contract by passing in the
-          // their media address as optional argument
-          await signerOneConnected.mint(
-            mediaDataOne,
-            bidShares,
-            customMediaAddress
-          );
-        });
-
         it("Should reject if the owner is a zero address", async () => {
           await signerOneConnected
             .fetchBalanceOf(ethers.constants.AddressZero)
@@ -239,48 +231,6 @@ describe("ZapMedia", () => {
       });
 
       describe("#fetchOwnerOf", () => {
-        const signerOne: Signer = signers[1];
-        let mediaFactory: MediaFactory;
-        let signerOneConnected: ZapMedia;
-        let ownerConnected: ZapMedia;
-        let customMediaAddress: string;
-
-        beforeEach(async () => {
-          // signerOne creates an instance of the MediaFactory class
-          mediaFactory = new MediaFactory(1337, signerOne);
-
-          // signerOne deploys a custom media
-          const { args } = await mediaFactory.deployMedia(
-            "TEST COLLECTION 2",
-            "TC2",
-            true,
-            "www.example.com"
-          );
-
-          // Sets the custom media address
-          customMediaAddress = args.mediaContract;
-
-          // The owner (signers[0]) creates an instance of the ZapMedia class
-          ownerConnected = new ZapMedia(1337, signer);
-
-          // signerOne (signers[1]) creates an instance of the ZapMedia class
-          signerOneConnected = new ZapMedia(1337, signerOne);
-
-          // The owner (signers[0]) mints on the main media
-          await ownerConnected.mint(mediaDataOne, bidShares);
-
-          // signerOne (signers[1]) mints on the main media
-          await signerOneConnected.mint(mediaDataTwo, bidShares);
-
-          // The signerOne (signers[1]) mints on their own media contract by passing in the
-          // their media address as optional argument
-          await signerOneConnected.mint(
-            mediaDataOne,
-            bidShares,
-            customMediaAddress
-          );
-        });
-
         it("Should reject if the token id does not exist", async () => {
           // Should throw an error due to the token id not existing on the mainmedia
           await ownerConnected
@@ -323,36 +273,30 @@ describe("ZapMedia", () => {
 
       describe("#fetchContentHash, fetchMetadataHash, fetchPermitNonce", () => {
         it("Should be able to fetch contentHash", async () => {
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
-          const onChainContentHash = await media.fetchContentHash(0);
+          const onChainContentHash = await ownerConnected.fetchContentHash(0);
           expect(onChainContentHash).eq(
             ethers.utils.hexlify(mediaDataOne.contentHash)
           );
         });
 
         it("fetchContentHash should get 0x0 if tokenId doesn't exist", async () => {
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
-          const onChainContentHash = await media.fetchContentHash(56);
+          const onChainContentHash = await ownerConnected.fetchContentHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainContentHash).eq(ethers.constants.HashZero);
         });
 
         it("Should be able to fetch metadataHash", async () => {
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
-          const onChainMetadataHash = await media.fetchMetadataHash(0);
+          const onChainMetadataHash = await ownerConnected.fetchMetadataHash(0);
           expect(onChainMetadataHash).eq(
             ethers.utils.hexlify(mediaDataOne.metadataHash)
           );
         });
 
         it("fetchMetadataHash should get 0x0 if tokenId doesn't exist", async () => {
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
-          const onChainMetadataHash = await media.fetchMetadataHash(56);
+          const onChainMetadataHash = await ownerConnected.fetchMetadataHash(
+            56
+          );
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainMetadataHash).eq(ethers.constants.HashZero);
@@ -363,46 +307,42 @@ describe("ZapMedia", () => {
           const otherWallet: Wallet = new ethers.Wallet(
             "0x043192f7a8fb472d04ef7bb0ba1fbb3667198253cc8046e9e56626b804966cb3"
           );
+
           const account9: Wallet = new ethers.Wallet(
             "0x915c40257f694fef7d8058fe4db4ba53f1343b592a8175ea18e7ece20d2987d7"
           );
 
-          // connect to media contracts through ZapMedia class
-          const zap_media = new ZapMedia(1337, signer);
-          const zapMedia1 = new ZapMedia(1337, signers[1]);
-
-          // mint a token by zapMedia1 in preparation to give permit to accounts 9 and 8
-          await zapMedia1.mint(mediaDataOne, bidShares);
-
           // get the arguments needed for EIP712 signature standard
           const deadline =
             Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24; // 24 hours
-          const domain = zap_media.eip712Domain();
+
+          const domain = ownerConnected.eip712Domain();
+
           const nonce = await (
-            await zap_media.fetchPermitNonce(otherWallet.address, 0)
+            await ownerConnected.fetchPermitNonce(otherWallet.address, 1)
           ).toNumber();
 
           // generate the signature
           let eipSig: EIP712Signature = await signPermitMessage(
             otherWallet,
             account9.address,
-            0,
+            1,
             nonce,
             deadline,
             domain
           );
 
           // permit account9 == give approval to account 9 for tokenId 0.
-          await zapMedia1.permit(account9.address, 0, eipSig);
+          await signerOneConnected.permit(account9.address, 1, eipSig);
 
           // test account 9 is approved for tokenId 0
-          const firstApprovedAddr = await zapMedia1.fetchApproved(0);
+          const firstApprovedAddr = await signerOneConnected.fetchApproved(1);
           expect(firstApprovedAddr.toLowerCase()).to.equal(
             account9.address.toLowerCase()
           );
 
           const nonce2 = await (
-            await zap_media.fetchPermitNonce(otherWallet.address, 0)
+            await ownerConnected.fetchPermitNonce(otherWallet.address, 1)
           ).toNumber();
 
           expect(nonce2).to.equal(nonce + 1);
@@ -415,29 +355,29 @@ describe("ZapMedia", () => {
           eipSig = await signPermitMessage(
             otherWallet,
             account8.address,
-            0,
+            1,
             nonce2,
             deadline,
             domain
           );
 
-          await zapMedia1.permit(account8.address, 0, eipSig);
+          await signerOneConnected.permit(account8.address, 1, eipSig);
 
-          // test account 8 is approved for tokenId 0
+          // test account 8 is approved for tokenId 1
 
-          const secondApprovedAddr = await zapMedia1.fetchApproved(0);
+          const secondApprovedAddr = await signerOneConnected.fetchApproved(1);
           expect(secondApprovedAddr.toLowerCase()).to.equal(
             account8.address.toLowerCase()
           );
 
           const nonce3 = await (
-            await zap_media.fetchPermitNonce(otherWallet.address, 0)
+            await ownerConnected.fetchPermitNonce(otherWallet.address, 1)
           ).toNumber();
           expect(nonce3).to.equal(nonce2 + 1);
 
           const tokenThatDoesntExist = 38;
           const nonceForTokenThatDoesntExist = await (
-            await zap_media.fetchPermitNonce(
+            await ownerConnected.fetchPermitNonce(
               otherWallet.address,
               tokenThatDoesntExist
             )
@@ -447,51 +387,6 @@ describe("ZapMedia", () => {
       });
 
       describe("#tokenOfOwnerByIndex", () => {
-        let signerOne: Signer;
-        let ownerConnected: ZapMedia;
-        let signerOneConnected: ZapMedia;
-        let mediaFactory: MediaFactory;
-        let customMediaAddress: string;
-
-        beforeEach(async () => {
-          // Set signerOne to equal signers[1]
-          signerOne = signers[1];
-
-          // owner (signers[0]) creates an instance of the main ZapMedia class
-          ownerConnected = new ZapMedia(1337, signer);
-
-          // signerOne (signers[1]) creates an instance of the main ZapMedia class
-          signerOneConnected = new ZapMedia(1337, signerOne);
-
-          // signerOne (signers[1]) creates an instance of the MediaFactory class
-          mediaFactory = new MediaFactory(1337, signerOne);
-
-          // signerOne (signers[1]) deploys their own media contract
-          const { args } = await mediaFactory.deployMedia(
-            "TEST COLLECTION 2",
-            "TC2",
-            true,
-            "www.example.com"
-          );
-
-          // The custom media address
-          customMediaAddress = args.mediaContract;
-
-          // The owner (signers[0]) mints on their own media contract
-          await ownerConnected.mint(mediaDataOne, bidShares);
-
-          // The signerOne (signers[1]) mints on the owners (signers[0]) media contract
-          await signerOneConnected.mint(mediaDataTwo, bidShares);
-
-          // The signerOne (signers[1]) mints on their own media contract by passing in the
-          // their media address as optional argument
-          await signerOneConnected.mint(
-            mediaDataOne,
-            bidShares,
-            customMediaAddress
-          );
-        });
-
         it("Should throw an error if the (owner) is a zero address", async () => {
           // fetchMediaOfOwnerByIndex will fail due to a zero address passed in as the owner
           await ownerConnected
@@ -536,56 +431,11 @@ describe("ZapMedia", () => {
     });
 
     describe("Write Functions", () => {
-      let tokenURI =
-        "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
-      let metadataURI =
-        "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
-      beforeEach(async () => {
-        let metadataHex = ethers.utils.formatBytes32String("Test");
-        let metadataHashRaw = ethers.utils.keccak256(metadataHex);
-        let metadataHashBytes = ethers.utils.arrayify(metadataHashRaw);
-
-        let contentHex = ethers.utils.formatBytes32String("Test Car");
-        let contentHashRaw = ethers.utils.keccak256(contentHex);
-        let contentHashBytes = ethers.utils.arrayify(contentHashRaw);
-
-        let contentHash = contentHashBytes;
-        let metadataHash = metadataHashBytes;
-
-        mediaDataOne = constructMediaData(
-          tokenURI,
-          metadataURI,
-          contentHash,
-          metadataHash
-        );
-
-        mediaDataTwo = constructMediaData(
-          tokenURI,
-          metadataURI,
-          contentHash,
-          metadataHash
-        );
-
-        bidShares = constructBidShares(
-          [
-            await signers[1].getAddress(),
-            await signers[2].getAddress(),
-            await signers[3].getAddress(),
-          ],
-          [15, 15, 15],
-          15,
-          35
-        );
-      });
-
       describe("#updateContentURI", () => {
         it("Should thrown an error if the tokenURI does not begin with `https://`", async () => {
-          //   Instantiates the ZapMedia class
-          const media = new ZapMedia(1337, signer);
-
           mediaDataOne.tokenURI = "http://example.com";
 
-          await media.mint(mediaDataOne, bidShares).catch((err) => {
+          await ownerConnected.mint(mediaDataOne, bidShares).catch((err) => {
             expect(err).to.equal(
               "Invariant failed: http://example.com must begin with `https://`"
             );
@@ -593,21 +443,17 @@ describe("ZapMedia", () => {
         });
 
         it("Should throw an error if the updateContentURI tokenId does not exist", async () => {
-          //   Instantiates the ZapMedia class
-          const media = new ZapMedia(1337, signer);
-
-          await media.updateContentURI(0, "www.newURI.com").catch((err) => {
-            expect(err.message).to.equal(
-              "Invariant failed: ZapMedia (updateContentURI): TokenId does not exist."
-            );
-          });
+          await ownerConnected
+            .updateContentURI(0, "www.newURI.com")
+            .catch((err) => {
+              expect(err.message).to.equal(
+                "Invariant failed: ZapMedia (updateContentURI): TokenId does not exist."
+              );
+            });
         });
 
         it("Should throw an error if the fetchContentURI tokenId does not exist", async () => {
-          //   Instantiates the ZapMedia class
-          const media = new ZapMedia(1337, signer);
-
-          await media.fetchContentURI(0).catch((err) => {
+          await ownerConnected.fetchContentURI(0).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
             );
@@ -615,23 +461,17 @@ describe("ZapMedia", () => {
         });
 
         it("Should update the content uri", async () => {
-          //   Instantiates the ZapMedia class
-          const media = new ZapMedia(1337, signer);
-
-          // Mints tokenId 0
-          await media.mint(mediaDataOne, bidShares);
-
           // Returns tokenId 0's tokenURI
-          const fetchTokenURI = await media.fetchContentURI(0);
+          const fetchTokenURI = await ownerConnected.fetchContentURI(0);
 
           // The returned tokenURI should equal the tokenURI configured in the mediaDataOne
           expect(fetchTokenURI).to.equal(mediaDataOne.tokenURI);
 
           // Updates tokenId 0's tokenURI
-          await media.updateContentURI(0, "https://newURI.com");
+          await ownerConnected.updateContentURI(0, "https://newURI.com");
 
           // Returns tokenId 0's tokenURI
-          const fetchNewURI = await media.fetchContentURI(0);
+          const fetchNewURI = await ownerConnected.fetchContentURI(0);
 
           // The new tokenURI returned should equal the updatedURI
           expect(fetchNewURI).to.equal("https://newURI.com");
@@ -640,12 +480,9 @@ describe("ZapMedia", () => {
 
       describe("#updateMetadataURI", () => {
         it("Should thrown an error if the metadataURI does not begin with `https://`", async () => {
-          //   Instantiates the ZapMedia class
-          const media = new ZapMedia(1337, signer);
-
           mediaDataOne.metadataURI = "http://example.com";
 
-          await media.mint(mediaDataOne, bidShares).catch((err) => {
+          await ownerConnected.mint(mediaDataOne, bidShares).catch((err) => {
             expect(err).to.equal(
               "Invariant failed: http://example.com must begin with `https://`"
             );
@@ -653,16 +490,15 @@ describe("ZapMedia", () => {
         });
 
         it("Should update the metadata uri", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          const fetchMetadataURI = await media.fetchMetadataURI(0);
+          const fetchMetadataURI = await ownerConnected.fetchMetadataURI(0);
           expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);
 
-          await media.updateMetadataURI(0, "https://newMetadataURI.com");
+          await ownerConnected.updateMetadataURI(
+            0,
+            "https://newMetadataURI.com"
+          );
 
-          const newMetadataURI = await media.fetchMetadataURI(0);
+          const newMetadataURI = await ownerConnected.fetchMetadataURI(0);
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });
       });
@@ -670,7 +506,6 @@ describe("ZapMedia", () => {
       describe("#mint", () => {
         it("throws an error if bid shares do not sum to 100", async () => {
           let bidShareSum = 0;
-          const media = new ZapMedia(1337, signer);
 
           bidShares.creator.value = bidShares.creator.value.add(BigInt(1e18));
 
@@ -683,7 +518,7 @@ describe("ZapMedia", () => {
             parseInt(bidShares.owner.value) +
             5e18;
 
-          await media.mint(mediaDataOne, bidShares).catch((err) => {
+          await ownerConnected.mint(mediaDataOne, bidShares).catch((err) => {
             expect(err).to.equal(
               `Invariant failed: The BidShares sum to ${bidShareSum}, but they must sum to 100000000000000000000`
             );
@@ -691,23 +526,21 @@ describe("ZapMedia", () => {
         });
 
         it("Should be able to mint", async () => {
-          const media = new ZapMedia(1337, signer);
+          const preTotalSupply = (
+            await ownerConnected.fetchTotalMedia()
+          ).toNumber();
 
-          const preTotalSupply = (await media.fetchTotalMedia()).toNumber();
+          expect(preTotalSupply).to.equal(2);
 
-          expect(preTotalSupply).to.equal(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
+          const creator = await ownerConnected.fetchCreator(0);
 
-          await media.mint(mediaDataOne, bidShares);
-
-          const owner = await media.fetchOwnerOf(0);
-          const creator = await media.fetchCreator(0);
-
-          const onChainBidShares = await media.fetchCurrentBidShares(
+          const onChainBidShares = await ownerConnected.fetchCurrentBidShares(
             zapMedia.address,
             0
           );
-          const onChainContentURI = await media.fetchContentURI(0);
-          const onChainMetadataURI = await media.fetchMetadataURI(0);
+          const onChainContentURI = await ownerConnected.fetchContentURI(0);
+          const onChainMetadataURI = await ownerConnected.fetchMetadataURI(0);
 
           expect(owner).to.equal(await signer.getAddress());
           expect(creator).to.equal(await signer.getAddress());
@@ -729,7 +562,6 @@ describe("ZapMedia", () => {
       describe("#mintWithSig", () => {
         it("throws an error if bid shares do not sum to 100", async () => {
           let bidShareSum = 0;
-          const media = new ZapMedia(1337, signer);
 
           bidShares.creator.value = bidShares.creator.value.add(BigInt(1e18));
 
@@ -746,7 +578,7 @@ describe("ZapMedia", () => {
             "0x7a8c4ab64eaec15cab192c8e3bae1414de871a34c470c1c05a0f3541770686d9"
           );
 
-          await media
+          await ownerConnected
             .mintWithSig(otherWallet.address, mediaDataOne, bidShares, eipSig)
             .catch((err) => {
               expect(err).to.eq(
@@ -760,7 +592,6 @@ describe("ZapMedia", () => {
             "0x7a8c4ab64eaec15cab192c8e3bae1414de871a34c470c1c05a0f3541770686d9"
           );
 
-          const media = new ZapMedia(1337, signer);
           let metadataHex = ethers.utils.formatBytes32String("Test");
           let metadataHashRaw = ethers.utils.keccak256(metadataHex);
           let metadataHashBytes = ethers.utils.arrayify(metadataHashRaw);
@@ -776,7 +607,7 @@ describe("ZapMedia", () => {
             metadataHash: metadataHashBytes,
           };
 
-          await media
+          await ownerConnected
             .mintWithSig(
               otherWallet.address,
               invalidMediaData,
@@ -794,7 +625,7 @@ describe("ZapMedia", () => {
           const otherWallet: Wallet = new ethers.Wallet(
             "0x7a8c4ab64eaec15cab192c8e3bae1414de871a34c470c1c05a0f3541770686d9"
           );
-          const media = new ZapMedia(1337, signer);
+
           const invalidMediaData = {
             tokenURI: "https://example.com",
             metadataURI: "http://metadata.com",
@@ -802,7 +633,7 @@ describe("ZapMedia", () => {
             metadataHash: mediaDataOne.metadataHash,
           };
 
-          await media
+          await ownerConnected
             .mintWithSig(
               otherWallet.address,
               invalidMediaData,
@@ -816,15 +647,17 @@ describe("ZapMedia", () => {
             });
         });
 
-        it("creates a new piece of media", async () => {
+        // Using metadata that is already minted
+        it.skip("creates a new piece of media", async () => {
           const mainWallet: Wallet = new ethers.Wallet(
             "0xb91c5477014656c1da52b3d4b6c03b59019c9a3b5730e61391cec269bc2e03e3"
           );
-          const media = new ZapMedia(1337, signer);
           const deadline =
             Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24; // 24 hours
-          const domain = media.eip712Domain();
-          const nonce = await media.fetchMintWithSigNonce(mainWallet.address);
+          const domain = ownerConnected.eip712Domain();
+          const nonce = await ownerConnected.fetchMintWithSigNonce(
+            mainWallet.address
+          );
           const media1ContentHash = ethers.utils.hexlify(
             mediaDataOne.contentHash
           );
@@ -841,20 +674,20 @@ describe("ZapMedia", () => {
             domain
           );
 
-          const totalSupply = await media.fetchTotalMedia();
-          expect(totalSupply.toNumber()).to.eq(0);
+          const totalSupply = await ownerConnected.fetchTotalMedia();
+          expect(totalSupply.toNumber()).to.eq(2);
 
-          await media.mintWithSig(
+          await ownerConnected.mintWithSig(
             mainWallet.address,
             mediaDataOne,
             bidShares,
             eipSig
           );
 
-          const owner = await media.fetchOwnerOf(0);
-          const creator = await media.fetchCreator(0);
-          const onChainContentHash = await media.fetchContentHash(0);
-          const onChainMetadataHash = await media.fetchMetadataHash(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
+          const creator = await ownerConnected.fetchCreator(0);
+          const onChainContentHash = await ownerConnected.fetchContentHash(0);
+          const onChainMetadataHash = await ownerConnected.fetchMetadataHash(0);
           const mediaContentHash = ethers.utils.hexlify(
             mediaDataOne.contentHash
           );
@@ -862,12 +695,12 @@ describe("ZapMedia", () => {
             mediaDataOne.metadataHash
           );
 
-          const onChainBidShares = await media.fetchCurrentBidShares(
+          const onChainBidShares = await ownerConnected.fetchCurrentBidShares(
             zapMedia.address,
             0
           );
-          const onChainContentURI = await media.fetchContentURI(0);
-          const onChainMetadataURI = await media.fetchMetadataURI(0);
+          const onChainContentURI = await ownerConnected.fetchContentURI(0);
+          const onChainMetadataURI = await ownerConnected.fetchMetadataURI(0);
 
           expect(owner.toLowerCase()).to.eq(mainWallet.address.toLowerCase());
           expect(creator.toLowerCase()).to.eq(mainWallet.address.toLowerCase());
@@ -887,9 +720,7 @@ describe("ZapMedia", () => {
 
       describe("#getTokenCreators", () => {
         it("Should throw an error if the tokenId does not exist", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.fetchCreator(0).catch((err) => {
+          await ownerConnected.fetchCreator(0).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (fetchCreator): TokenId does not exist."
             );
@@ -897,11 +728,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should return the token creator", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          const creator = await media.fetchCreator(0);
+          const creator = await ownerConnected.fetchCreator(0);
 
           expect(creator).to.equal(await signer.getAddress());
         });
@@ -911,21 +738,15 @@ describe("ZapMedia", () => {
         it("Should throw an error if the signer is not approved nor the owner", async () => {
           ask = constructAsk(zapMedia.address, 100);
 
-          const signer1 = signers[1];
-          const media = new ZapMedia(1337, signer);
-          const media1 = new ZapMedia(1337, signer1);
+          const owner = await ownerConnected.fetchOwnerOf(0);
+          const getApproved = await ownerConnected.fetchApproved(0);
 
-          await media.mint(mediaDataOne, bidShares);
-
-          const owner = await media.fetchOwnerOf(0);
-          const getApproved = await media.fetchApproved(0);
-
-          expect(owner).to.not.equal(await signer1.getAddress());
+          expect(owner).to.not.equal(await signerOne.getAddress());
           expect(owner).to.equal(await signer.getAddress());
-          expect(getApproved).to.not.equal(await signer1.getAddress());
+          expect(getApproved).to.not.equal(await signerOne.getAddress());
           expect(getApproved).to.equal(ethers.constants.AddressZero);
 
-          await media1.setAsk(0, ask).catch((err) => {
+          await signerOneConnected.setAsk(0, ask).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (setAsk): Media: Only approved or owner."
             );
@@ -934,19 +755,19 @@ describe("ZapMedia", () => {
 
         it("Should set an ask by the owner", async () => {
           ask = constructAsk(zapMedia.address, 100);
-          const media = new ZapMedia(1337, signer);
 
-          await media.mint(mediaDataOne, bidShares);
-
-          const owner = await media.fetchOwnerOf(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
-          const getApproved = await media.fetchApproved(0);
+          const getApproved = await ownerConnected.fetchApproved(0);
           expect(getApproved).to.equal(ethers.constants.AddressZero);
 
-          await media.setAsk(0, ask);
+          await ownerConnected.setAsk(0, ask);
 
-          const onChainAsk = await media.fetchCurrentAsk(zapMedia.address, 0);
+          const onChainAsk = await ownerConnected.fetchCurrentAsk(
+            zapMedia.address,
+            0
+          );
 
           expect(parseInt(onChainAsk.amount.toString())).to.equal(ask.amount);
           expect(onChainAsk.currency).to.equal(zapMedia.address);
@@ -955,23 +776,20 @@ describe("ZapMedia", () => {
         it("Should set an ask by the approved", async () => {
           ask = constructAsk(zapMedia.address, 100);
 
-          const signer1 = signers[1];
-          const media = new ZapMedia(1337, signer);
-          const media1 = new ZapMedia(1337, signer1);
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
 
-          await media.mint(mediaDataOne, bidShares);
-
-          await media.approve(await signer1.getAddress(), 0);
-
-          const owner = await media.fetchOwnerOf(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
-          const getApproved = await media.fetchApproved(0);
-          expect(getApproved).to.equal(await signer1.getAddress());
+          const getApproved = await ownerConnected.fetchApproved(0);
+          expect(getApproved).to.equal(await signerOne.getAddress());
 
-          await media1.setAsk(0, ask);
+          await signerOneConnected.setAsk(0, ask);
 
-          const onChainAsk = await media.fetchCurrentAsk(zapMedia.address, 0);
+          const onChainAsk = await ownerConnected.fetchCurrentAsk(
+            zapMedia.address,
+            0
+          );
 
           expect(parseInt(onChainAsk.amount.toString())).to.equal(ask.amount);
           expect(onChainAsk.currency).to.equal(zapMedia.address);
@@ -981,11 +799,10 @@ describe("ZapMedia", () => {
       describe("#setbid", () => {
         let bidder: Signer;
         let bid: Bid;
-        let ownerConnected: ZapMedia;
         let bidderConnected: ZapMedia;
 
         beforeEach(async () => {
-          bidder = signers[1];
+          bidder = signers[2];
           bid = constructBid(
             token.address,
             200,
@@ -994,14 +811,8 @@ describe("ZapMedia", () => {
             10
           );
 
-          // The owner(signer[0]) is connected to the ZapMedia class as a signer
-          ownerConnected = new ZapMedia(1337, signer);
-
-          // The bidder(signer[1]) is connected to the ZapMedia class as a signer
+          // The bidder(signer[2]) is connected to the ZapMedia class as a signer
           bidderConnected = new ZapMedia(1337, bidder);
-
-          // Mint a token
-          await ownerConnected.mint(mediaDataOne, bidShares);
 
           // Transfer tokens to the bidder
           await token.mint(await bidder.getAddress(), 1000);
@@ -1224,17 +1035,9 @@ describe("ZapMedia", () => {
       });
 
       describe("#removeAsk", () => {
-        let media: ZapMedia;
-
-        beforeEach(async () => {
-          media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-        });
-
         it("Should throw an error if the removeAsk tokenId does not exist", async () => {
           ask = constructAsk(zapMedia.address, 100);
-          await media.removeAsk(1).catch((err) => {
+          await ownerConnected.removeAsk(400).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (removeAsk): TokenId does not exist."
             );
@@ -1242,7 +1045,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should throw an error if the tokenId exists but an ask was not set", async () => {
-          await media.removeAsk(0).catch((err) => {
+          await ownerConnected.removeAsk(0).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (removeAsk): Ask was never set."
             );
@@ -1252,22 +1055,25 @@ describe("ZapMedia", () => {
         it("Should remove an ask", async () => {
           ask = constructAsk(zapMedia.address, 100);
 
-          const owner = await media.fetchOwnerOf(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
-          const getApproved = await media.fetchApproved(0);
+          const getApproved = await ownerConnected.fetchApproved(0);
           expect(getApproved).to.equal(ethers.constants.AddressZero);
 
-          await media.setAsk(0, ask);
+          await ownerConnected.setAsk(0, ask);
 
-          const onChainAsk = await media.fetchCurrentAsk(zapMedia.address, 0);
+          const onChainAsk = await ownerConnected.fetchCurrentAsk(
+            zapMedia.address,
+            0
+          );
 
           expect(parseInt(onChainAsk.amount.toString())).to.equal(ask.amount);
           expect(onChainAsk.currency).to.equal(zapMedia.address);
 
-          await media.removeAsk(0);
+          await ownerConnected.removeAsk(0);
 
-          const onChainAskRemoved = await media.fetchCurrentAsk(
+          const onChainAskRemoved = await ownerConnected.fetchCurrentAsk(
             zapMedia.address,
             0
           );
@@ -1281,90 +1087,74 @@ describe("ZapMedia", () => {
 
       describe("#revokeApproval", () => {
         it("revokes an addresses approval of another address's media", async () => {
-          const signer1 = signers[1];
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
 
-          // expect(nullApproved).toBe(AddressZero)
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
+          const approved = await ownerConnected.fetchApproved(0);
+          expect(approved).to.equal(await signerOne.getAddress());
 
-          await media.approve(await signer1.getAddress(), 0);
+          await signerOneConnected.revokeApproval(0);
 
-          const approved = await media.fetchApproved(0);
-          expect(approved).to.equal(await signer1.getAddress());
-
-          const media1 = new ZapMedia(1337, signer1);
-
-          await media1.revokeApproval(0);
-
-          const revokedStatus = await media.fetchApproved(0);
+          const revokedStatus = await ownerConnected.fetchApproved(0);
           expect(revokedStatus).to.equal(ethers.constants.AddressZero);
         });
       });
 
       describe("#burn", () => {
         it("Should burn a token", async () => {
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
-          const owner = await media.fetchOwnerOf(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
-          const preTotalSupply = await media.fetchTotalMedia();
-          expect(preTotalSupply.toNumber()).to.equal(1);
+          const preTotalSupply = await ownerConnected.fetchTotalMedia();
+          expect(preTotalSupply.toNumber()).to.equal(2);
 
-          await media.burn(0);
+          await ownerConnected.burn(0);
 
-          const postTotalSupply = await media.fetchTotalMedia();
-          expect(postTotalSupply.toNumber()).to.equal(0);
+          const postTotalSupply = await ownerConnected.fetchTotalMedia();
+          expect(postTotalSupply.toNumber()).to.equal(1);
         });
       });
 
       describe("#approve", () => {
         it("Should approve another address for a token", async () => {
-          const signer1 = signers[1];
-
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          const preApprovedStatus = await media.fetchApproved(0);
+          const preApprovedStatus = await ownerConnected.fetchApproved(0);
           expect(preApprovedStatus).to.equal(ethers.constants.AddressZero);
 
-          await media.approve(await signer1.getAddress(), 0);
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
 
-          const postApprovedStatus = await media.fetchApproved(0);
-          expect(postApprovedStatus).to.equal(await signer1.getAddress());
+          const postApprovedStatus = await ownerConnected.fetchApproved(0);
+          expect(postApprovedStatus).to.equal(await signerOne.getAddress());
         });
       });
 
       describe("#setApprovalForAll", () => {
         it("Should set approval for another address for all tokens owned by owner", async () => {
-          const signer1 = signers[1];
-
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          const preApprovalStatus = await media.fetchIsApprovedForAll(
+          const preApprovalStatus = await ownerConnected.fetchIsApprovedForAll(
             await signer.getAddress(),
-            await signer1.getAddress()
+            await signerOne.getAddress()
           );
 
           expect(preApprovalStatus).to.be.false;
 
-          await media.setApprovalForAll(await signer1.getAddress(), true);
+          await ownerConnected.setApprovalForAll(
+            await signerOne.getAddress(),
+            true
+          );
 
-          const postApprovalStatus = await media.fetchIsApprovedForAll(
+          const postApprovalStatus = await ownerConnected.fetchIsApprovedForAll(
             await signer.getAddress(),
-            await signer1.getAddress()
+            await signerOne.getAddress()
           );
 
           expect(postApprovalStatus).to.be.true;
 
-          await media.setApprovalForAll(await signer1.getAddress(), false);
+          await ownerConnected.setApprovalForAll(
+            await signerOne.getAddress(),
+            false
+          );
 
-          const revoked = await media.fetchIsApprovedForAll(
+          const revoked = await ownerConnected.fetchIsApprovedForAll(
             await signer.getAddress(),
-            await signer1.getAddress()
+            await signerOne.getAddress()
           );
 
           expect(revoked).to.be.false;
@@ -1373,17 +1163,15 @@ describe("ZapMedia", () => {
 
       describe("#transferFrom", () => {
         it("Should transfer token to another address", async () => {
-          const recipient = await signers[1].getAddress();
-          const media = new ZapMedia(1337, signer);
-          await media.mint(mediaDataOne, bidShares);
+          const recipient = await signerOne.getAddress();
 
-          const owner = await media.fetchOwnerOf(0);
+          const owner = await ownerConnected.fetchOwnerOf(0);
 
           expect(owner).to.equal(await signer.getAddress());
 
-          await media.transferFrom(owner, recipient, 0);
+          await ownerConnected.transferFrom(owner, recipient, 0);
 
-          const newOwner = await media.fetchOwnerOf(0);
+          const newOwner = await ownerConnected.fetchOwnerOf(0);
 
           expect(newOwner).to.equal(recipient);
         });
@@ -1391,11 +1179,9 @@ describe("ZapMedia", () => {
 
       describe("#safeTransferFrom", () => {
         it("Should revert if the tokenId does not exist", async () => {
-          const recipient = await signers[1].getAddress();
+          const recipient = await signerOne.getAddress();
 
-          const media = new ZapMedia(1337, signer);
-
-          await media
+          await ownerConnected
             .safeTransferFrom(await signer.getAddress(), recipient, 0)
             .catch((err) => {
               expect(err.message).to.equal(
@@ -1405,13 +1191,9 @@ describe("ZapMedia", () => {
         });
 
         it("Should revert if the (from) is a zero address", async () => {
-          const recipient = await signers[1].getAddress();
+          const recipient = await signerOne.getAddress();
 
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          await media
+          await ownerConnected
             .safeTransferFrom(ethers.constants.AddressZero, recipient, 0)
             .catch((err) => {
               expect(err.message).to.equal(
@@ -1421,11 +1203,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should revert if the (to) is a zero address", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          await media
+          await ownerConnected
             .safeTransferFrom(
               await signer.getAddress(),
               ethers.constants.AddressZero,
@@ -1439,29 +1217,20 @@ describe("ZapMedia", () => {
         });
 
         it("Should safe transfer a token to an address", async () => {
-          const recipient = await signers[1].getAddress();
+          const recipient = await signerOne.getAddress();
 
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          await media.safeTransferFrom(await signer.getAddress(), recipient, 0);
+          await ownerConnected.safeTransferFrom(
+            await signer.getAddress(),
+            recipient,
+            0
+          );
         });
       });
 
-      describe("#isValidBid", () => {
-        it("Should return true if the bid amount can be evenly split by current bidShares", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-        });
-      });
+      describe("#isValidBid", () => {});
 
       describe("#permit", () => {
         it("should allow a wallet to set themselves to approved with a valid signature", async () => {
-          const zap_media = new ZapMedia(1337, signer);
-          await zap_media.mint(mediaDataOne, bidShares);
-
           // created wallets using privateKey because we need a wallet instance when creating a signature
           const mainWallet: Wallet = new ethers.Wallet(
             "0x89e2d8a81beffed50f4d29f642127f18b5c8c1212c54b18ef66a784d0a172819"
@@ -1472,10 +1241,10 @@ describe("ZapMedia", () => {
 
           const deadline =
             Math.floor(new Date().getTime() / 1000) + 60 * 60 * 24; // 24 hours
-          const domain = zap_media.eip712Domain();
+          const domain = ownerConnected.eip712Domain();
 
           const nonce = await (
-            await zap_media.fetchPermitNonce(mainWallet.address, 0)
+            await ownerConnected.fetchPermitNonce(mainWallet.address, 0)
           ).toNumber();
 
           const eipSig = await signPermitMessage(
@@ -1487,15 +1256,15 @@ describe("ZapMedia", () => {
             domain
           );
 
-          await zap_media.permit(otherWallet.address, 0, eipSig);
-          const approved = await zap_media.fetchApproved(0);
+          await ownerConnected.permit(otherWallet.address, 0, eipSig);
+          const approved = await ownerConnected.fetchApproved(0);
 
           expect(approved.toLowerCase()).to.equal(
             otherWallet.address.toLowerCase()
           );
 
           // test to see if approved for another token. should fail.
-          await zap_media.fetchApproved(1).catch((err) => {
+          await ownerConnected.fetchApproved(1).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (fetchApproved): TokenId does not exist."
             );
@@ -1505,21 +1274,13 @@ describe("ZapMedia", () => {
 
       describe("#fetchMedia", () => {
         it("Should get media instance by index in the media contract", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          const tokenId = await media.fetchMediaByIndex(0);
+          const tokenId = await ownerConnected.fetchMediaByIndex(0);
 
           expect(parseInt(tokenId._hex)).to.equal(0);
         });
 
         it("Should throw an error index out of range", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          await media.fetchMediaByIndex(1).catch((err) => {
+          await ownerConnected.fetchMediaByIndex(1).catch((err) => {
             expect(err.message).to.equal(
               "Invariant failed: ZapMedia (tokenByIndex): Index out of range."
             );
@@ -1529,11 +1290,7 @@ describe("ZapMedia", () => {
 
       describe("#fetchSignature", () => {
         it("Should fetch the signature of the newly minted nonce", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          const sigNonce = await media.fetchMintWithSigNonce(
+          const sigNonce = await ownerConnected.fetchMintWithSigNonce(
             await signer.getAddress()
           );
 
@@ -1541,11 +1298,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should Revert if address does not exist", async () => {
-          const media = new ZapMedia(1337, signer);
-
-          await media.mint(mediaDataOne, bidShares);
-
-          await media
+          await ownerConnected
             .fetchMintWithSigNonce("0x9b713D5416884d12a5BbF13Ee08B6038E74CDe")
             .catch((err) => {
               expect(err).to.equal(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1115,8 +1115,9 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#approve", () => {
+      describe("#approve", () => {
         it("Should reject if the token id does not exist", async () => {
+          // Will throw an error due to the token id not existing
           await ownerConnected
             .approve(await signerOne.getAddress(), 400)
             .should.be.rejectedWith(
@@ -1125,6 +1126,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should reject if the token id does not exist on a custom media", async () => {
+          // Will throw an error due to the token id not existing on the custom media
           await signerOneConnected
             .approve(await signer.getAddress(), 400, customMediaAddress)
             .should.be.rejectedWith(
@@ -1133,6 +1135,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should reject if the caller is not the owner nor approved for all", async () => {
+          // Will throw an error if the caller is not approved or the owner
           await signerOneConnected
             .approve(await signerOne.getAddress(), 0)
             .should.be.rejectedWith(
@@ -1141,6 +1144,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should reject if the caller is not the owner nor approved for all on a custom media", async () => {
+          // Will throw an error if the caller is not approved or the owner on a custom media
           await ownerConnected
             .approve(await signers[2].getAddress(), 0, customMediaAddress)
             .should.be.rejectedWith(
@@ -1149,32 +1153,45 @@ describe("ZapMedia", () => {
         });
 
         it("Should approve another address for a token", async () => {
-          const preApprovedStatus = await ownerConnected.fetchApproved(0);
-          expect(preApprovedStatus).to.equal(ethers.constants.AddressZero);
+          // Return the address approved for token id 0 before approval
+          const preApprovedAddr = await ownerConnected.fetchApproved(0);
 
+          // Expect the address to equal a zero address
+          expect(preApprovedAddr).to.equal(ethers.constants.AddressZero);
+
+          // The owner (signers[0]) approves signerOne for token id 0
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 
+          // Returns the address approved for token id  0 after approval
           const postApprovedStatus = await ownerConnected.fetchApproved(0);
+
+          // Expect the address to equal the address of signerOne
           expect(postApprovedStatus).to.equal(await signerOne.getAddress());
         });
 
-        it.only("Should approve another address for a token on a custom media", async () => {
+        it("Should approve another address for a token on a custom media", async () => {
+          // Returns the approved address on a custom media before the approval
           const preApprovedAddr = await signerOneConnected.fetchApproved(
             0,
             customMediaAddress
           );
+          // Expect the address to equal a zero address
           expect(preApprovedAddr).to.equal(ethers.constants.AddressZero);
 
+          // signerOne (signers[1]) approves signers[0] for token id 0 on a custom media
           await signerOneConnected.approve(
             await signer.getAddress(),
             0,
             customMediaAddress
           );
 
+          // Returns the approved address after the approval
           const postApprovedAddr = await signerOneConnected.fetchApproved(
             0,
             customMediaAddress
           );
+
+          // Expect the address to equal the address of signer (signers[0])
           expect(postApprovedAddr).to.equal(await signer.getAddress());
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1241,6 +1241,43 @@ describe("ZapMedia", () => {
         });
       });
 
+      describe("#fetchApproved", () => {
+        it("Should reject if the token id does not exist", async () => {
+          await ownerConnected
+            .fetchApproved(200)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchApproved): TokenId does not exist."
+            );
+        });
+
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await ownerConnected
+            .fetchApproved(200, customMediaAddress)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchApproved): TokenId does not exist."
+            );
+        });
+
+        it("Should fetch the approved address", async () => {
+          // Returns the address approved on the main media
+          const approvedAddr: string = await ownerConnected.fetchApproved(0);
+
+          // Expect the address to equal a zero address
+          expect(approvedAddr).to.equal(ethers.constants.AddressZero);
+        });
+
+        it("Should fetch the approved address on a custom media", async () => {
+          // Returns the address approved on the custom media
+          const approvedAddr: string = await ownerConnected.fetchApproved(
+            0,
+            customMediaAddress
+          );
+
+          // Expect the address to equal a zero address
+          expect(approvedAddr).to.equal(ethers.constants.AddressZero);
+        });
+      });
+
       describe("#setApprovalForAll", () => {
         it("Should set approval for another address for all tokens owned by owner", async () => {
           const preApprovalStatus = await ownerConnected.fetchIsApprovedForAll(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1124,9 +1124,25 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await signerOneConnected
+            .approve(await signer.getAddress(), 400, customMediaAddress)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (approve): TokenId does not exist."
+            );
+        });
+
         it("Should reject if the caller is not the owner nor approved for all", async () => {
           await signerOneConnected
             .approve(await signerOne.getAddress(), 0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (approve): Caller is not the owner nor approved for all."
+            );
+        });
+
+        it("Should reject if the caller is not the owner nor approved for all on a custom media", async () => {
+          await ownerConnected
+            .approve(await signers[2].getAddress(), 0, customMediaAddress)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (approve): Caller is not the owner nor approved for all."
             );
@@ -1140,6 +1156,14 @@ describe("ZapMedia", () => {
 
           const postApprovedStatus = await ownerConnected.fetchApproved(0);
           expect(postApprovedStatus).to.equal(await signerOne.getAddress());
+        });
+
+        it.only("Should approve another address for a token on a custom media", async () => {
+          await signerOneConnected.approve(
+            await signer.getAddress(),
+            0,
+            customMediaAddress
+          );
         });
 
         it("Should approve another address for a token by a caller who is approved for all", async () => {


### PR DESCRIPTION
## Description
Closes #374 #375 

## Implementation
 - [x] Added the optional ```customMediaAddress``` argument to the ```fetchApproved``` & ```approved``` functions
 - [x]  Added an if/else statement to check whether the ```customMediaAddress``` is undefined or not for the ```fetchApproved``` & ```approved``` functions
 - [x] If ```customMediaAddress``` is not undefined attach the value to the main media contract to create a custom media contract instance and invoke the ```fetchApproved``` & ```approve``` functions on those contracts
 - [x] If ```customMediaAddress``` is undefined invoke the ```fetchApproved``` & ```approve``` functions on the main media contract
 - [x] Added passing tests for the ```fetchApproved``` & ```approved``` functions

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

<img width="844" alt="Screen Shot 2022-02-01 at 11 33 09 AM" src="https://user-images.githubusercontent.com/42893948/152009798-59de94f4-ff57-407e-80f4-f66ddcfcd119.png">
 