### PR TITLE
Refactory FetchTotalMedia

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -244,13 +244,8 @@ class ZapMedia {
   /**
    * Fetches the total amount of non-burned media that has been minted on an instance of the Zap Media Contract
    */
-  public async fetchTotalMedia(
-    customMediaAddress?: string
-  ): Promise<BigNumber> {
-    if (customMediaAddress !== undefined) {
-      return this.media.attach(customMediaAddress).totalSupply();
-    }
-    return this.media.totalSupply();
+  public async fetchTotalMedia(): Promise<BigNumber> {
+    return await this.media.totalSupply();
   }
 
   public async fetchMediaByIndex(index: BigNumberish): Promise<BigNumber> {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -568,8 +568,8 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchTotalMedia", () => {
-        it("Should fetch the total media minted", async () => {
+      describe.only("#fetchTotalMedia", () => {
+        it("Should fetch the total media minted on the main media", async () => {
           // Returns the total amount tokens minted on the main media
           const totalSupply: BigNumberish =
             await signerOneConnected.fetchTotalMedia();
@@ -581,7 +581,7 @@ describe("ZapMedia", () => {
         it("Should fetch the total media minted on a custom media", async () => {
           // Returns the total amount tokens minted on the custom media
           const totalSupply: BigNumberish =
-            await ownerConnected.fetchTotalMedia(customMediaAddress);
+            await customMediaSigner1.fetchTotalMedia();
 
           // Expect the totalSupply to equal 1
           expect(parseInt(totalSupply._hex)).to.equal(1);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -568,7 +568,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchTotalMedia", () => {
+      describe("#fetchTotalMedia", () => {
         it("Should fetch the total media minted on the main media", async () => {
           // Returns the total amount tokens minted on the main media
           const totalSupply: BigNumberish =


### PR DESCRIPTION
## Summary
Closes #400 

## Implementation
 - [ ]  Removed the ```customMediaAddress``` argument from the ```fetchTotalMedia``` function
 - [ ]  Removed the if statement checking if the ```customMediaAddress``` is undefined
 - [ ] Removed the if statement checking if the ```customMediaAddress``` is a zero address
 - [ ]  Refactored the ```fetchTotalMedia``` tests and maintained custom media & main media functionality

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview

<img width="674" alt="Screen Shot 2022-02-07 at 1 21 02 PM" src="https://user-images.githubusercontent.com/42893948/152848321-1e39c3fa-9151-4a43-969f-e30bbb9b898c.png">


Before refactor

```
public async fetchTotalMedia(
    customMediaAddress?: string
  ): Promise<BigNumber> {
    if (customMediaAddress !== undefined) {
      return this.media.attach(customMediaAddress).totalSupply();
    }
    return this.media.totalSupply();
  }

  public async fetchMediaByIndex(index: BigNumberish): Promise<BigNumber> {
    let totalMedia = await this.fetchTotalMedia();

    if (index > parseInt(totalMedia._hex) - 1) {
      invariant(false, "ZapMedia (tokenByIndex): Index out of range.");
    }

    return this.media.tokenByIndex(index);
  }
```

After refactoring

```
 public async fetchTotalMedia(): Promise<BigNumber> {
    return await this.media.totalSupply();
  }
````

