### PR TITLE
NFT SDK: Custom Media UpdateContentURI Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -297,10 +297,11 @@ class ZapMedia {
     tokenURI: string
   ): Promise<ContractTransaction> {
     try {
-      return await this.media.updateTokenURI(mediaId, tokenURI);
-    } catch (err) {
+      await this.media.ownerOf(mediaId);
+    } catch {
       invariant(false, "ZapMedia (updateContentURI): TokenId does not exist.");
     }
+    return await this.media.updateTokenURI(mediaId, tokenURI);
   }
 
   /**fetches the media specified Signature nonce. if signature nonce does not exist, function

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -301,6 +301,13 @@ class ZapMedia {
     } catch {
       invariant(false, "ZapMedia (updateContentURI): TokenId does not exist.");
     }
+
+    try {
+      validateURI(tokenURI);
+    } catch (err: any) {
+      return Promise.reject(err.message);
+    }
+
     return await this.media.updateTokenURI(mediaId, tokenURI);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -296,8 +296,10 @@ class ZapMedia {
     mediaId: number,
     tokenURI: string
   ): Promise<ContractTransaction> {
+    let owner: string;
+
     try {
-      await this.media.ownerOf(mediaId);
+      owner = await this.media.ownerOf(mediaId);
     } catch {
       invariant(false, "ZapMedia (updateContentURI): TokenId does not exist.");
     }
@@ -306,6 +308,28 @@ class ZapMedia {
       validateURI(tokenURI);
     } catch (err: any) {
       return Promise.reject(err.message);
+    }
+
+    // Returns the address approved for the tokenId by the owner
+    const approveAddr: string = await this.media.getApproved(mediaId);
+
+    // Returns true/false if the operator was approved for all by the owner
+    const approveForAllStatus: boolean = await this.media.isApprovedForAll(
+      owner,
+      await this.signer.getAddress()
+    );
+
+    // Checks if the caller is not approved, not approved for all, and not the owner.
+    // If the caller meets the three conditions throw an error
+    if (
+      approveAddr == ethers.constants.AddressZero &&
+      approveForAllStatus == false &&
+      owner !== (await this.signer.getAddress())
+    ) {
+      invariant(
+        false,
+        "ZapMedia (updateContentURI): Caller is not approved nor the owner."
+      );
     }
 
     return await this.media.updateTokenURI(mediaId, tokenURI);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -792,12 +792,12 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should throw an error if the fetchContentURI tokenId does not exist", async () => {
-          await ownerConnected.fetchContentURI(0).catch((err) => {
-            expect(err.message).to.equal(
-              "Invariant failed: ZapMedia (fetchContentURI): TokenId does not exist."
+        it("Should reject if the caller is not the owner or approved on the main media", async () => {
+          await signerOneConnected
+            .updateContentURI(0, "https://newTokenURI.com")
+            .should.be.rejectedWith(
+              "ZapMedia (updateContentURI): Caller is not approved nor the owner."
             );
-          });
         });
 
         it("Should update the content uri", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -826,6 +826,27 @@ describe("ZapMedia", () => {
           expect(tokenURI).to.equal("https://newTokenURI.com");
         });
 
+        it("Should update the content uri if approved on a custom media", async () => {
+          const preApproveAddr: string = await customMediaSigner0.fetchApproved(
+            0
+          );
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await customMediaSigner1.approve(await signer.getAddress(), 0);
+
+          const postApproveAddr: string =
+            await customMediaSigner0.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signer.getAddress());
+
+          await customMediaSigner0.updateContentURI(
+            0,
+            "https://newTokenURI.com"
+          );
+
+          const tokenURI: string = await customMediaSigner0.fetchContentURI(0);
+          expect(tokenURI).to.equal("https://newTokenURI.com");
+        });
+
         it("Should update the content uri", async () => {
           // Returns tokenId 0's tokenURI
           const fetchTokenURI = await ownerConnected.fetchContentURI(0);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -800,6 +800,14 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should reject if the caller is not the owner or approved on a custom media", async () => {
+          await customMediaSigner0
+            .updateContentURI(0, "https://newTokenURI.com")
+            .should.be.rejectedWith(
+              "ZapMedia (updateContentURI): Caller is not approved nor the owner."
+            );
+        });
+
         it("Should update the content uri", async () => {
           // Returns tokenId 0's tokenURI
           const fetchTokenURI = await ownerConnected.fetchContentURI(0);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -759,7 +759,7 @@ describe("ZapMedia", () => {
     });
 
     describe("Write Functions", () => {
-      describe.only("#updateContentURI", () => {
+      describe("#updateContentURI", () => {
         it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
             .updateContentURI(4, "https://newTokenURI.com")

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -808,6 +808,21 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should update the content uri if approved on the main media", async () => {
+          const preApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
+
+          const postApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signerOne.getAddress());
+
+          await signerOneConnected.updateContentURI(
+            0,
+            "https://newTokenURI.com"
+          );
+        });
+
         it("Should update the content uri", async () => {
           // Returns tokenId 0's tokenURI
           const fetchTokenURI = await ownerConnected.fetchContentURI(0);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -784,14 +784,12 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should throw an error if the updateContentURI tokenId does not exist", async () => {
-          await ownerConnected
-            .updateContentURI(0, "www.newURI.com")
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: ZapMedia (updateContentURI): TokenId does not exist."
-              );
-            });
+        it("Should reject if the tokenURI does not begin with `https://` on a custom media", async () => {
+          await customMediaSigner1
+            .updateContentURI(0, "http://newTokenURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: http://newTokenURI.com must begin with `https://`"
+            );
         });
 
         it("Should throw an error if the fetchContentURI tokenId does not exist", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -843,25 +843,33 @@ describe("ZapMedia", () => {
             "https://newTokenURI.com"
           );
 
-          const tokenURI: string = await customMediaSigner0.fetchContentURI(0);
-          expect(tokenURI).to.equal("https://newTokenURI.com");
+          const fetchNewURI: string = await customMediaSigner0.fetchContentURI(
+            0
+          );
+          expect(fetchNewURI).to.equal("https://newTokenURI.com");
         });
 
-        it("Should update the content uri", async () => {
-          // Returns tokenId 0's tokenURI
-          const fetchTokenURI = await ownerConnected.fetchContentURI(0);
-
-          // The returned tokenURI should equal the tokenURI configured in the mediaDataOne
+        it("Should update the content uri on the main media by owner", async () => {
+          const fetchTokenURI: string = await ownerConnected.fetchContentURI(0);
           expect(fetchTokenURI).to.equal(mediaDataOne.tokenURI);
 
-          // Updates tokenId 0's tokenURI
-          await ownerConnected.updateContentURI(0, "https://newURI.com");
+          await ownerConnected.updateContentURI(0, "https://newTokenURI.com");
 
-          // Returns tokenId 0's tokenURI
-          const fetchNewURI = await ownerConnected.fetchContentURI(0);
+          const fetchNewURI: string = await ownerConnected.fetchContentURI(0);
 
-          // The new tokenURI returned should equal the updatedURI
-          expect(fetchNewURI).to.equal("https://newURI.com");
+          expect(fetchNewURI).to.equal("https://newTokenURI.com");
+        });
+
+        it("Should update the content uri on a custom media by owner", async () => {
+          await customMediaSigner1.updateContentURI(
+            0,
+            "https://newTokenURI.com"
+          );
+
+          const fetchNewURI: string = await customMediaSigner1.fetchContentURI(
+            0
+          );
+          expect(fetchNewURI).to.equal("https://newTokenURI.com");
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -821,6 +821,9 @@ describe("ZapMedia", () => {
             0,
             "https://newTokenURI.com"
           );
+
+          const tokenURI: string = await signerOneConnected.fetchContentURI(0);
+          expect(tokenURI).to.equal("https://newTokenURI.com");
         });
 
         it("Should update the content uri", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -760,6 +760,13 @@ describe("ZapMedia", () => {
 
     describe("Write Functions", () => {
       describe.only("#updateContentURI", () => {
+        it.only("Should reject if the token id does not exist on the main media", async () => {
+          await ownerConnected
+            .updateContentURI(4, "https://newTokenURI/com")
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (updateContentURI): TokenId does not exist."
+            );
+        });
         it("Should thrown an error if the tokenURI does not begin with `https://` on the main media", async () => {
           mediaDataOne.tokenURI = "http://example.com";
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -759,8 +759,8 @@ describe("ZapMedia", () => {
     });
 
     describe("Write Functions", () => {
-      describe("#updateContentURI", () => {
-        it("Should thrown an error if the tokenURI does not begin with `https://`", async () => {
+      describe.only("#updateContentURI", () => {
+        it("Should thrown an error if the tokenURI does not begin with `https://` on the main media", async () => {
           mediaDataOne.tokenURI = "http://example.com";
 
           await ownerConnected.mint(mediaDataOne, bidShares).catch((err) => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -760,13 +760,22 @@ describe("ZapMedia", () => {
 
     describe("Write Functions", () => {
       describe.only("#updateContentURI", () => {
-        it.only("Should reject if the token id does not exist on the main media", async () => {
+        it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
-            .updateContentURI(4, "https://newTokenURI/com")
+            .updateContentURI(4, "https://newTokenURI.com")
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (updateContentURI): TokenId does not exist."
             );
         });
+
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await customMediaSigner1
+            .updateContentURI(4, "https://newTokenURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (updateContentURI): TokenId does not exist."
+            );
+        });
+
         it("Should thrown an error if the tokenURI does not begin with `https://` on the main media", async () => {
           mediaDataOne.tokenURI = "http://example.com";
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -776,14 +776,12 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should thrown an error if the tokenURI does not begin with `https://` on the main media", async () => {
-          mediaDataOne.tokenURI = "http://example.com";
-
-          await ownerConnected.mint(mediaDataOne, bidShares).catch((err) => {
-            expect(err).to.equal(
-              "Invariant failed: http://example.com must begin with `https://`"
+        it("Should reject if the tokenURI does not begin with `https://` on the main media", async () => {
+          await ownerConnected
+            .updateContentURI(0, "http://newTokenURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: http://newTokenURI.com must begin with `https://`"
             );
-          });
         });
 
         it("Should throw an error if the updateContentURI tokenId does not exist", async () => {


### PR DESCRIPTION
## Summary
Closes #416 

## Implementation
 - [x] Added error handling checking if the mediaId exists
 - [x] Added error handling if the new uri is valid
 - [x] Added error handling checking if the caller is either the owner or approved
 - [x] Added  the ```Should reject if the token id does not exist on the main media``` test
 - [x] Added the ```Should reject if the token id does not exist on a custom media``` test
 - [x] Added the ```Should reject if the tokenURI does not begin with `https://` on the main media``` test
 - [x] Added the ```Should reject if the tokenURI does not begin with `https://` on a custom media``` test
 - [x] Added the ```Should reject if the caller is not the owner or approved on the main media``` test
 - [x] Added the ```Should reject if the caller is not the owner or approved on a custom media```
 - [x] Added the ```Should update the content uri if approved on the main media``` test
 - [x] Added the ```Should update the content uri if approved on a custom media``` test
 - [x] Added the ```Should update the content uri on the main media by owner``` test
 - [x] Added the ```Should update the content uri on a custom media by owner``` test
 - [x] Unit tests passing for the ```updateContentURI``` function for the main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/src/zapMedia.ts```

## Visual Preview
<img width="898" alt="Screen Shot 2022-02-11 at 6 41 16 PM" src="https://user-images.githubusercontent.com/42893948/153685114-9aef5161-88aa-4b59-ab80-65846106b0e4.png">

