### PR TITLE
FetchContentHash Custom Media Functionality 

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -195,9 +195,16 @@ class ZapMedia {
     if (customMediaAddress == ethers.constants.AddressZero) {
       invariant(
         false,
-        "ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
+        "ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
       );
     }
+
+    if (customMediaAddress !== undefined) {
+      return await this.media
+        .attach(customMediaAddress)
+        .getTokenContentHashes(mediaId);
+    }
+
     return this.media.getTokenContentHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -185,7 +185,8 @@ class ZapMedia {
 
   /**
    * Fetches the content hash for the specified media on the ZapMedia Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
+   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchContentHash(
     mediaId: BigNumberish,
@@ -199,12 +200,15 @@ class ZapMedia {
       );
     }
 
+    // If the customMediaAddress does not equal undefined create a custom media instance and
+    // invoke the getTokenHashes function on that custom media
     if (customMediaAddress !== undefined) {
       return await this.media
         .attach(customMediaAddress)
         .getTokenContentHashes(mediaId);
     }
 
+    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenContentHashes function
     return this.media.getTokenContentHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -191,6 +191,13 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
+    // If the customMediaAddress is a zero address throw an error
+    if (customMediaAddress == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
+      );
+    }
     return this.media.getTokenContentHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -187,7 +187,10 @@ class ZapMedia {
    * Fetches the content hash for the specified media on the ZapMedia Contract
    * @param mediaId
    */
-  public async fetchContentHash(mediaId: BigNumberish): Promise<string> {
+  public async fetchContentHash(
+    mediaId: BigNumberish,
+    customMediaAddress?: string
+  ): Promise<string> {
     return this.media.getTokenContentHashes(mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -320,6 +320,7 @@ describe("ZapMedia", () => {
 
       describe.only("#fetchContentHash", () => {
         it("Should reject if the custom media is a zero address", async () => {
+          // If the custom media is a zero address it will throw an error
           await ownerConnected
             .fetchContentHash(0, ethers.constants.AddressZero)
             .should.be.rejectedWith(
@@ -327,30 +328,44 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+          // Return 0x0 due to a non existent tokenId on the main media
+          const onChainContentHash: string =
+            await ownerConnected.fetchContentHash(56);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainContentHash).eq(ethers.constants.HashZero);
+        });
+
         it("Should be able to fetch contentHash on the main media", async () => {
+          // Returns the content hash of tokenId 0 on the main media
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(0);
 
-          expect(onChainContentHash).eq(
-            ethers.utils.hexlify(mediaDataOne.contentHash)
-          );
-        });
-
-        it("Should be able to fetch contentHash on a custom media", async () => {
-          const onChainContentHash: string =
-            await ownerConnected.fetchContentHash(0, customMediaAddress);
-
+          // Expect the returned content hash to equal the content hash set on mint
           expect(onChainContentHash).eq(
             ethers.utils.hexlify(mediaDataOne.contentHash)
           );
         });
 
         it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+          // Return 0x0 due to a non existent tokenId on a custom media
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(56, customMediaAddress);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainContentHash).eq(ethers.constants.HashZero);
+        });
+
+        it("Should be able to fetch contentHash on a custom media", async () => {
+          // Returns the content hash of tokenId 0 on a custom media
+          const onChainContentHash: string =
+            await ownerConnected.fetchContentHash(0, customMediaAddress);
+
+          // Expect the returned content hash to equal the content hash set on mint
+          expect(onChainContentHash).eq(
+            ethers.utils.hexlify(mediaDataOne.contentHash)
+          );
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -320,13 +320,15 @@ describe("ZapMedia", () => {
 
       describe.only("#fetchContentHash", () => {
         it("Should be able to fetch contentHash", async () => {
-          const onChainContentHash = await ownerConnected.fetchContentHash(0);
+          const onChainContentHash: string =
+            await ownerConnected.fetchContentHash(0);
+
           expect(onChainContentHash).eq(
             ethers.utils.hexlify(mediaDataOne.contentHash)
           );
         });
 
-        it("fetchContentHash should get 0x0 if tokenId doesn't exist", async () => {
+        it("Should return 0x0 if tokenId doesn't exist", async () => {
           const onChainContentHash = await ownerConnected.fetchContentHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -319,6 +319,14 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchContentHash", () => {
+        it("Should reject if the custom media is a zero address", async () => {
+          await ownerConnected
+            .fetchContentHash(0, ethers.constants.AddressZero)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
+            );
+        });
+
         it("Should be able to fetch contentHash on the main media", async () => {
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(0);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -336,12 +336,13 @@ describe("ZapMedia", () => {
           );
         });
 
-        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+        it("Should be able to fetch contentHash on a custom media", async () => {
           const onChainContentHash: string =
-            await ownerConnected.fetchContentHash(56);
+            await ownerConnected.fetchContentHash(0, customMediaAddress);
 
-          // tokenId doesn't exists, so we expect a default return value of 0x0000...
-          expect(onChainContentHash).eq(ethers.constants.HashZero);
+          expect(onChainContentHash).eq(
+            ethers.utils.hexlify(mediaDataOne.contentHash)
+          );
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -318,7 +318,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchContentHash", () => {
+      describe("#fetchContentHash", () => {
         it("Should reject if the custom media is a zero address", async () => {
           // If the custom media is a zero address it will throw an error
           await ownerConnected

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -318,7 +318,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchContentHash, fetchMetadataHash, fetchPermitNonce", () => {
+      describe.only("#fetchContentHash", () => {
         it("Should be able to fetch contentHash", async () => {
           const onChainContentHash = await ownerConnected.fetchContentHash(0);
           expect(onChainContentHash).eq(
@@ -332,7 +332,9 @@ describe("ZapMedia", () => {
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainContentHash).eq(ethers.constants.HashZero);
         });
+      });
 
+      describe("#fetchContentHash, fetchMetadataHash, fetchPermitNonce", () => {
         it("Should be able to fetch metadataHash", async () => {
           const onChainMetadataHash = await ownerConnected.fetchMetadataHash(0);
           expect(onChainMetadataHash).eq(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -319,7 +319,7 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchContentHash", () => {
-        it("Should be able to fetch contentHash", async () => {
+        it("Should be able to fetch contentHash on the main media", async () => {
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(0);
 
@@ -328,7 +328,7 @@ describe("ZapMedia", () => {
           );
         });
 
-        it("Should return 0x0 if tokenId doesn't exist", async () => {
+        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
           const onChainContentHash = await ownerConnected.fetchContentHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -329,14 +329,15 @@ describe("ZapMedia", () => {
         });
 
         it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
-          const onChainContentHash = await ownerConnected.fetchContentHash(56);
+          const onChainContentHash: string =
+            await ownerConnected.fetchContentHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainContentHash).eq(ethers.constants.HashZero);
         });
       });
 
-      describe("#fetchContentHash, fetchMetadataHash, fetchPermitNonce", () => {
+      describe("fetchMetadataHash, fetchPermitNonce", () => {
         it("Should be able to fetch metadataHash", async () => {
           const onChainMetadataHash = await ownerConnected.fetchMetadataHash(0);
           expect(onChainMetadataHash).eq(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -344,6 +344,14 @@ describe("ZapMedia", () => {
             ethers.utils.hexlify(mediaDataOne.contentHash)
           );
         });
+
+        it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+          const onChainContentHash: string =
+            await ownerConnected.fetchContentHash(56, customMediaAddress);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainContentHash).eq(ethers.constants.HashZero);
+        });
       });
 
       describe("fetchMetadataHash, fetchPermitNonce", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -339,12 +339,21 @@ describe("ZapMedia", () => {
 
         it("Should be able to fetch contentHash on the main media", async () => {
           // Returns the content hash of tokenId 0 on the main media
-          const onChainContentHash: string =
+          const onChainContentHashOne: string =
             await ownerConnected.fetchContentHash(0);
 
+          // Returns the content hash of tokenId 1 on the main media
+          const onChainContentHashTwo: string =
+            await ownerConnected.fetchContentHash(1);
+
           // Expect the returned content hash to equal the content hash set on mint
-          expect(onChainContentHash).eq(
+          expect(onChainContentHashOne).eq(
             ethers.utils.hexlify(mediaDataOne.contentHash)
+          );
+
+          // Expect the returned content hash to equal the content hash set on mint
+          expect(onChainContentHashTwo).eq(
+            ethers.utils.hexlify(mediaDataTwo.contentHash)
           );
         });
 


### PR DESCRIPTION
## Summary
Closes #368 

## Implementation
 - [x]  The optional argument ```customMediaAddress``` to the ```fetchContentHash``` function
 - [x] Added error handling if the ```custoMediaAddress``` is a zero address
 - [x] Added an if statement that checks if the ```customMediaAddress``` is not undefined and will attach to the main media instance to create a custom media instance and invoke the ```fetchContentHash```  function on that custom media
 - [x]  If the ```customMediaAddress``` is undefined default back to the main media instance and invoke the ```fetchContentHash``` function on the main media
 - [x] Added passing unit tests for the ```fetchContentHash``` function with custom media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="736" alt="Screen Shot 2022-02-03 at 1 41 57 PM" src="https://user-images.githubusercontent.com/42893948/152407870-abb71a2f-f3fe-49bd-a870-c77a183fa7db.png">
<img width="765" alt="Screen Shot 2022-02-03 at 1 41 40 PM" src="https://user-images.githubusercontent.com/42893948/152407838-46000203-11cd-4b3e-a384-a98f4512954a.png">

