### PR TITLE
Refactor FetchCreator

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -173,29 +173,8 @@ class ZapMedia {
   /**
    * Fetches the creator for the specified media on an instance of the Zap Media Contract
    * @param mediaId Numerical identifier for a minted token
-   * @param customMediaAddress An optional argument that designates which media contract to connect to.
    */
-  public async fetchCreator(
-    mediaId: BigNumberish,
-    customMediaAddress?: string
-  ): Promise<string> {
-    // If the customMediaAddress is a zero address throw an error
-    if (customMediaAddress == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
-      );
-    }
-
-    // If the customMediaAddress does not equal undefined create a custom media instance and
-    // invoke the getTokenCreators function on that custom media
-    if (customMediaAddress !== undefined) {
-      return await this.media
-        .attach(customMediaAddress)
-        .getTokenCreators(mediaId);
-    }
-
-    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenCreators function
+  public async fetchCreator(mediaId: BigNumberish): Promise<string> {
     return await this.media.getTokenCreators(mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -588,7 +588,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchCreator", () => {
+      describe.only("#fetchCreator", () => {
         it("Should return a zero address if the token id does not exist on the main media", async () => {
           // Returns a zero address due to the nonexistent tokenId on the custom media
           const ownerAddr: string = await ownerConnected.fetchCreator(300);
@@ -599,10 +599,7 @@ describe("ZapMedia", () => {
 
         it("Should return a zero address if the token id does not exist on a custom media", async () => {
           // Returns a zero address due to the nonexistent tokenId on a custom media
-          const ownerAddr: string = await ownerConnected.fetchCreator(
-            12,
-            customMediaAddress
-          );
+          const ownerAddr: string = await customMediaSigner1.fetchCreator(12);
 
           // Expect the address to equal a zero address
           expect(ownerAddr).to.equal(ethers.constants.AddressZero);
@@ -624,10 +621,7 @@ describe("ZapMedia", () => {
 
         it("Should return the token creator on a custom media", async () => {
           // Returns the creator address of tokenId 0 on a custom media
-          const creator: string = await ownerConnected.fetchCreator(
-            0,
-            customMediaAddress
-          );
+          const creator: string = await customMediaSigner1.fetchCreator(0);
 
           // Expect the creator of tokenId 0 on the custom media to equal the signerOne (signers[1]) address
           expect(creator).to.equal(await signerOne.getAddress());

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -588,7 +588,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchCreator", () => {
+      describe("#fetchCreator", () => {
         it("Should return a zero address if the token id does not exist on the main media", async () => {
           // Returns a zero address due to the nonexistent tokenId on the custom media
           const ownerAddr: string = await ownerConnected.fetchCreator(300);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -589,15 +589,6 @@ describe("ZapMedia", () => {
       });
 
       describe("#fetchCreator", () => {
-        it("Should reject if the custom media is a zero address", async () => {
-          // Attempt to fetch a tokenId creator with a zero address as the media
-          await signerOneConnected
-            .fetchCreator(0, ethers.constants.AddressZero)
-            .should.be.rejectedWith(
-              "Invariant failed: ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
-            );
-        });
-
         it("Should return a zero address if the token id does not exist on the main media", async () => {
           // Returns a zero address due to the nonexistent tokenId on the custom media
           const ownerAddr: string = await ownerConnected.fetchCreator(300);


### PR DESCRIPTION
## Summary
Closes #399 

## Implementation
 - [x]  Removed the ```customMediaAddress``` argument from the ```fetchCreator``` function
 - [x] Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [x]  Removed the if statement checking if the ```customMediaAddress``` is a zero address
 - [x]  Refactored the ```fetchCreator``` tests and maintained custom media & main media functionality

## Visual Preview

Before refactor

``` 
public async fetchCreator(
    mediaId: BigNumberish,
    customMediaAddress?: string
  ): Promise<string> {
    // If the customMediaAddress is a zero address throw an error
    if (customMediaAddress == ethers.constants.AddressZero) {
      invariant(
        false,
        "ZapMedia (fetchCreator): The (customMediaAddress) cannot be a zero address."
      );
    }

    // If the customMediaAddress does not equal undefined create a custom media instance and
    // invoke the getTokenCreators function on that custom media
    if (customMediaAddress !== undefined) {
      return await this.media
        .attach(customMediaAddress)
        .getTokenCreators(mediaId);
    }

    // If the customMediaAddress is undefined use the main media instance to invoke the getTokenCreators function
    return await this.media.getTokenCreators(mediaId);
  }
```

After refactor

```
 public async fetchCreator(mediaId: BigNumberish): Promise<string> {
    return await this.media.getTokenCreators(mediaId);
  }

```