### PR TITLE
FetchTotalMedia Custom Media Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -258,7 +258,12 @@ class ZapMedia {
   /**
    * Fetches the total amount of non-burned media that has been minted on an instance of the Zap Media Contract
    */
-  public async fetchTotalMedia(): Promise<BigNumber> {
+  public async fetchTotalMedia(
+    customMediaAddress?: string
+  ): Promise<BigNumber> {
+    if (customMediaAddress !== undefined) {
+      return this.media.attach(customMediaAddress).totalSupply();
+    }
     return this.media.totalSupply();
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -147,8 +147,12 @@ class ZapMedia {
   /**
    * Fetches the content uri for the specified media on an instance of the Zap Media Contract
    * @param mediaId
+   * @param customMediaAddress
    */
-  public async fetchContentURI(mediaId: BigNumberish): Promise<string> {
+  public async fetchContentURI(
+    mediaId: BigNumberish,
+    customMediaAddress?: string
+  ): Promise<string> {
     try {
       return await this.media.tokenURI(mediaId);
     } catch {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -149,10 +149,7 @@ class ZapMedia {
    * @param mediaId
    * @param customMediaAddress
    */
-  public async fetchContentURI(
-    mediaId: BigNumberish,
-    customMediaAddress?: string
-  ): Promise<string> {
+  public async fetchContentURI(mediaId: BigNumberish): Promise<string> {
     try {
       return await this.media.tokenURI(mediaId);
     } catch {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -153,14 +153,6 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
-    if (customMediaAddress !== undefined) {
-      try {
-        return await this.media.attach(customMediaAddress).tokenURI(mediaId);
-      } catch {
-        invariant(false, "ZapMedia (fetchContentURI): TokenId does not exist.");
-      }
-    }
-
     try {
       return await this.media.tokenURI(mediaId);
     } catch {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -153,6 +153,14 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
+    if (customMediaAddress !== undefined) {
+      try {
+        return await this.media.attach(customMediaAddress).tokenURI(mediaId);
+      } catch {
+        invariant(false, "ZapMedia (fetchContentURI): TokenId does not exist.");
+      }
+    }
+
     try {
       return await this.media.tokenURI(mediaId);
     } catch {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -430,18 +430,22 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchTotalMedia", () => {
+      describe("#fetchTotalMedia", () => {
         it("Should fetch the total media minted", async () => {
+          // Returns the total amount tokens minted on the main media
           const totalSupply: BigNumberish =
             await signerOneConnected.fetchTotalMedia();
 
+          // Expect the totalSupply to equal 2
           expect(parseInt(totalSupply._hex)).to.equal(2);
         });
 
-        it("Should fetch the total media minted on custom media", async () => {
+        it("Should fetch the total media minted on a custom media", async () => {
+          // Returns the total amount tokens minted on the custom media
           const totalSupply: BigNumberish =
             await ownerConnected.fetchTotalMedia(customMediaAddress);
 
+          // Expect the totalSupply to equal 1
           expect(parseInt(totalSupply._hex)).to.equal(1);
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -429,6 +429,8 @@ describe("ZapMedia", () => {
           expect(parseInt(fetchToken._hex)).to.equal(0);
         });
       });
+
+      describe("#fetchTotalMedia", () => {});
     });
 
     describe("Write Functions", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -437,6 +437,13 @@ describe("ZapMedia", () => {
 
           expect(parseInt(totalSupply._hex)).to.equal(2);
         });
+
+        it("Should fetch the total media minted on custom media", async () => {
+          const totalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia(customMediaAddress);
+
+          expect(parseInt(totalSupply._hex)).to.equal(1);
+        });
       });
     });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2,7 +2,7 @@ import chai, { expect } from "chai";
 
 import chaiAsPromised from "chai-as-promised";
 
-import { ethers, Wallet, Signer, Contract } from "ethers";
+import { ethers, Wallet, Signer, Contract, BigNumberish } from "ethers";
 
 import { formatUnits } from "ethers/lib/utils";
 
@@ -430,7 +430,14 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchTotalMedia", () => {});
+      describe.only("#fetchTotalMedia", () => {
+        it("Should fetch the total media minted", async () => {
+          const totalSupply: BigNumberish =
+            await signerOneConnected.fetchTotalMedia();
+
+          expect(parseInt(totalSupply._hex)).to.equal(2);
+        });
+      });
     });
 
     describe("Write Functions", () => {


### PR DESCRIPTION
## Summary
Closes #373 

## Implementation
 - [x]  Added the optional ```customMediaAddress``` argument to the ```fetchTotalMedia``` function
 - [x] Added an if/else statement to check whether the ```customMediaAddress``` is undefined or not
 - [x]  If ```customMediaAddress``` is not undefined attach the value to the main media contract to create a custom media contract instance and invoke the ```fetchTotalMedia``` on that contract
 - [x] If ```customMediaAddress``` is undefined invoke the ```fetchTotalMedia``` function on the main media contract
 - [x] Added passing tests for the ```fetchTotalMedia``` function

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

The ```fetchTotalMedia``` tests are passing

<img width="626" alt="Screen Shot 2022-02-01 at 2 38 52 PM" src="https://user-images.githubusercontent.com/42893948/152038978-a5a36d62-e2cc-4423-b739-4d205df0fc0c.png">


All tests are passing

<img width="865" alt="Screen Shot 2022-02-01 at 2 38 14 PM" src="https://user-images.githubusercontent.com/42893948/152038884-53523024-e67c-49e5-9c6e-d352068863f5.png">

