### PR TITLE
FetchMetadataHash Custom Media Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -216,7 +216,10 @@ class ZapMedia {
    * Fetches the metadata hash for the specified media on the ZapMedia Contract
    * @param mediaId
    */
-  public async fetchMetadataHash(mediaId: BigNumberish): Promise<string> {
+  public async fetchMetadataHash(
+    mediaId: BigNumberish,
+    customMediaAddress?: string
+  ): Promise<string> {
     return this.media.getTokenMetadataHashes(mediaId);
   }
 
@@ -278,7 +281,7 @@ class ZapMedia {
    */
   public async fetchCurrentAsk(
     mediaAddress: string,
-    mediaId: BigNumberish,
+    mediaId: BigNumberish
   ): Promise<Ask> {
     return this.market.currentAskForToken(mediaAddress, mediaId);
   }

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -228,6 +228,14 @@ class ZapMedia {
       );
     }
 
+    // If the customMediaAddress does not equal undefined create a custom media instance and
+    // invoke the getTokenCreators function on that custom media
+    if (customMediaAddress !== undefined) {
+      return await this.media
+        .attach(customMediaAddress)
+        .getTokenMetadataHashes(mediaId);
+    }
+
     return this.media.getTokenMetadataHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -214,7 +214,8 @@ class ZapMedia {
 
   /**
    * Fetches the metadata hash for the specified media on the ZapMedia Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
+   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchMetadataHash(
     mediaId: BigNumberish,
@@ -235,7 +236,7 @@ class ZapMedia {
         .attach(customMediaAddress)
         .getTokenMetadataHashes(mediaId);
     }
-
+    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenMetadataHashes function
     return this.media.getTokenMetadataHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -220,6 +220,14 @@ class ZapMedia {
     mediaId: BigNumberish,
     customMediaAddress?: string
   ): Promise<string> {
+    // If the customMediaAddress is a zero address throw an error
+    if (customMediaAddress == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchMetadataHash): The (customMediaAddress) cannot be a zero address."
+      );
+    }
+
     return this.media.getTokenMetadataHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -229,7 +229,7 @@ class ZapMedia {
     }
 
     // If the customMediaAddress does not equal undefined create a custom media instance and
-    // invoke the getTokenCreators function on that custom media
+    // invoke the getTokenMetadataHashes function on that custom media
     if (customMediaAddress !== undefined) {
       return await this.media
         .attach(customMediaAddress)

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -395,10 +395,9 @@ describe("ZapMedia", () => {
           );
         });
 
-        it("fetchMetadataHash should get 0x0 if tokenId doesn't exist", async () => {
-          const onChainMetadataHash = await ownerConnected.fetchMetadataHash(
-            56
-          );
+        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+          const onChainMetadataHash: string =
+            await ownerConnected.fetchMetadataHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainMetadataHash).eq(ethers.constants.HashZero);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -402,6 +402,14 @@ describe("ZapMedia", () => {
             ethers.utils.hexlify(mediaDataTwo.metadataHash)
           );
         });
+
+        it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+          const onChainMetadataHash: string =
+            await ownerConnected.fetchMetadataHash(1001, customMediaAddress);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainMetadataHash).eq(ethers.constants.HashZero);
+        });
       });
 
       describe("#fetchPermitNonce", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -378,7 +378,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchMetadataHash", async () => {
+      describe("#fetchMetadataHash", async () => {
         it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
           // Returns 0x0 due to a non existent tokenId on the main media
           const onChainMetadataHash: string =

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -378,7 +378,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("fetchMetadataHash, fetchPermitNonce", () => {
+      describe("#fetchMetadataHash", async () => {
         it("Should be able to fetch metadataHash", async () => {
           const onChainMetadataHash = await ownerConnected.fetchMetadataHash(0);
           expect(onChainMetadataHash).eq(
@@ -394,7 +394,9 @@ describe("ZapMedia", () => {
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainMetadataHash).eq(ethers.constants.HashZero);
         });
+      });
 
+      describe("#fetchPermitNonce", () => {
         it("Should be able to fetch permitNonce", async () => {
           // created wallets using privateKey because we need a wallet instance when creating a signature
           const otherWallet: Wallet = new ethers.Wallet(
@@ -1146,11 +1148,12 @@ describe("ZapMedia", () => {
               ethers.constants.AddressZero,
               0
             );
-  
-            expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
+
+            expect(fetchAddress.currency).to.equal(
+              ethers.constants.AddressZero
+            );
 
             expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
-
           });
 
           it("Should return null values if the token id does not exist", async () => {
@@ -1159,10 +1162,11 @@ describe("ZapMedia", () => {
               10
             );
 
-            expect(fetchAddress.currency).to.equal(ethers.constants.AddressZero);
-            
+            expect(fetchAddress.currency).to.equal(
+              ethers.constants.AddressZero
+            );
+
             expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
-            
           });
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -358,7 +358,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
-          // Return 0x0 due to a non existent tokenId on a custom media
+          // Returns 0x0 due to a non existent tokenId on a custom media
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(56, customMediaAddress);
 
@@ -380,6 +380,7 @@ describe("ZapMedia", () => {
 
       describe.only("#fetchMetadataHash", async () => {
         it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+          // Returns 0x0 due to a non existent tokenId on the main media
           const onChainMetadataHash: string =
             await ownerConnected.fetchMetadataHash(56);
 
@@ -388,22 +389,27 @@ describe("ZapMedia", () => {
         });
 
         it("Should be able to fetch metadataHash on the main media", async () => {
+          // Returns the metadataHash of tokenId 0 on the main media
           const onChainMetadataHashOne: string =
             await ownerConnected.fetchMetadataHash(0);
 
+          // Returns the metadataHash of tokenId 1 on the main media
           const onChainMetadataHashTwo: string =
             await ownerConnected.fetchMetadataHash(1);
 
+          // Expect the returned metadata hash for tokenId 0 to equal the one set on mint
           expect(onChainMetadataHashOne).eq(
             ethers.utils.hexlify(mediaDataOne.metadataHash)
           );
 
+          // Expect the returned metadata hash for tokenId 1 to equal the one set on mint
           expect(onChainMetadataHashTwo).eq(
             ethers.utils.hexlify(mediaDataTwo.metadataHash)
           );
         });
 
         it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+          // Returns 0x0 due to a non existent tokenId on a custom media
           const onChainMetadataHash: string =
             await ownerConnected.fetchMetadataHash(1001, customMediaAddress);
 
@@ -412,6 +418,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should be able to fetch metadataHash on a custom media", async () => {
+          // Returns the metadata hash of tokenId 0 on a custom media
           const onChainMetadataHash: string =
             await ownerConnected.fetchMetadataHash(0, customMediaAddress);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -379,6 +379,14 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchMetadataHash", async () => {
+        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+          const onChainMetadataHash: string =
+            await ownerConnected.fetchMetadataHash(56);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainMetadataHash).eq(ethers.constants.HashZero);
+        });
+
         it("Should be able to fetch metadataHash on the main media", async () => {
           const onChainMetadataHashOne: string =
             await ownerConnected.fetchMetadataHash(0);
@@ -393,14 +401,6 @@ describe("ZapMedia", () => {
           expect(onChainMetadataHashTwo).eq(
             ethers.utils.hexlify(mediaDataTwo.metadataHash)
           );
-        });
-
-        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
-          const onChainMetadataHash: string =
-            await ownerConnected.fetchMetadataHash(56);
-
-          // tokenId doesn't exists, so we expect a default return value of 0x0000...
-          expect(onChainMetadataHash).eq(ethers.constants.HashZero);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -410,6 +410,16 @@ describe("ZapMedia", () => {
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainMetadataHash).eq(ethers.constants.HashZero);
         });
+
+        it("Should be able to fetch metadataHash on a custom media", async () => {
+          const onChainMetadataHash: string =
+            await ownerConnected.fetchMetadataHash(0, customMediaAddress);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainMetadataHash).eq(
+            ethers.utils.hexlify(mediaDataOne.metadataHash)
+          );
+        });
       });
 
       describe("#fetchPermitNonce", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -378,11 +378,20 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchMetadataHash", async () => {
-        it("Should be able to fetch metadataHash", async () => {
-          const onChainMetadataHash = await ownerConnected.fetchMetadataHash(0);
-          expect(onChainMetadataHash).eq(
+      describe.only("#fetchMetadataHash", async () => {
+        it("Should be able to fetch metadataHash on the main media", async () => {
+          const onChainMetadataHashOne: string =
+            await ownerConnected.fetchMetadataHash(0);
+
+          const onChainMetadataHashTwo: string =
+            await ownerConnected.fetchMetadataHash(1);
+
+          expect(onChainMetadataHashOne).eq(
             ethers.utils.hexlify(mediaDataOne.metadataHash)
+          );
+
+          expect(onChainMetadataHashTwo).eq(
+            ethers.utils.hexlify(mediaDataTwo.metadataHash)
           );
         });
 


### PR DESCRIPTION
## Summary
Closes #383 

## Implementation
 - [x] Added the optional argument ```customMediaAddress``` to the ```fetchMetadataHash``` function
 - [x]  Added error handling if the ```customMediaAddress``` is a zero address
 - [x]  Added an if statement that checks if the ```customMediaAddress``` is not undefined and will attach to the main media instance to create a custom media instance and invoke the ```fetchMetadataHash``` function on that custom media
 - [x] If the ```customMediaAddress``` is undefined default back to the main media instance and invoke the ```fetchMetadataHash```function on the main media
 - [x]  Added passing unit tests for the ```fetchMetadataHash``` function with custom media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview


<img width="710" alt="Screen Shot 2022-02-03 at 5 35 34 PM" src="https://user-images.githubusercontent.com/42893948/152440686-9d055900-9c61-4977-9d82-4ab4031163d9.png">



