### PR TITLE
Refactor FetchMediaOfOwnerByIndex

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -106,12 +106,10 @@ class ZapMedia {
    * Fetches the mediaId of the specified owner by index on an instance of the Zap Media Contract
    * @param owner Address of who the tokenId belongs to.
    * @param index The position of a tokenId that an address owns.
-   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchMediaOfOwnerByIndex(
     owner: string,
-    index: BigNumberish,
-    customMediaAddress?: string
+    index: BigNumberish
   ): Promise<BigNumber> {
     // If the owner is a zero address throw an error
     if (owner == ethers.constants.AddressZero) {
@@ -121,16 +119,7 @@ class ZapMedia {
       );
     }
 
-    // If customMediaAddress is not undefined attach the address to the main media contract
-    // create a custom media contract instance and invoke tokenOfOwnerByIndex
-    if (customMediaAddress !== undefined) {
-      return this.media
-        .attach(customMediaAddress)
-        .tokenOfOwnerByIndex(owner, index);
-      // If the customMediaAddress is undefined invoke tokenOfOwnerByIndex on the main media
-    } else {
-      return this.media.tokenOfOwnerByIndex(owner, index);
-    }
+    return this.media.tokenOfOwnerByIndex(owner, index);
   }
 
   /**

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -534,7 +534,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchMediaOfOwnerByIndex", () => {
+      describe("#fetchMediaOfOwnerByIndex", () => {
         it("Should throw an error if the (owner) is a zero address on the main media", async () => {
           // fetchMediaOfOwnerByIndex will fail due to a zero address passed in as the owner
           await ownerConnected

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -544,6 +544,15 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should throw an error if the (owner) is a zero address on a custom media", async () => {
+          // fetchMediaOfOwnerByIndex will fail due to a zero address passed in as the owner
+          await customMediaSigner1
+            .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
+            );
+        });
+
         it("Should return the token of the owner by index on the main media", async () => {
           // Returns the tokenId owner (signers[0]) minted on the main media contract
           const fetchToken = await ownerConnected.fetchMediaOfOwnerByIndex(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -534,8 +534,8 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#tokenOfOwnerByIndex", () => {
-        it("Should throw an error if the (owner) is a zero address", async () => {
+      describe.only("#fetchMediaOfOwnerByIndex", () => {
+        it("Should throw an error if the (owner) is a zero address on the main media", async () => {
           // fetchMediaOfOwnerByIndex will fail due to a zero address passed in as the owner
           await ownerConnected
             .fetchMediaOfOwnerByIndex(ethers.constants.AddressZero, 0)
@@ -544,7 +544,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should return the token of the owner by index", async () => {
+        it("Should return the token of the owner by index on the main media", async () => {
           // Returns the tokenId owner (signers[0]) minted on the main media contract
           const fetchToken = await ownerConnected.fetchMediaOfOwnerByIndex(
             await signer.getAddress(),
@@ -566,10 +566,9 @@ describe("ZapMedia", () => {
 
         it("Should return the token of an owner by index from a custom media", async () => {
           // Returns the tokenId signerOne (signers[1]) minted on their media contract
-          const fetchToken = await signerOneConnected.fetchMediaOfOwnerByIndex(
+          const fetchToken = await customMediaSigner1.fetchMediaOfOwnerByIndex(
             await signerOne.getAddress(),
-            0,
-            customMediaAddress
+            0
           );
 
           // Expect signerOne (signers[1]) to own tokenId 0 on their own media contract


### PR DESCRIPTION
## Summary
Closes #393 

## Implementation
 - [x] Removed the  ```customMediaAddress``` argument from the ```fetchMediaOfOwnerByIndex ``` function
 - [x]  Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [x] Kept the error handler that checks if the owner is a zero address
 - [x] Refactored the ```fetchMediaOfOwnerByIndex``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Before refactor

```
public async fetchMediaOfOwnerByIndex(
    owner: string,
    index: BigNumberish,
    customMediaAddress?: string
  ): Promise<BigNumber> {
    // If the owner is a zero address throw an error
    if (owner == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
      );
    }

    // If customMediaAddress is not undefined attach the address to the main media contract
    // create a custom media contract instance and invoke tokenOfOwnerByIndex
    if (customMediaAddress !== undefined) {
      return this.media
        .attach(customMediaAddress)
        .tokenOfOwnerByIndex(owner, index);
      // If the customMediaAddress is undefined invoke tokenOfOwnerByIndex on the main media
    } else {
      return this.media.tokenOfOwnerByIndex(owner, index);
    }
  }
```

After refactoring

```
public async fetchMediaOfOwnerByIndex(
    owner: string,
    index: BigNumberish
  ): Promise<BigNumber> {
    // If the owner is a zero address throw an error
    if (owner == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchMediaOfOwnerByIndex): The (owner) address cannot be a zero address."
      );
    }

    return this.media.tokenOfOwnerByIndex(owner, index);
  }
```
<img width="901" alt="Screen Shot 2022-02-07 at 7 44 22 AM" src="https://user-images.githubusercontent.com/42893948/152790412-4ba93547-bfe2-4917-9112-2c957cd72fc8.png">


<img width="901" alt="Screen Shot 2022-02-07 at 7 43 38 AM" src="https://user-images.githubusercontent.com/42893948/152790291-7c59659c-c756-47e4-af35-7532bcfda078.png">



