### PR TITLE
NFT SDK: Custom Media RemoveBid Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -571,6 +571,11 @@ class ZapMedia {
    * @param mediaId
    */
   public async removeBid(mediaId: BigNumberish): Promise<ContractTransaction> {
+    try {
+      await this.media.ownerOf(mediaId);
+    } catch {
+      invariant(false, "ZapMedia (removeBid): The token id does not exist.");
+    }
     return this.media.removeBid(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -576,6 +576,7 @@ class ZapMedia {
     } catch {
       invariant(false, "ZapMedia (removeBid): The token id does not exist.");
     }
+
     return this.media.removeBid(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -194,7 +194,7 @@ class ZapMedia {
       invariant(
         false,
         "ZapMedia (fetchCurrentBidShares): The (mediaAddress) cannot be a zero address."
-      )
+      );
     }
     return this.market.bidSharesForToken(mediaAddress, mediaId);
   }
@@ -564,6 +564,14 @@ class ZapMedia {
     } else {
       return this.media.removeAsk(mediaId);
     }
+  }
+
+  /**
+   * Removes the bid for the msg.sender on the specified media on an instance of the Zap Media Contract
+   * @param mediaId
+   */
+  public async removeBid(mediaId: BigNumberish): Promise<ContractTransaction> {
+    return this.media.removeBid(mediaId);
   }
 
   /**

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1782,7 +1782,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#removeBid", () => {
+      describe("#removeBid", () => {
         let mainBid: Bid;
         let customBid: Bid;
         let bidderCustomConnected: ZapMedia;
@@ -1797,7 +1797,7 @@ describe("ZapMedia", () => {
 
           customBid = constructBid(
             token.address,
-            200,
+            300,
             await signer.getAddress(),
             await signer.getAddress(),
             10
@@ -1867,7 +1867,7 @@ describe("ZapMedia", () => {
           const postMarketBal: string = await token.balanceOf(
             zapMarket.address
           );
-          expect(parseInt(postMarketBal)).to.equal(mainBid.amount);
+          expect(parseInt(postMarketBal)).to.equal(customBid.amount);
 
           await bidderCustomConnected
             .removeBid(200)
@@ -1876,7 +1876,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should remove a bid on the main media", async () => {
+        it("Should remove a bid on the main media", async () => {
           const preBidBal: string = await token.balanceOf(
             await signerOne.getAddress()
           );
@@ -1901,6 +1901,39 @@ describe("ZapMedia", () => {
 
           const bidderRemoveBal = await token.balanceOf(
             await signerOne.getAddress()
+          );
+
+          expect(parseInt(bidderRemoveBal)).to.equal(parseInt(preBidBal));
+
+          const marketRemoveBal = await token.balanceOf(zapMarket.address);
+          expect(parseInt(marketRemoveBal)).to.equal(parseInt(preMarketBal));
+        });
+
+        it("Should remove a bid on a custom media", async () => {
+          const preBidBal: string = await token.balanceOf(
+            await signer.getAddress()
+          );
+          expect(parseInt(preBidBal)).to.equal(520000000e18);
+
+          const preMarketBal: string = await token.balanceOf(zapMarket.address);
+          expect(parseInt(preMarketBal)).to.equal(0);
+
+          await bidderCustomConnected.setBid(0, customBid);
+
+          const postBidBal: string = await token.balanceOf(
+            await signer.getAddress()
+          );
+          expect(parseInt(postBidBal)).to.equal(520000000e18 - 200);
+
+          const postMarketBal: string = await token.balanceOf(
+            zapMarket.address
+          );
+          expect(parseInt(postMarketBal)).to.equal(customBid.amount);
+
+          await bidderCustomConnected.removeBid(0);
+
+          const bidderRemoveBal = await token.balanceOf(
+            await signer.getAddress()
           );
 
           expect(parseInt(bidderRemoveBal)).to.equal(parseInt(preBidBal));

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1808,9 +1808,10 @@ describe("ZapMedia", () => {
           await token
             .connect(signerOne)
             .approve(zapMarket.address, mainBid.amount);
+
           await token
             .connect(signer)
-            .approve(zapMarket.address, mainBid.amount);
+            .approve(zapMarket.address, customBid.amount);
 
           bidderCustomConnected = new ZapMedia(
             1337,
@@ -1873,6 +1874,39 @@ describe("ZapMedia", () => {
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (removeBid): The token id does not exist."
             );
+        });
+
+        it.only("Should remove a bid on the main media", async () => {
+          const preBidBal: string = await token.balanceOf(
+            await signerOne.getAddress()
+          );
+          expect(parseInt(preBidBal)).to.equal(mainBid.amount);
+
+          const preMarketBal: string = await token.balanceOf(zapMarket.address);
+          expect(parseInt(preMarketBal)).to.equal(0);
+
+          await signerOneConnected.setBid(0, mainBid);
+
+          const postBidBal: string = await token.balanceOf(
+            await signerOne.getAddress()
+          );
+          expect(parseInt(postBidBal)).to.equal(0);
+
+          const postMarketBal: string = await token.balanceOf(
+            zapMarket.address
+          );
+          expect(parseInt(postMarketBal)).to.equal(mainBid.amount);
+
+          await signerOneConnected.removeBid(0);
+
+          const bidderRemoveBal = await token.balanceOf(
+            await signerOne.getAddress()
+          );
+
+          expect(parseInt(bidderRemoveBal)).to.equal(parseInt(preBidBal));
+
+          const marketRemoveBal = await token.balanceOf(zapMarket.address);
+          expect(parseInt(marketRemoveBal)).to.equal(parseInt(preMarketBal));
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -703,10 +703,18 @@ describe("ZapMedia", () => {
             zapMedia.address,
             0
           );
-          expect(parseInt(onChainBidShares.creator.value._hex)).to.equal(parseInt(bidShares.creator.value._hex));
-          expect(parseInt(onChainBidShares.owner.value._hex)).to.equal(parseInt(bidShares.owner.value._hex));
-          expect(onChainBidShares.collaborators).to.deep.equal(bidShares.collaborators);
-          expect(onChainBidShares.collabShares).to.deep.equal(bidShares.collabShares);
+          expect(parseInt(onChainBidShares.creator.value._hex)).to.equal(
+            parseInt(bidShares.creator.value._hex)
+          );
+          expect(parseInt(onChainBidShares.owner.value._hex)).to.equal(
+            parseInt(bidShares.owner.value._hex)
+          );
+          expect(onChainBidShares.collaborators).to.deep.equal(
+            bidShares.collaborators
+          );
+          expect(onChainBidShares.collabShares).to.deep.equal(
+            bidShares.collabShares
+          );
         });
 
         it("Should return the bidShares of a token Id on the main media", async () => {
@@ -714,21 +722,38 @@ describe("ZapMedia", () => {
             zapMedia.address,
             1
           );
-          expect(parseInt(onChainBidShares.creator.value._hex)).to.equal(parseInt(bidShares.creator.value._hex));
-          expect(parseInt(onChainBidShares.owner.value._hex)).to.equal(parseInt(bidShares.owner.value._hex));
-          expect(onChainBidShares.collaborators).to.deep.equal(bidShares.collaborators);
-          expect(onChainBidShares.collabShares).to.deep.equal(bidShares.collabShares);
-        });
-        
-        it("should return the bidShares of a token Id on the custom media", async () => {
-          const onChainBidShares = await customMediaSigner1.fetchCurrentBidShares(
-            customMediaAddress,
-            0
+          expect(parseInt(onChainBidShares.creator.value._hex)).to.equal(
+            parseInt(bidShares.creator.value._hex)
           );
-          expect(parseInt(onChainBidShares.creator.value._hex)).to.equal(parseInt(bidShares.creator.value._hex));
-          expect(parseInt(onChainBidShares.owner.value._hex)).to.equal(parseInt(bidShares.owner.value._hex));
-          expect(onChainBidShares.collaborators).to.deep.equal(bidShares.collaborators);
-          expect(onChainBidShares.collabShares).to.deep.equal(bidShares.collabShares);
+          expect(parseInt(onChainBidShares.owner.value._hex)).to.equal(
+            parseInt(bidShares.owner.value._hex)
+          );
+          expect(onChainBidShares.collaborators).to.deep.equal(
+            bidShares.collaborators
+          );
+          expect(onChainBidShares.collabShares).to.deep.equal(
+            bidShares.collabShares
+          );
+        });
+
+        it("should return the bidShares of a token Id on the custom media", async () => {
+          const onChainBidShares =
+            await customMediaSigner1.fetchCurrentBidShares(
+              customMediaAddress,
+              0
+            );
+          expect(parseInt(onChainBidShares.creator.value._hex)).to.equal(
+            parseInt(bidShares.creator.value._hex)
+          );
+          expect(parseInt(onChainBidShares.owner.value._hex)).to.equal(
+            parseInt(bidShares.owner.value._hex)
+          );
+          expect(onChainBidShares.collaborators).to.deep.equal(
+            bidShares.collaborators
+          );
+          expect(onChainBidShares.collabShares).to.deep.equal(
+            bidShares.collabShares
+          );
         });
       });
     });
@@ -1756,6 +1781,8 @@ describe("ZapMedia", () => {
           );
         });
       });
+
+      describe("#removeBid", () => {});
 
       describe("#revokeApproval", () => {
         it("revokes an addresses approval of another address's media", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1782,7 +1782,50 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#removeBid", () => {});
+      describe.only("#removeBid", () => {
+        let bid: Bid;
+        beforeEach(async () => {
+          bid = constructBid(
+            token.address,
+            200,
+            await signerOne.getAddress(),
+            await signerOne.getAddress(),
+            10
+          );
+
+          await token.mint(await signerOne.getAddress(), 200);
+
+          await token.connect(signerOne).approve(zapMarket.address, bid.amount);
+        });
+
+        it("Should reject if the token id does not exist on the main media", async () => {
+          const preBidBal: string = await token.balanceOf(
+            await signerOne.getAddress()
+          );
+          expect(parseInt(preBidBal)).to.equal(bid.amount);
+
+          const preMarketBal: string = await token.balanceOf(zapMarket.address);
+          expect(parseInt(preMarketBal)).to.equal(0);
+
+          await signerOneConnected.setBid(0, bid);
+
+          const postBidBal: string = await token.balanceOf(
+            await signerOne.getAddress()
+          );
+          expect(parseInt(postBidBal)).to.equal(0);
+
+          const postMarketBal: string = await token.balanceOf(
+            zapMarket.address
+          );
+          expect(parseInt(postMarketBal)).to.equal(bid.amount);
+
+          await signerOneConnected
+            .removeBid(200)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (removeBid): The token id does not exist."
+            );
+        });
+      });
 
       describe("#revokeApproval", () => {
         it("revokes an addresses approval of another address's media", async () => {


### PR DESCRIPTION
## Summary
Closes #312 

## Implementation
 - [x] Added error handling to check if the token id exists
 - [x] Added the ```"Should reject if the token id does not exist on the main media"``` test
 - [x] Added the ```Should reject if the token id does not exist on a custom media``` test
 - [x] Added the ```Should remove a bid on the main media```
 - [x] Added the ```Should remove a bid on a custom media```
 - [x] Unit tests for the ```removeBid``` function passing for main & custom media contracts

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="900" alt="Screen Shot 2022-02-11 at 3 05 19 PM" src="https://user-images.githubusercontent.com/42893948/153662361-b4f4bde9-e4c9-4796-931e-dd4c8030fc45.png">

