### PR TITLE
Refactor FetchOwnerOf

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -93,16 +93,9 @@ class ZapMedia {
   /**
    * Fetches the owner of the specified media on an instance of the Zap Media Contract
    * @param mediaId Numerical identifier for a minted token
-   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
-  public async fetchOwnerOf(
-    mediaId: BigNumberish,
-    customMediaAddress?: string
-  ): Promise<string> {
+  public async fetchOwnerOf(mediaId: BigNumberish): Promise<string> {
     try {
-      if (customMediaAddress !== undefined) {
-        return await this.media.attach(customMediaAddress).ownerOf(mediaId);
-      }
       return await this.media.ownerOf(mediaId);
     } catch {
       invariant(false, "ZapMedia (fetchOwnerOf): The token id does not exist.");

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -296,8 +296,8 @@ describe("ZapMedia", () => {
       });
 
       describe("#fetchOwnerOf", () => {
-        it("Should reject if the token id does not exist", async () => {
-          // Should throw an error due to the token id not existing on the mainmedia
+        it("Should reject if the token id does not exist on the main media", async () => {
+          // Should throw an error due to the token id not existing on the main media
           await ownerConnected
             .fetchOwnerOf(12)
             .should.be.rejectedWith(
@@ -307,14 +307,14 @@ describe("ZapMedia", () => {
 
         it("Should reject if the token id does not exist on a custom media", async () => {
           // Should throw an error due to the token id not existing on the custom media
-          await ownerConnected
-            .fetchOwnerOf(7, customMediaAddress)
+          await customMediaSigner1
+            .fetchOwnerOf(7)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchOwnerOf): The token id does not exist."
             );
         });
 
-        it("Should fetch an owner of a token id", async () => {
+        it("Should fetch an owner of a token id on the main media", async () => {
           // Returns the owner address of tokenId 0 on the main media contract
           const tokenOwner: string = await ownerConnected.fetchOwnerOf(0);
 
@@ -330,9 +330,11 @@ describe("ZapMedia", () => {
 
         it("Should fetch an owner of a token id on a custom media", async () => {
           // The owner of tokenId 0 on the custom media should equal the address of signerOne
-          await ownerConnected
-            .fetchOwnerOf(0, customMediaAddress)
+          const tokenOwner: string = await customMediaSigner1
+            .fetchOwnerOf(0)
             .should.eventually.equal(await signerOne.getAddress());
+
+          expect(tokenOwner).to.equal(await signerOne.getAddress());
         });
       });
 


### PR DESCRIPTION
## Summary
Closes #391 

## Implementation
 - [x] Removed the ```customMediaAddress``` argument from the ```fetchOwnerOf``` function
 - [x] Removed the if statement checking if the customMediaAddress is undefined
 - [x]  Kept the error handler that checks if media tokenId exists
 - [x]  Refactored the ```fetchOwnerOf``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Before refactor

```
public async fetchOwnerOf(
    mediaId: BigNumberish,
    customMediaAddress?: string
  ): Promise<string> {
    try {
      if (customMediaAddress !== undefined) {
        return await this.media.attach(customMediaAddress).ownerOf(mediaId);
      }
      return await this.media.ownerOf(mediaId);
    } catch {
      invariant(false, "ZapMedia (fetchOwnerOf): The token id does not exist.");
    }
  }
```

After refactoring and achieving the same output due to the ```customMediaAddress``` added to the constructor

```
 public async fetchOwnerOf(mediaId: BigNumberish): Promise<string> {
    try {
      return await this.media.ownerOf(mediaId);
    } catch {
      invariant(false, "ZapMedia (fetchOwnerOf): The token id does not exist.");
    }
  }
```