### PR TITLE
Refactor FetchContentURI

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -124,7 +124,7 @@ class ZapMedia {
 
   /**
    * Fetches the content uri for the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
    */
   public async fetchContentURI(mediaId: BigNumberish): Promise<string> {
     try {

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -125,27 +125,8 @@ class ZapMedia {
   /**
    * Fetches the content uri for the specified media on an instance of the Zap Media Contract
    * @param mediaId
-   * @param customMediaAddress
    */
-  public async fetchContentURI(
-    mediaId: BigNumberish,
-    customMediaAddress?: string
-  ): Promise<string> {
-    if (customMediaAddress == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
-      );
-    }
-
-    if (customMediaAddress !== undefined) {
-      try {
-        return await this.media.attach(customMediaAddress).tokenURI(mediaId);
-      } catch {
-        invariant(false, "ZapMedia (fetchContentURI): TokenId does not exist.");
-      }
-    }
-
+  public async fetchContentURI(mediaId: BigNumberish): Promise<string> {
     try {
       return await this.media.tokenURI(mediaId);
     } catch {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -251,7 +251,7 @@ describe("ZapMedia", () => {
       });
 
       describe("#fetchContentURI", () => {
-        it("should reject if the token id does not exist", async () => {
+        it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
             .fetchContentURI(5)
             .should.be.rejectedWith(
@@ -260,35 +260,30 @@ describe("ZapMedia", () => {
         });
 
         it("Should reject if the token id does not exist on a custom media", async () => {
-          await ownerConnected
+          await customMediaSigner1
             .fetchContentURI(1)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
             );
         });
 
-        it("Should reject if the customMediaAddress is a zero address", async () => {
-          await ownerConnected
-            .fetchContentURI(0)
-            .should.be.rejectedWith(
-              "Invariant failed: ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
-            );
-        });
+        it("Should fetch the content uri on the main media", async () => {
+          const firstTokenURI: string = await ownerConnected.fetchContentURI(0);
 
-        it("Should fetch the content uri on a custom media", async () => {
-          const firstContentURI = await ownerConnected.fetchContentURI(0);
-
-          expect(firstContentURI).to.equal(tokenURI);
-        });
-
-        it("should fetch the content uri", async () => {
-          const firstTokenURI = await ownerConnected.fetchContentURI(0);
-
-          const secondTokenURI = await ownerConnected.fetchContentURI(1);
+          const secondTokenURI: string = await ownerConnected.fetchContentURI(
+            1
+          );
 
           expect(firstTokenURI).to.equal(tokenURI);
 
           expect(secondTokenURI).to.equal(tokenURI);
+        });
+
+        it("Should fetch the content uri on a custom media", async () => {
+          const firstContentURI: string =
+            await customMediaSigner1.fetchContentURI(0);
+
+          expect(firstContentURI).to.equal(tokenURI);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -261,7 +261,7 @@ describe("ZapMedia", () => {
 
         it("Should reject if the token id does not exist on a custom media", async () => {
           await ownerConnected
-            .fetchContentURI(1, customMediaAddress)
+            .fetchContentURI(1)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
             );
@@ -269,17 +269,14 @@ describe("ZapMedia", () => {
 
         it("Should reject if the customMediaAddress is a zero address", async () => {
           await ownerConnected
-            .fetchContentURI(0, ethers.constants.AddressZero)
+            .fetchContentURI(0)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
             );
         });
 
         it("Should fetch the content uri on a custom media", async () => {
-          const firstContentURI = await ownerConnected.fetchContentURI(
-            0,
-            customMediaAddress
-          );
+          const firstContentURI = await ownerConnected.fetchContentURI(0);
 
           expect(firstContentURI).to.equal(tokenURI);
         });


### PR DESCRIPTION
## Summary
Closes #395 

## Implemenetation
 - [x] Removed the ```customMediaAddress``` argument from the ```fetchContentURI``` function
 - [x] Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [x] Removed the if statement checking if the ```custoMediaAddress``` is a zero address
 - [x] Removed the a dupicate try/catch that checks if the tokenId exists
 - [x]  Refactored the ```fetchContentURI``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview


Before refactor

```
 public async fetchContentURI(
    mediaId: BigNumberish,
    customMediaAddress?: string
  ): Promise<string> {
    if (customMediaAddress == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchContentURI): The (customMediaAddress) address cannot be a zero address."
      );
    }

    if (customMediaAddress !== undefined) {
      try {
        return await this.media.attach(customMediaAddress).tokenURI(mediaId);
      } catch {
        invariant(false, "ZapMedia (fetchContentURI): TokenId does not exist.");
      }
    }

    try {
      return await this.media.tokenURI(mediaId);
    } catch {
      invariant(false, "ZapMedia (fetchContentURI): TokenId does not exist.");
    }
  }
```

After refactor

```
 public async fetchContentURI(mediaId: BigNumberish): Promise<string> {
    try {
      return await this.media.tokenURI(mediaId);
    } catch {
      invariant(false, "ZapMedia (fetchContentURI): TokenId does not exist.");
    }
  }
```





