### PR TITLE
Refactor FetchBalanceOf

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -78,12 +78,8 @@ class ZapMedia {
   /**
    * Fetches the amount of tokens an address owns on a media contract
    * @param owner The address to fetch the token balance for
-   * @param mediaIndex The index to access media contracts as an optional argument
    */
-  public async fetchBalanceOf(
-    owner: string,
-    customMediaAddress?: BigNumberish
-  ): Promise<BigNumber> {
+  public async fetchBalanceOf(owner: string): Promise<BigNumber> {
     if (owner == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -91,11 +87,7 @@ class ZapMedia {
       );
     }
 
-    if (customMediaAddress !== undefined) {
-      return this.media.attach(customMediaAddress).balanceOf(owner);
-    } else {
-      return this.media.balanceOf(owner);
-    }
+    return this.media.balanceOf(owner);
   }
 
   /**

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -207,7 +207,7 @@ describe("ZapMedia", () => {
 
     describe("View Functions", () => {
       describe.only("#fetchBalanceOf", () => {
-        it("Should reject if the owner is a zero address", async () => {
+        it("Should reject if the owner is a zero address on the main media", async () => {
           await signerOneConnected
             .fetchBalanceOf(ethers.constants.AddressZero)
             .should.be.rejectedWith(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -206,7 +206,7 @@ describe("ZapMedia", () => {
     });
 
     describe("View Functions", () => {
-      describe.only("#fetchBalanceOf", () => {
+      describe("#fetchBalanceOf", () => {
         it("Should reject if the owner is a zero address on the main media", async () => {
           await signerOneConnected
             .fetchBalanceOf(ethers.constants.AddressZero)

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -223,7 +223,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should fetch the owner balance", async () => {
+        it("Should fetch the owner balance on a custom media", async () => {
           const balance = await ownerConnected.fetchBalanceOf(
             await signer.getAddress()
           );

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -206,7 +206,7 @@ describe("ZapMedia", () => {
     });
 
     describe("View Functions", () => {
-      describe("#fetchBalanceOf", () => {
+      describe.only("#fetchBalanceOf", () => {
         it("Should reject if the owner is a zero address", async () => {
           await signerOneConnected
             .fetchBalanceOf(ethers.constants.AddressZero)
@@ -216,8 +216,8 @@ describe("ZapMedia", () => {
         });
 
         it("Should reject if the owner is a zero address through a custom media", async () => {
-          await signerOneConnected
-            .fetchBalanceOf(ethers.constants.AddressZero, customMediaAddress)
+          await customMediaSigner1
+            .fetchBalanceOf(ethers.constants.AddressZero)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchBalanceOf): The (owner) address cannot be a zero address."
             );
@@ -237,57 +237,56 @@ describe("ZapMedia", () => {
         });
 
         it("Should fetch the owner balance through a custom collection", async () => {
-          const balance = await ownerConnected.fetchBalanceOf(
-            await signerOne.getAddress(),
-            customMediaAddress
+          const balance = await customMediaSigner1.fetchBalanceOf(
+            await signerOne.getAddress()
           );
 
           expect(parseInt(balance._hex)).to.equal(1);
         });
+      });
 
-        describe("#fetchContentURI", () => {
-          it("should reject if the token id does not exist", async () => {
-            await ownerConnected
-              .fetchContentURI(5)
-              .should.be.rejectedWith(
-                "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
-              );
-          });
-
-          it("Should reject if the token id does not exist on a custom media", async () => {
-            await ownerConnected
-              .fetchContentURI(1, customMediaAddress)
-              .should.be.rejectedWith(
-                "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
-              );
-          });
-
-          it("Should reject if the customMediaAddress is a zero address", async () => {
-            await ownerConnected
-              .fetchContentURI(0, ethers.constants.AddressZero)
-              .should.be.rejectedWith(
-                "Invariant failed: ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
-              );
-          });
-
-          it("Should fetch the content uri on a custom media", async () => {
-            const firstContentURI = await ownerConnected.fetchContentURI(
-              0,
-              customMediaAddress
+      describe("#fetchContentURI", () => {
+        it("should reject if the token id does not exist", async () => {
+          await ownerConnected
+            .fetchContentURI(5)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
             );
+        });
 
-            expect(firstContentURI).to.equal(tokenURI);
-          });
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await ownerConnected
+            .fetchContentURI(1, customMediaAddress)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
+            );
+        });
 
-          it("should fetch the content uri", async () => {
-            const firstTokenURI = await ownerConnected.fetchContentURI(0);
+        it("Should reject if the customMediaAddress is a zero address", async () => {
+          await ownerConnected
+            .fetchContentURI(0, ethers.constants.AddressZero)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
+            );
+        });
 
-            const secondTokenURI = await ownerConnected.fetchContentURI(1);
+        it("Should fetch the content uri on a custom media", async () => {
+          const firstContentURI = await ownerConnected.fetchContentURI(
+            0,
+            customMediaAddress
+          );
 
-            expect(firstTokenURI).to.equal(tokenURI);
+          expect(firstContentURI).to.equal(tokenURI);
+        });
 
-            expect(secondTokenURI).to.equal(tokenURI);
-          });
+        it("should fetch the content uri", async () => {
+          const firstTokenURI = await ownerConnected.fetchContentURI(0);
+
+          const secondTokenURI = await ownerConnected.fetchContentURI(1);
+
+          expect(firstTokenURI).to.equal(tokenURI);
+
+          expect(secondTokenURI).to.equal(tokenURI);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -223,12 +223,12 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should fetch the owner balance on a custom media", async () => {
-          const balance = await ownerConnected.fetchBalanceOf(
+        it("Should fetch the owner balance on the main media", async () => {
+          const balance: BigNumberish = await ownerConnected.fetchBalanceOf(
             await signer.getAddress()
           );
 
-          const balanceOne = await ownerConnected.fetchBalanceOf(
+          const balanceOne: BigNumberish = await ownerConnected.fetchBalanceOf(
             await signerOne.getAddress()
           );
 
@@ -236,12 +236,17 @@ describe("ZapMedia", () => {
           expect(parseInt(balanceOne._hex)).to.equal(1);
         });
 
-        it("Should fetch the owner balance through a custom collection", async () => {
-          const balance = await customMediaSigner1.fetchBalanceOf(
-            await signerOne.getAddress()
-          );
+        it("Should fetch the owner balance through a custom media", async () => {
+          const balance0: BigNumberish =
+            await customMediaSigner1.fetchBalanceOf(await signer.getAddress());
 
-          expect(parseInt(balance._hex)).to.equal(1);
+          const balance1: BigNumberish =
+            await customMediaSigner1.fetchBalanceOf(
+              await signerOne.getAddress()
+            );
+
+          expect(parseInt(balance0._hex)).to.equal(0);
+          expect(parseInt(balance1._hex)).to.equal(1);
         });
       });
 


### PR DESCRIPTION
## Summary
Closes #389 

## Implementation
 - [x] Removed the ```customMediaAddress``` argument from the ```fetchBalanceOf``` function
 - [x] Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [x] Kept the error handler that checks if there is a zero address
 - [x] Returnd the ```balanceOf``` function
 - [x] Refactored the ```fetchBalanceOf``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Before Refactor
```
 public async fetchBalanceOf(
    owner: string,
    customMediaAddress?: BigNumberish
  ): Promise<BigNumber> {
    if (owner == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchBalanceOf): The (owner) address cannot be a zero address."
      );
    }

    if (customMediaAddress !== undefined) {
      return this.media.attach(customMediaAddress).balanceOf(owner);
    } else {
      return this.media.balanceOf(owner);
    }
  }
```

After refactoring and achieving the same output due to the ```customMediaAddress``` added to the constructor

```
 public async fetchBalanceOf(owner: string): Promise<BigNumber> {
    if (owner == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchBalanceOf): The (owner) address cannot be a zero address."
      );
    }

    return this.media.balanceOf(owner);
  }
```

<img width="684" alt="Screen Shot 2022-02-06 at 5 00 04 PM" src="https://user-images.githubusercontent.com/42893948/152703127-80ebfb72-9600-4b19-9271-a9f76fd02bc6.png">

