### PR TITLE
NFT SDK: Custom Media FetchCurrentAsk Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -243,7 +243,6 @@ class ZapMedia {
   public async fetchCurrentAsk(
     mediaAddress: string,
     mediaId: BigNumberish,
-    customMediaAddress?: string
   ): Promise<Ask> {
     return this.market.currentAskForToken(mediaAddress, mediaId);
   }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -242,7 +242,8 @@ class ZapMedia {
    */
   public async fetchCurrentAsk(
     mediaAddress: string,
-    mediaId: BigNumberish
+    mediaId: BigNumberish,
+    customMediaAddress?: string
   ): Promise<Ask> {
     return this.market.currentAskForToken(mediaAddress, mediaId);
   }

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1063,7 +1063,18 @@ describe("ZapMedia", () => {
   
             expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
 
-            //expect(fetchAddress.amount).to.equal(ethers.constants.AddressZero);
+            expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
+          });
+
+          it("Should return null values if the token id does not exist", async () => {
+            const fetchAddress = await ownerConnected.fetchCurrentAsk(
+              zapMedia.address,
+              10
+            );
+
+            expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
+            
+            expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
           });
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1054,6 +1054,10 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
+        describe.only("#fetchCurrentAsk", () => {
+
+        })
+
         describe("#fetchCurrentBidForBidder", () => {
           it("Should reject if the media contract is a zero address", async () => {
             await ownerConnected

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1055,10 +1055,17 @@ describe("ZapMedia", () => {
         });
 
         describe.only("#fetchCurrentAsk", () => {
-          it("Should reject if the media address is a zero address", async () => {
+          it("Should return null values if the media is a zero address with a valid token id", async () => {
+            const fetchAddress = await ownerConnected.fetchCurrentAsk(
+              ethers.constants.AddressZero,
+              0
+            );
+  
+            expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
 
-          })
-        })
+            //expect(fetchAddress.amount).to.equal(ethers.constants.AddressZero);
+          });
+        });
 
         describe("#fetchCurrentBidForBidder", () => {
           it("Should reject if the media contract is a zero address", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1054,7 +1054,7 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
-        describe.only("#fetchCurrentAsk", () => {
+        describe("#fetchCurrentAsk", () => {
           it("Should return null values if the media is a zero address with a valid token id", async () => {
             const fetchAddress = await ownerConnected.fetchCurrentAsk(
               ethers.constants.AddressZero,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1064,6 +1064,7 @@ describe("ZapMedia", () => {
             expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
 
             expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
+
           });
 
           it("Should return null values if the token id does not exist", async () => {
@@ -1075,6 +1076,7 @@ describe("ZapMedia", () => {
             expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
             
             expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
+            
           });
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1055,7 +1055,9 @@ describe("ZapMedia", () => {
         });
 
         describe.only("#fetchCurrentAsk", () => {
+          it("Should reject if the media address is a zero address", async () => {
 
+          })
         })
 
         describe("#fetchCurrentBidForBidder", () => {


### PR DESCRIPTION
## Summary
@aidnii @kimanikelly 
Closes #371  

## Implementation

### First Test
 - [x] Created a test titled ```Should return null values if the media is a zero address with a valid token id```
 - [x] Constructed a valid ```ask``` 
 - [x] Invoked the ```fetchCurrentAsk``` function with a zero address and save its value in a variable
 - [x] Created ```expect```'s that test against the returned null values

### Second Test
 - [x] Created a test titled ```Should return null values if the token id does not exist```
 - [x] Constructed a valid ```ask``` 
 - [x] Invoked the ```fetchCurrentAsk``` function with a  valid media address and nonexistent token id
 - [x] Created ```expect```'s that test against the returned null values

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="561" alt="Screen Shot 2022-02-03 at 9 17 05 AM" src="https://user-images.githubusercontent.com/58867896/152371336-e64a77cc-67ee-4d3d-8c1b-6661d30bcebc.png">