### PR TITLE
Refactor FetchMetadataHash

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -153,28 +153,8 @@ class ZapMedia {
   /**
    * Fetches the metadata hash for the specified media on the ZapMedia Contract
    * @param mediaId Numerical identifier for a minted token
-   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
-  public async fetchMetadataHash(
-    mediaId: BigNumberish,
-    customMediaAddress?: string
-  ): Promise<string> {
-    // If the customMediaAddress is a zero address throw an error
-    if (customMediaAddress == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "ZapMedia (fetchMetadataHash): The (customMediaAddress) cannot be a zero address."
-      );
-    }
-
-    // If the customMediaAddress does not equal undefined create a custom media instance and
-    // invoke the getTokenMetadataHashes function on that custom media
-    if (customMediaAddress !== undefined) {
-      return await this.media
-        .attach(customMediaAddress)
-        .getTokenMetadataHashes(mediaId);
-    }
-    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenMetadataHashes function
+  public async fetchMetadataHash(mediaId: BigNumberish): Promise<string> {
     return this.media.getTokenMetadataHashes(mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -391,6 +391,15 @@ describe("ZapMedia", () => {
           expect(onChainMetadataHash).eq(ethers.constants.HashZero);
         });
 
+        it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
+          // Returns 0x0 due to a non existent tokenId on a custom media
+          const onChainMetadataHash: string =
+            await customMediaSigner1.fetchMetadataHash(1001);
+
+          // tokenId doesn't exists, so we expect a default return value of 0x0000...
+          expect(onChainMetadataHash).eq(ethers.constants.HashZero);
+        });
+
         it("Should be able to fetch metadataHash on the main media", async () => {
           // Returns the metadataHash of tokenId 0 on the main media
           const onChainMetadataHashOne: string =
@@ -411,19 +420,10 @@ describe("ZapMedia", () => {
           );
         });
 
-        it("Should return 0x0 if tokenId doesn't exist on a custom media", async () => {
-          // Returns 0x0 due to a non existent tokenId on a custom media
-          const onChainMetadataHash: string =
-            await ownerConnected.fetchMetadataHash(1001, customMediaAddress);
-
-          // tokenId doesn't exists, so we expect a default return value of 0x0000...
-          expect(onChainMetadataHash).eq(ethers.constants.HashZero);
-        });
-
         it("Should be able to fetch metadataHash on a custom media", async () => {
           // Returns the metadata hash of tokenId 0 on a custom media
           const onChainMetadataHash: string =
-            await ownerConnected.fetchMetadataHash(0, customMediaAddress);
+            await customMediaSigner1.fetchMetadataHash(0);
 
           // tokenId doesn't exists, so we expect a default return value of 0x0000...
           expect(onChainMetadataHash).eq(


### PR DESCRIPTION
## Summary
Closes #398

## Implementation
 - [ ]  Removed the ```customMediaAddress``` argument from the ```fetchMetadataHash``` function
 - [ ] Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [ ]  Removed the if statement checking if the customMediaAddress is a zero address
 - [ ]  Refactored the ```fetchMetadataHash``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

Before refactor

```
public async fetchMetadataHash(
    mediaId: BigNumberish,
    customMediaAddress?: string
  ): Promise<string> {
    // If the customMediaAddress is a zero address throw an error
    if (customMediaAddress == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchMetadataHash): The (customMediaAddress) cannot be a zero address."
      );
    }

    // If the customMediaAddress does not equal undefined create a custom media instance and
    // invoke the getTokenMetadataHashes function on that custom media
    if (customMediaAddress !== undefined) {
      return await this.media
        .attach(customMediaAddress)
        .getTokenMetadataHashes(mediaId);
    }
    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenMetadataHashes function
    return this.media.getTokenMetadataHashes(mediaId);
  }
```

After refactor 

```
  public async fetchMetadataHash(mediaId: BigNumberish): Promise<string> {
    return this.media.getTokenMetadataHashes(mediaId);
  }
```


