### PR TITLE
Refactor FetchContentHash

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -145,7 +145,6 @@ class ZapMedia {
   /**
    * Fetches the content hash for the specified media on the ZapMedia Contract
    * @param mediaId Numerical identifier for a minted token
-   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
   public async fetchContentHash(mediaId: BigNumberish): Promise<string> {
     // If the customMediaAddress is undefined use the main media instance to invoke the getTokenContentHashes function

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -147,7 +147,6 @@ class ZapMedia {
    * @param mediaId Numerical identifier for a minted token
    */
   public async fetchContentHash(mediaId: BigNumberish): Promise<string> {
-    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenContentHashes function
     return this.media.getTokenContentHashes(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -147,26 +147,7 @@ class ZapMedia {
    * @param mediaId Numerical identifier for a minted token
    * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
-  public async fetchContentHash(
-    mediaId: BigNumberish,
-    customMediaAddress?: string
-  ): Promise<string> {
-    // If the customMediaAddress is a zero address throw an error
-    if (customMediaAddress == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
-      );
-    }
-
-    // If the customMediaAddress does not equal undefined create a custom media instance and
-    // invoke the getTokenHashes function on that custom media
-    if (customMediaAddress !== undefined) {
-      return await this.media
-        .attach(customMediaAddress)
-        .getTokenContentHashes(mediaId);
-    }
-
+  public async fetchContentHash(mediaId: BigNumberish): Promise<string> {
     // If the customMediaAddress is undefined use the main media instance to invoke the getTokenContentHashes function
     return this.media.getTokenContentHashes(mediaId);
   }

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -330,8 +330,8 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchContentHash", () => {
-        it.only("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+      describe("#fetchContentHash", () => {
+        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
           // Return 0x0 due to a non existent tokenId on the main media
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(56);
@@ -340,7 +340,7 @@ describe("ZapMedia", () => {
           expect(onChainContentHash).eq(ethers.constants.HashZero);
         });
 
-        it.only("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+        it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
           // Returns 0x0 due to a non existent tokenId on a custom media
           const onChainContentHash: string =
             await customMediaSigner1.fetchContentHash(56);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -330,16 +330,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchContentHash", () => {
-        it("Should reject if the custom media is a zero address", async () => {
-          // If the custom media is a zero address it will throw an error
-          await ownerConnected
-            .fetchContentHash(0, ethers.constants.AddressZero)
-            .should.be.rejectedWith(
-              "Invariant failed: ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
-            );
-        });
-
+      describe.only("#fetchContentHash", () => {
         it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
           // Return 0x0 due to a non existent tokenId on the main media
           const onChainContentHash: string =

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -331,10 +331,19 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchContentHash", () => {
-        it("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
+        it.only("Should return 0x0 if tokenId doesn't exist on the main media", async () => {
           // Return 0x0 due to a non existent tokenId on the main media
           const onChainContentHash: string =
             await ownerConnected.fetchContentHash(56);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainContentHash).eq(ethers.constants.HashZero);
+        });
+
+        it.only("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+          // Returns 0x0 due to a non existent tokenId on a custom media
+          const onChainContentHash: string =
+            await customMediaSigner1.fetchContentHash(56);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainContentHash).eq(ethers.constants.HashZero);
@@ -360,19 +369,10 @@ describe("ZapMedia", () => {
           );
         });
 
-        it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
-          // Returns 0x0 due to a non existent tokenId on a custom media
-          const onChainContentHash: string =
-            await ownerConnected.fetchContentHash(56, customMediaAddress);
-
-          // tokenId doesn't exists, so we expect a default return value of 0x0000...
-          expect(onChainContentHash).eq(ethers.constants.HashZero);
-        });
-
         it("Should be able to fetch contentHash on a custom media", async () => {
           // Returns the content hash of tokenId 0 on a custom media
           const onChainContentHash: string =
-            await ownerConnected.fetchContentHash(0, customMediaAddress);
+            await customMediaSigner1.fetchContentHash(0);
 
           // Expect the returned content hash to equal the content hash set on mint
           expect(onChainContentHash).eq(


### PR DESCRIPTION
## Summary 
Closes #397 

## Implemenetation
 - [x] Removed the ```customMediaAddress``` argument from the ```fetchContentHash``` function
 - [x] Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [x] Removed the if statement checking if the ```custoMediaAddress``` is a zero address
 - [x] Removed the a dupicate try/catch that checks if the tokenId exists
 - [x]  Refactored the ```fetchContentHash``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```


## Visual Preview

Before refactor

```
public async fetchContentHash(
    mediaId: BigNumberish,
    customMediaAddress?: string
  ): Promise<string> {
    // If the customMediaAddress is a zero address throw an error
    if (customMediaAddress == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchContentHash): The (customMediaAddress) cannot be a zero address."
      );
    }

    // If the customMediaAddress does not equal undefined create a custom media instance and
    // invoke the getTokenHashes function on that custom media
    if (customMediaAddress !== undefined) {
      return await this.media
        .attach(customMediaAddress)
        .getTokenContentHashes(mediaId);
    }

    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenContentHashes function
    return this.media.getTokenContentHashes(mediaId);
  }
```

After refactoring

```
 /**
   * Fetches the content hash for the specified media on the ZapMedia Contract
   * @param mediaId Numerical identifier for a minted token
   */
  public async fetchContentHash(mediaId: BigNumberish): Promise<string> {
    return this.media.getTokenContentHashes(mediaId);
  }
```