### PR TITLE
FetchCurrentBidForBidder Custom Media Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -239,6 +239,13 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
+    if (mediaContractAddress == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
+      );
+    }
+
     try {
       await this.media.attach(mediaContractAddress).ownerOf(mediaId);
     } catch {
@@ -248,12 +255,7 @@ class ZapMedia {
       );
     }
 
-    if (mediaContractAddress == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
-      );
-    } else if (bidder == ethers.constants.AddressZero) {
+    if (bidder == ethers.constants.AddressZero) {
       invariant(
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -239,14 +239,14 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
-    await this.fetchOwnerOf(mediaId);
+    await this.media.ownerOf(mediaId);
 
-    if (mediaContractAddress === ethers.constants.AddressZero) {
+    if (mediaContractAddress == ethers.constants.AddressZero) {
       invariant(
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
       );
-    } else if (bidder === ethers.constants.AddressZero) {
+    } else if (bidder == ethers.constants.AddressZero) {
       invariant(
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -230,15 +230,16 @@ class ZapMedia {
 
   /**
    * Fetches the current bid for the specified bidder for the specified media on an instance of the Zap Media Contract
-   * @param mediaContractAddress
-   * @param mediaId
-   * @param bidder
+   * @param mediaContractAddress Designates which media contract to connect to.
+   * @param mediaId Numerical identifier for a minted token
+   * @param bidder The public address that set the bid
    */
   public async fetchCurrentBidForBidder(
     mediaContractAddress: string,
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
+    // Checks if the mediaContractAddress is a zero address
     if (mediaContractAddress == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -246,6 +247,7 @@ class ZapMedia {
       );
     }
 
+    // Checks if the tokenId exists
     try {
       await this.media.attach(mediaContractAddress).ownerOf(mediaId);
     } catch {
@@ -255,12 +257,15 @@ class ZapMedia {
       );
     }
 
+    // Checks if the bidder address is a zero address
     if (bidder == ethers.constants.AddressZero) {
       invariant(
         false,
         "ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
       );
     }
+
+    // Invokes the bidForTokenBidder function on the ZapMarket contract and returns the bidders bid details
     return this.market.bidForTokenBidder(mediaContractAddress, mediaId, bidder);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -239,7 +239,14 @@ class ZapMedia {
     mediaId: BigNumberish,
     bidder: string
   ): Promise<Bid> {
-    await this.media.ownerOf(mediaId);
+    try {
+      await this.media.attach(mediaContractAddress).ownerOf(mediaId);
+    } catch {
+      invariant(
+        false,
+        "ZapMedia (fetchCurrentBidForBidder): The token id does not exist."
+      );
+    }
 
     if (mediaContractAddress == ethers.constants.AddressZero) {
       invariant(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1042,11 +1042,9 @@ describe("ZapMedia", () => {
                 0,
                 ethers.constants.AddressZero
               )
-              .catch((err) => {
-                expect(err.message).to.equal(
-                  "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
-                );
-              });
+              .should.be.rejectedWith(
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
+              );
           });
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1017,11 +1017,9 @@ describe("ZapMedia", () => {
                 0,
                 await bidder.getAddress()
               )
-              .catch((err) => {
-                expect(err.message).to.equal(
-                  "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
-                );
-              });
+              .should.be.rejectedWith(
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (media contract) address cannot be a zero address."
+              );
           });
 
           it("Should reject if the token id does not exist", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1009,7 +1009,7 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
-        describe("#bidForTokenBidder", () => {
+        describe.only("#bidForTokenBidder", () => {
           it("Should reject if the media contract is a zero address", async () => {
             await ownerConnected
               .fetchCurrentBidForBidder(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1029,11 +1029,9 @@ describe("ZapMedia", () => {
                 10,
                 await bidder.getAddress()
               )
-              .catch((err) => {
-                expect(err.message).to.equal(
-                  "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
-                );
-              });
+              .should.be.rejectedWith(
+                "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
+              );
           });
 
           it("Should reject if the bidder is a zero address", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1009,7 +1009,7 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
-        describe("#bidForTokenBidder", () => {
+        describe("#fetchCurrentBidForBidder", () => {
           it("Should reject if the media contract is a zero address", async () => {
             await ownerConnected
               .fetchCurrentBidForBidder(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1030,7 +1030,7 @@ describe("ZapMedia", () => {
                 await bidder.getAddress()
               )
               .should.be.rejectedWith(
-                "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The token id does not exist."
               );
           });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1009,7 +1009,7 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
-        describe.only("#bidForTokenBidder", () => {
+        describe("#bidForTokenBidder", () => {
           it("Should reject if the media contract is a zero address", async () => {
             await ownerConnected
               .fetchCurrentBidForBidder(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1035,7 +1035,6 @@ describe("ZapMedia", () => {
           });
 
           it("Should reject if the bidder is a zero address on the main media", async () => {
-            // Add an assertion by expecting the function to throw the invariant with a bidder as the zero address
             await ownerConnected
               .fetchCurrentBidForBidder(
                 zapMedia.address,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1022,7 +1022,7 @@ describe("ZapMedia", () => {
               );
           });
 
-          it("Should reject if the token id does not exist", async () => {
+          it("Should reject if the token id does not exist on the main media", async () => {
             await ownerConnected
               .fetchCurrentBidForBidder(
                 zapMedia.address,
@@ -1034,7 +1034,7 @@ describe("ZapMedia", () => {
               );
           });
 
-          it("Should reject if the bidder is a zero address", async () => {
+          it("Should reject if the bidder is a zero address on the main media", async () => {
             // Add an assertion by expecting the function to throw the invariant with a bidder as the zero address
             await ownerConnected
               .fetchCurrentBidForBidder(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1046,6 +1046,30 @@ describe("ZapMedia", () => {
                 "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
               );
           });
+
+          it("Should reject if the token id does not exist on a custom media", async () => {
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                customMediaAddress,
+                10,
+                await bidder.getAddress()
+              )
+              .should.be.rejectedWith(
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The token id does not exist."
+              );
+          });
+
+          it("Should reject if the bidder is a zero address on a custom media", async () => {
+            await ownerConnected
+              .fetchCurrentBidForBidder(
+                customMediaAddress,
+                0,
+                ethers.constants.AddressZero
+              )
+              .should.be.rejectedWith(
+                "Invariant failed: ZapMedia (fetchCurrentBidForBidder): The (bidder) address cannot be a zero address."
+              );
+          });
         });
       });
 


### PR DESCRIPTION
## Summary
Closes #372 

## Implementation
 - [x]  Moved the if statement and error handler for the ```mediaContractAddress``` to the top scope of the ```fetchCurrentBidForBidder``` function
 - [x] Added the ```attach``` function to the ```ownerOf``` function inside the try/catch allowing any media address passed as an argument to check if the token id exists on that collection
 - [x]  Added passing tests for the ```fetchCurrentBidForBidder``` function on the main media and custom media contracts

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

<img width="687" alt="Screen Shot 2022-02-01 at 11 26 33 PM" src="https://user-images.githubusercontent.com/42893948/152093046-f30abd38-2cd1-4ae1-aabf-7e34f38818b9.png">

