### PR TITLE
FetchCreator Custom Media Functionality 

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -219,9 +219,17 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
+    if (customMediaAddress !== undefined) {
+      try {
+        await this.media.attach(customMediaAddress).ownerOf(mediaId);
+      } catch {
+        invariant(false, "ZapMedia (fetchCreator): TokenId does not exist.");
+      }
+    }
+
     try {
       await this.media.ownerOf(mediaId);
-    } catch (err: any) {
+    } catch {
       invariant(false, "ZapMedia (fetchCreator): TokenId does not exist.");
     }
     return this.media.getTokenCreators(mediaId);

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -213,12 +213,14 @@ class ZapMedia {
 
   /**
    * Fetches the creator for the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
+   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchCreator(
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
+    // If the customMediaAddress is a zero address throw an error
     if (customMediaAddress == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -226,16 +228,15 @@ class ZapMedia {
       );
     }
 
+    // If the customMediaAddress does not equal undefined create a custom media instance and
+    // invoke the getTokenCreators function on that custom media
     if (customMediaAddress !== undefined) {
-      try {
-        return await this.media
-          .attach(customMediaAddress)
-          .getTokenCreators(mediaId);
-      } catch {
-        invariant(false, "ZapMedia (fetchCreator): TokenId does not exist.");
-      }
+      return await this.media
+        .attach(customMediaAddress)
+        .getTokenCreators(mediaId);
     }
 
+    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenCreators function
     return await this.media.getTokenCreators(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -153,14 +153,13 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
-    
     if (customMediaAddress == ethers.constants.AddressZero) {
       invariant(
         false,
         "ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
       );
     }
-    
+
     if (customMediaAddress !== undefined) {
       try {
         return await this.media.attach(customMediaAddress).tokenURI(mediaId);
@@ -216,7 +215,10 @@ class ZapMedia {
    * Fetches the creator for the specified media on an instance of the Zap Media Contract
    * @param mediaId
    */
-  public async fetchCreator(mediaId: BigNumberish): Promise<string> {
+  public async fetchCreator(
+    mediaId: BigNumberish,
+    customMediaAddress?: string
+  ): Promise<string> {
     try {
       await this.media.ownerOf(mediaId);
     } catch (err: any) {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -218,21 +218,25 @@ class ZapMedia {
   public async fetchCreator(
     mediaId: BigNumberish,
     customMediaAddress?: string
-  ): Promise<string> {
+  ): Promise<any> {
+    if (customMediaAddress == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
+      );
+    }
+
     if (customMediaAddress !== undefined) {
       try {
-        await this.media.attach(customMediaAddress).ownerOf(mediaId);
+        return await this.media
+          .attach(customMediaAddress)
+          .getTokenCreators(mediaId);
       } catch {
         invariant(false, "ZapMedia (fetchCreator): TokenId does not exist.");
       }
     }
 
-    try {
-      await this.media.ownerOf(mediaId);
-    } catch {
-      invariant(false, "ZapMedia (fetchCreator): TokenId does not exist.");
-    }
-    return this.media.getTokenCreators(mediaId);
+    return await this.media.getTokenCreators(mediaId);
   }
 
   /**

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -218,7 +218,7 @@ class ZapMedia {
   public async fetchCreator(
     mediaId: BigNumberish,
     customMediaAddress?: string
-  ): Promise<any> {
+  ): Promise<string> {
     if (customMediaAddress == ethers.constants.AddressZero) {
       invariant(
         false,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -529,6 +529,15 @@ describe("ZapMedia", () => {
 
           expect(creatorTwo).to.equal(await signerOne.getAddress());
         });
+
+        it("Should return the token creator on a custom media", async () => {
+          const creator: string = await ownerConnected.fetchCreator(
+            0,
+            customMediaAddress
+          );
+
+          expect(creator).to.equal(await signerOne.getAddress());
+        });
       });
     });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -449,6 +449,8 @@ describe("ZapMedia", () => {
           expect(parseInt(totalSupply._hex)).to.equal(1);
         });
       });
+
+      describe("#fetchCreator", () => {});
     });
 
     describe("Write Functions", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -450,7 +450,21 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchCreator", () => {});
+      describe.only("#fetchCreator", () => {
+        it("Should throw an error if the tokenId does not exist", async () => {
+          await ownerConnected.fetchCreator(0).catch((err) => {
+            expect(err.message).to.equal(
+              "Invariant failed: ZapMedia (fetchCreator): TokenId does not exist."
+            );
+          });
+        });
+
+        it("Should return the token creator", async () => {
+          const creator = await ownerConnected.fetchCreator(0);
+
+          expect(creator).to.equal(await signer.getAddress());
+        });
+      });
     });
 
     describe("Write Functions", () => {
@@ -738,22 +752,6 @@ describe("ZapMedia", () => {
             parseInt(bidShares.owner.value)
           );
           expect(onChainBidShares.collabShares).to.eql(bidShares.collabShares);
-        });
-      });
-
-      describe("#getTokenCreators", () => {
-        it("Should throw an error if the tokenId does not exist", async () => {
-          await ownerConnected.fetchCreator(0).catch((err) => {
-            expect(err.message).to.equal(
-              "Invariant failed: ZapMedia (fetchCreator): TokenId does not exist."
-            );
-          });
-        });
-
-        it("Should return the token creator", async () => {
-          const creator = await ownerConnected.fetchCreator(0);
-
-          expect(creator).to.equal(await signer.getAddress());
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -497,12 +497,27 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchCreator", () => {
-        it("Should reject if the tokenId does not exist on the main media", async () => {
-          await ownerConnected
-            .fetchCreator(300)
+        it("Should reject if the custom media is a zero address", async () => {
+          await signerOneConnected
+            .fetchCreator(0, ethers.constants.AddressZero)
             .should.be.rejectedWith(
-              "Invariant failed: ZapMedia (fetchCreator): TokenId does not exist."
+              "Invariant failed: ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
             );
+        });
+
+        it("Should return a zero address if the token id does not exist on the main media", async () => {
+          const ownerAddr: string = await ownerConnected.fetchCreator(300);
+
+          expect(ownerAddr).to.equal(ethers.constants.AddressZero);
+        });
+
+        it("Should return a zero address if the token id does not exist on a custom media", async () => {
+          const ownerAddr: string = await ownerConnected.fetchCreator(
+            12,
+            customMediaAddress
+          );
+
+          expect(ownerAddr).to.equal(ethers.constants.AddressZero);
         });
 
         it("Should return the token creator on the main media", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -498,6 +498,7 @@ describe("ZapMedia", () => {
 
       describe.only("#fetchCreator", () => {
         it("Should reject if the custom media is a zero address", async () => {
+          // Attempt to fetch a tokenId creator with a zero address as the media
           await signerOneConnected
             .fetchCreator(0, ethers.constants.AddressZero)
             .should.be.rejectedWith(
@@ -506,36 +507,46 @@ describe("ZapMedia", () => {
         });
 
         it("Should return a zero address if the token id does not exist on the main media", async () => {
+          // Returns a zero address due to the nonexistent tokenId on the custom media
           const ownerAddr: string = await ownerConnected.fetchCreator(300);
 
+          // Expect the address to equal a zero address
           expect(ownerAddr).to.equal(ethers.constants.AddressZero);
         });
 
         it("Should return a zero address if the token id does not exist on a custom media", async () => {
+          // Returns a zero address due to the nonexistent tokenId on a custom media
           const ownerAddr: string = await ownerConnected.fetchCreator(
             12,
             customMediaAddress
           );
 
+          // Expect the address to equal a zero address
           expect(ownerAddr).to.equal(ethers.constants.AddressZero);
         });
 
         it("Should return the token creator on the main media", async () => {
+          // Returns the creator address of tokenId 0 on the main media
           const creatorOne: string = await ownerConnected.fetchCreator(0);
 
+          // Returns the creator address of tokenId 1 on the main media
           const creatorTwo: string = await ownerConnected.fetchCreator(1);
 
+          // Expect creator of tokenId 0 to equal the owner (signers[0]) address
           expect(creatorOne).to.equal(await signer.getAddress());
 
+          // Expect the creator of tokenId 1 to equal the signerOne (signers[1]) address
           expect(creatorTwo).to.equal(await signerOne.getAddress());
         });
 
         it("Should return the token creator on a custom media", async () => {
+          // Returns the creator address of tokenId 0 on a custom media
           const creator: string = await ownerConnected.fetchCreator(
             0,
             customMediaAddress
           );
 
+          // Expect the creator of tokenId 0 on the custom media to equal the signerOne (signers[1]) address
           expect(creator).to.equal(await signerOne.getAddress());
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -452,7 +452,7 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchCreator", () => {
-        it.only("Should reject if the tokenId does not exist", async () => {
+        it("Should reject if the tokenId does not exist on the main media", async () => {
           await ownerConnected
             .fetchCreator(300)
             .should.be.rejectedWith(
@@ -461,9 +461,13 @@ describe("ZapMedia", () => {
         });
 
         it("Should return the token creator on the main media", async () => {
-          const creator: string = await ownerConnected.fetchCreator(0);
+          const creatorOne: string = await ownerConnected.fetchCreator(0);
 
-          expect(creator).to.equal(await signer.getAddress());
+          const creatorTwo: string = await ownerConnected.fetchCreator(1);
+
+          expect(creatorOne).to.equal(await signer.getAddress());
+
+          expect(creatorTwo).to.equal(await signerOne.getAddress());
         });
       });
     });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -39,6 +39,7 @@ import {
 } from "./test_utils";
 import { EIP712Signature, Bid } from "../src/types";
 import { BlobOptions } from "buffer";
+import { SrvRecord } from "dns";
 
 const provider = new ethers.providers.JsonRpcProvider("http://localhost:8545");
 
@@ -451,16 +452,16 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchCreator", () => {
-        it("Should throw an error if the tokenId does not exist", async () => {
-          await ownerConnected.fetchCreator(0).catch((err) => {
-            expect(err.message).to.equal(
+        it.only("Should reject if the tokenId does not exist", async () => {
+          await ownerConnected
+            .fetchCreator(300)
+            .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchCreator): TokenId does not exist."
             );
-          });
         });
 
-        it("Should return the token creator", async () => {
-          const creator = await ownerConnected.fetchCreator(0);
+        it("Should return the token creator on the main media", async () => {
+          const creator: string = await ownerConnected.fetchCreator(0);
 
           expect(creator).to.equal(await signer.getAddress());
         });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -496,7 +496,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchCreator", () => {
+      describe("#fetchCreator", () => {
         it("Should reject if the custom media is a zero address", async () => {
           // Attempt to fetch a tokenId creator with a zero address as the media
           await signerOneConnected


### PR DESCRIPTION
## Summary 
Closes #369 

## Implementation
 - [x] Added the optional argument ```custoMediaAddress``` to the ```fetchCreator``` function
 - [x] Added error handling if the ```customMediaAddress``` is a zero address
 - [x] Added an if statement that checks if the ```customMediaAddress``` is not undefined and will attach to the main media instance to create a custom media instance and invoke the ```fetchCreator``` function on that custom media
 - [x] Removed the unused try/catch
 - [x] If the ```customMediaAddress``` is undefined default back to the main media instance and invoke the ```fetchCreator``` function on the main media
 - [x] Added passing unit tests for the ```fetchCreator``` function with custom media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

<img width="726" alt="Screen Shot 2022-02-02 at 7 43 17 PM" src="https://user-images.githubusercontent.com/42893948/152262031-2b330a02-ec9d-4984-80e6-3d11710355e6.png">
<img width="831" alt="Screen Shot 2022-02-02 at 7 42 56 PM" src="https://user-images.githubusercontent.com/42893948/152261998-af1343ba-4386-4a2f-ba03-087750d21f83.png">

