### PR TITLE
Burn Custom Media Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -40,9 +40,8 @@ class ZapMedia {
   media: any;
   market: any;
   signer: Signer;
-  public readOnly: boolean;
 
-  constructor(networkId: number, signer: Signer) {
+  constructor(networkId: number, signer: Signer, customMediaAddress?: string) {
     this.networkId = networkId;
 
     this.signer = signer;
@@ -58,12 +57,6 @@ class ZapMedia {
       zapMediaAbi,
       signer
     );
-
-    if (Signer.isSigner(signer)) {
-      this.readOnly = false;
-    } else {
-      this.readOnly = true;
-    }
   }
 
   /*********************

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -773,10 +773,12 @@ class ZapMedia {
    */
   public async burn(mediaId: BigNumberish): Promise<ContractTransaction> {
     try {
-      return await this.media.burn(mediaId);
+      await this.media.ownerOf(mediaId);
     } catch {
       invariant(false, "ZapMedia (burn): TokenId does not exist.");
     }
+
+    return await this.media.burn(mediaId);
   }
 
   /**

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -52,11 +52,15 @@ class ZapMedia {
       signer
     );
 
-    this.media = new ethers.Contract(
-      contractAddresses(networkId).zapMediaAddress,
-      zapMediaAbi,
-      signer
-    );
+    if (customMediaAddress !== undefined) {
+      this.media = new ethers.Contract(customMediaAddress, zapMediaAbi, signer);
+    } else {
+      this.media = new ethers.Contract(
+        contractAddresses(networkId).zapMediaAddress,
+        zapMediaAbi,
+        signer
+      );
+    }
   }
 
   /*********************

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -55,7 +55,7 @@ class ZapMedia {
     if (customMediaAddress == ethers.constants.AddressZero) {
       invariant(
         false,
-        "ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
+        "ZapMedia (constructor): The (customMediaAddress) cannot be a zero address."
       );
     }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -772,7 +772,11 @@ class ZapMedia {
    * @param mediaId
    */
   public async burn(mediaId: BigNumberish): Promise<ContractTransaction> {
-    return this.media.burn(mediaId);
+    try {
+      return await this.media.burn(mediaId);
+    } catch {
+      invariant(false, "ZapMedia (burn): TokenId does not exist.");
+    }
   }
 
   /**

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -52,6 +52,13 @@ class ZapMedia {
       signer
     );
 
+    if (customMediaAddress == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
+      );
+    }
+
     if (customMediaAddress !== undefined) {
       this.media = new ethers.Contract(customMediaAddress, zapMediaAbi, signer);
     } else {
@@ -734,7 +741,7 @@ class ZapMedia {
   }
 
   /**
-   * Grants the spender approval for the specified media using meta transactions as outlined in EIP-712
+   * Grants the spender approval for the specificxed media using meta transactions as outlined in EIP-712
    * @param sender
    * @param mediaId
    * @param sig

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -766,13 +766,15 @@ class ZapMedia {
 
   /**
    * Burns the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
    */
   public async burn(mediaId: BigNumberish): Promise<ContractTransaction> {
+    // Will store the address of the token owner if the tokenId exists
     let owner: string;
 
+    // Checks if the tokenId exists. If the tokenId exists store the owner
+    // address in the variable and if it doesnt throw an error
     try {
-      // If the tokenId exists return the owner address and store it in the owner variable
       owner = await this.media.ownerOf(mediaId);
     } catch {
       invariant(false, "ZapMedia (burn): TokenId does not exist.");
@@ -787,6 +789,8 @@ class ZapMedia {
       await this.signer.getAddress()
     );
 
+    // Checks if the caller is not approved, not approved for all, and not the owner.
+    // If the caller meets the three conditions throw an error
     if (
       approveAddr == ethers.constants.AddressZero &&
       approveForAllStatus == false &&
@@ -798,6 +802,7 @@ class ZapMedia {
       );
     }
 
+    // Invoke the burn function if the caller is approved, approved for all, or the owner
     return await this.media.burn(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -790,14 +790,15 @@ class ZapMedia {
       await this.signer.getAddress()
     );
 
-    console.log(approveAddr);
-    console.log(approveForAllStatus);
-
     if (
       approveAddr == ethers.constants.AddressZero &&
+      approveForAllStatus == false &&
       owner !== (await this.signer.getAddress())
     ) {
-      invariant(false, "ZapMedia (burn): Caller is not approved nor the owner");
+      invariant(
+        false,
+        "ZapMedia (burn): Caller is not approved nor the owner."
+      );
     }
 
     return await this.media.burn(mediaId);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1331,8 +1331,8 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#burn", () => {
-        it("Should burn a token", async () => {
+      describe.only("#burn", () => {
+        it("Should burn a token on a custom media", async () => {
           const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1393,7 +1393,7 @@ describe("ZapMedia", () => {
           expect(postTotalSupply.toNumber()).to.equal(1);
         });
 
-        it.only("Should burn a token if the caller is approved on a custom media", async () => {
+        it("Should burn a token if the caller is approved on a custom media", async () => {
           const preTotalSupply: BigNumberish =
             await customMediaSigner1.fetchTotalMedia();
           expect(preTotalSupply.toNumber()).to.equal(1);
@@ -1446,6 +1446,38 @@ describe("ZapMedia", () => {
           const postTotalSupply: BigNumberish =
             await ownerConnected.fetchTotalMedia();
           expect(postTotalSupply.toNumber()).to.equal(1);
+        });
+
+        it("Should burn the token if the caller is approved for all on the main media", async () => {
+          const preTotalSupply: BigNumberish =
+            await customMediaSigner1.fetchTotalMedia();
+          expect(preTotalSupply.toNumber()).to.equal(1);
+
+          const preApprovedStatus: boolean =
+            await customMediaSigner1.fetchIsApprovedForAll(
+              await signerOne.getAddress(),
+              await signer.getAddress()
+            );
+          expect(preApprovedStatus).to.equal(false);
+
+          await customMediaSigner1.setApprovalForAll(
+            await signer.getAddress(),
+            true
+          );
+
+          const postApprovedStatus: boolean =
+            await customMediaSigner1.fetchIsApprovedForAll(
+              await signerOne.getAddress(),
+              await signer.getAddress()
+            );
+
+          expect(postApprovedStatus).to.equal(true);
+
+          await customMediaSigner0.burn(0);
+
+          const postTotalSupply: BigNumberish =
+            await customMediaSigner0.fetchTotalMedia();
+          expect(postTotalSupply.toNumber()).to.equal(0);
         });
 
         it("Should burn a token if the caller is the owner on the main media", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -195,6 +195,14 @@ describe("ZapMedia", () => {
           new ZapMedia(300, signer);
         }).to.throw("Constructor: Network Id is not supported.");
       });
+
+      it("Should throw an error if the custom media is a zero address", async () => {
+        expect(() => {
+          new ZapMedia(1337, signer, ethers.constants.AddressZero);
+        }).to.throw(
+          "ZapMedia (constructor): The (customMediaAddress) cannot be a zero address."
+        );
+      });
     });
 
     describe("View Functions", () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1332,7 +1332,15 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#burn", () => {
-        it("Should burn a token on a custom media", async () => {
+        it("Should reject if the token id does not exist on the main media", async () => {
+          await ownerConnected
+            .burn(3)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (burn): TokenId does not exist."
+            );
+        });
+
+        it("Should burn a token on the main media", async () => {
           const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -64,6 +64,7 @@ describe("ZapMedia", () => {
   let mediaFactory: MediaFactory;
   let signerOneConnected: ZapMedia;
   let ownerConnected: ZapMedia;
+  let customMedia: ZapMedia;
   let customMediaAddress: string;
 
   let eipSig: any;
@@ -170,6 +171,8 @@ describe("ZapMedia", () => {
     ownerConnected = new ZapMedia(1337, signer);
 
     signerOneConnected = new ZapMedia(1337, signerOne);
+
+    customMedia = new ZapMedia(1337, signerOne, customMediaAddress);
 
     // The owner (signers[0]) mints on their own media contract
     await ownerConnected.mint(mediaDataOne, bidShares);
@@ -1334,6 +1337,14 @@ describe("ZapMedia", () => {
       describe.only("#burn", () => {
         it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
+            .burn(3)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (burn): TokenId does not exist."
+            );
+        });
+
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await customMedia
             .burn(3)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (burn): TokenId does not exist."

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1340,20 +1340,12 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should reject ", async () => {
-          await ownerConnected.setApprovalForAll(
-            await signerOne.getAddress(),
-            true
-          );
-
-          console.log(await ownerConnected.fetchApproved(0));
-          console.log(
-            await ownerConnected.fetchIsApprovedForAll(
-              await signer.getAddress(),
-              await signerOne.getAddress()
-            )
-          );
-          // await signerOneConnected.burn(0);
+        it.only("Should reject if the caller is not approved nor the owner on the main media", async () => {
+          await signerOneConnected
+            .burn(0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (burn): Caller is not approved nor the owner"
+            );
         });
 
         it.skip("Should burn a token on the main media", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1340,7 +1340,23 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should burn a token on the main media", async () => {
+        it("Should reject ", async () => {
+          await ownerConnected.setApprovalForAll(
+            await signerOne.getAddress(),
+            true
+          );
+
+          console.log(await ownerConnected.fetchApproved(0));
+          console.log(
+            await ownerConnected.fetchIsApprovedForAll(
+              await signer.getAddress(),
+              await signerOne.getAddress()
+            )
+          );
+          // await signerOneConnected.burn(0);
+        });
+
+        it.skip("Should burn a token on the main media", async () => {
           const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1340,15 +1340,15 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the caller is not approved nor the owner on the main media", async () => {
+        it("Should reject if the caller is not approved nor the owner on the main media", async () => {
           await signerOneConnected
             .burn(0)
             .should.be.rejectedWith(
-              "Invariant failed: ZapMedia (burn): Caller is not approved nor the owner"
+              "Invariant failed: ZapMedia (burn): Caller is not approved nor the owner."
             );
         });
 
-        it.skip("Should burn a token on the main media", async () => {
+        it("Should burn a token on the main media", async () => {
           const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1348,6 +1348,29 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should burn a token if the caller is approved on the main media", async () => {
+          const preTotalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia();
+          expect(preTotalSupply.toNumber()).to.equal(2);
+
+          const preApprovedAddr: string = await ownerConnected.fetchApproved(0);
+          expect(preApprovedAddr).to.equal(ethers.constants.AddressZero);
+
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
+
+          const postApprovedAddr: string = await ownerConnected.fetchApproved(
+            0
+          );
+
+          expect(postApprovedAddr).to.equal(await signerOne.getAddress());
+
+          await signerOneConnected.burn(0);
+
+          const postTotalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia();
+          expect(postTotalSupply.toNumber()).to.equal(1);
+        });
+
         it("Should burn a token on the main media", async () => {
           const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1371,7 +1371,39 @@ describe("ZapMedia", () => {
           expect(postTotalSupply.toNumber()).to.equal(1);
         });
 
-        it("Should burn a token on the main media", async () => {
+        it("Should burn the token if the caller is approved for all on the main media", async () => {
+          const preTotalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia();
+          expect(preTotalSupply.toNumber()).to.equal(2);
+
+          const preApprovedStatus: boolean =
+            await ownerConnected.fetchIsApprovedForAll(
+              await signer.getAddress(),
+              await signerOne.getAddress()
+            );
+          expect(preApprovedStatus).to.equal(false);
+
+          await ownerConnected.setApprovalForAll(
+            await signerOne.getAddress(),
+            true
+          );
+
+          const postApprovedStatus: boolean =
+            await ownerConnected.fetchIsApprovedForAll(
+              await signer.getAddress(),
+              await signerOne.getAddress()
+            );
+
+          expect(postApprovedStatus).to.equal(true);
+
+          await signerOneConnected.burn(0);
+
+          const postTotalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia();
+          expect(postTotalSupply.toNumber()).to.equal(1);
+        });
+
+        it("Should burn a token if the caller is the owner on the main media", async () => {
           const owner = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1337,7 +1337,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#burn", () => {
+      describe("#burn", () => {
         it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
             .burn(3)
@@ -1448,7 +1448,7 @@ describe("ZapMedia", () => {
           expect(postTotalSupply.toNumber()).to.equal(1);
         });
 
-        it("Should burn the token if the caller is approved for all on the main media", async () => {
+        it("Should burn the token if the caller is approved for all on a custom media", async () => {
           const preTotalSupply: BigNumberish =
             await customMediaSigner1.fetchTotalMedia();
           expect(preTotalSupply.toNumber()).to.equal(1);
@@ -1481,16 +1481,30 @@ describe("ZapMedia", () => {
         });
 
         it("Should burn a token if the caller is the owner on the main media", async () => {
-          const owner = await ownerConnected.fetchOwnerOf(0);
+          const owner: string = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
-          const preTotalSupply = await ownerConnected.fetchTotalMedia();
+          const preTotalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia();
           expect(preTotalSupply.toNumber()).to.equal(2);
 
           await ownerConnected.burn(0);
 
-          const postTotalSupply = await ownerConnected.fetchTotalMedia();
+          const postTotalSupply: BigNumberish =
+            await ownerConnected.fetchTotalMedia();
           expect(postTotalSupply.toNumber()).to.equal(1);
+        });
+
+        it("Should burn a token if the caller is the owner on a custom media", async () => {
+          const preTotalSupply: BigNumberish =
+            await customMediaSigner0.fetchTotalMedia();
+          expect(preTotalSupply.toNumber()).to.equal(1);
+
+          await customMediaSigner1.burn(0);
+
+          const postTotalSupply: BigNumberish =
+            await customMediaSigner1.fetchTotalMedia();
+          expect(postTotalSupply.toNumber()).to.equal(0);
         });
       });
 


### PR DESCRIPTION
## Summary
Closes #387 

## Implementation
 - [x] Added the optional argument ``` customMediaAddress``` to the ZapMedia class constructor. This will remove the need to add the argument to the other functions and prevent duplicate code between switching from the main media to a custom media
 - [x] Added error handling if the ```customMediaAddress``` is a zero address inside the constructor
 - [x] Added error handling if the caller is not approved,approved for all, or the owner inside for the ```burn``` function
 - [x]  Added error handling if the tokenId does not exist for the ```burn``` function
 - [x] Added passing unit tests for the ```burn``` function with custom media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="895" alt="Screen Shot 2022-02-06 at 3 55 50 PM" src="https://user-images.githubusercontent.com/42893948/152700967-d9dd7b94-412e-4fce-8dae-54907c8c9254.png">

<img width="754" alt="Screen Shot 2022-02-06 at 3 55 15 PM" src="https://user-images.githubusercontent.com/42893948/152700945-73781d00-4fc5-4f94-8235-bacd082b6aa2.png">

