### PR TITLE
NFT SDK: Custom Media RemoveAsk Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -577,7 +577,7 @@ class ZapMedia {
 
   /**
    * Removes the ask on the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
    */
   public async removeAsk(mediaId: BigNumberish): Promise<ContractTransaction> {
     const ask = await this.market.currentAskForToken(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1799,13 +1799,13 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#removeAsk", () => {
-        it("Should throw an error if the removeAsk tokenId does not exist", async () => {
+        it("Should throw an error if the removeAsk tokenId does not exist on the main media", async () => {
           ask = constructAsk(zapMedia.address, 100);
-          await ownerConnected.removeAsk(400).catch((err) => {
-            expect(err.message).to.equal(
+          await ownerConnected
+            .removeAsk(400)
+            .should.be.rejectedWith(
               "Invariant failed: ZapMedia (removeAsk): TokenId does not exist."
             );
-          });
         });
 
         it("Should throw an error if the tokenId exists but an ask was not set", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -38,7 +38,7 @@ import {
   signPermitMessage,
   signMintWithSigMessage,
 } from "./test_utils";
-import { EIP712Signature, Bid, BidShares } from "../src/types";
+import { EIP712Signature, Bid, BidShares, Ask } from "../src/types";
 import { BlobOptions } from "buffer";
 import { SrvRecord } from "dns";
 
@@ -1799,7 +1799,7 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#removeAsk", () => {
-        it("Should throw an error if the removeAsk tokenId does not exist on the main media", async () => {
+        it("Should reject if the tokenId does not exist on the main media", async () => {
           ask = constructAsk(zapMedia.address, 100);
           await ownerConnected
             .removeAsk(400)
@@ -1808,7 +1808,16 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should throw an error if the tokenId exists but an ask was not set on the main media", async () => {
+        it("Should reject if the tokenId does not exist on a custom media", async () => {
+          ask = constructAsk(customMediaAddress, 100);
+          await customMediaSigner1
+            .removeAsk(400)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (removeAsk): TokenId does not exist."
+            );
+        });
+
+        it("Should reject if the ask was never set on the main media", async () => {
           await ownerConnected
             .removeAsk(0)
             .should.be.rejectedWith(
@@ -1816,18 +1825,26 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should remove an ask", async () => {
+        it("Should reject if the ask was never set on a custom media", async () => {
+          await customMediaSigner1
+            .removeAsk(0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (removeAsk): Ask was never set."
+            );
+        });
+
+        it("Should remove an ask on the main media", async () => {
           ask = constructAsk(zapMedia.address, 100);
 
-          const owner = await ownerConnected.fetchOwnerOf(0);
+          const owner: string = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
 
-          const getApproved = await ownerConnected.fetchApproved(0);
+          const getApproved: string = await ownerConnected.fetchApproved(0);
           expect(getApproved).to.equal(ethers.constants.AddressZero);
 
           await ownerConnected.setAsk(0, ask);
 
-          const onChainAsk = await ownerConnected.fetchCurrentAsk(
+          const onChainAsk: Ask = await ownerConnected.fetchCurrentAsk(
             zapMedia.address,
             0
           );
@@ -1837,10 +1854,40 @@ describe("ZapMedia", () => {
 
           await ownerConnected.removeAsk(0);
 
-          const onChainAskRemoved = await ownerConnected.fetchCurrentAsk(
+          const onChainAskRemoved: Ask = await ownerConnected.fetchCurrentAsk(
             zapMedia.address,
             0
           );
+
+          expect(parseInt(onChainAskRemoved.amount.toString())).to.equal(0);
+          expect(onChainAskRemoved.currency).to.equal(
+            ethers.constants.AddressZero
+          );
+        });
+
+        it("Should remove an ask on a custom media", async () => {
+          ask = constructAsk(customMediaAddress, 100);
+
+          const owner: string = await customMediaSigner0.fetchOwnerOf(0);
+          expect(owner).to.equal(await signerOne.getAddress());
+
+          const getApproved: string = await customMediaSigner0.fetchApproved(0);
+          expect(getApproved).to.equal(ethers.constants.AddressZero);
+
+          await customMediaSigner1.setAsk(0, ask);
+
+          const onChainAsk: Ask = await customMediaSigner0.fetchCurrentAsk(
+            customMediaAddress,
+            0
+          );
+
+          expect(parseInt(onChainAsk.amount.toString())).to.equal(ask.amount);
+          expect(onChainAsk.currency).to.equal(customMediaAddress);
+
+          await customMediaSigner1.removeAsk(0);
+
+          const onChainAskRemoved: Ask =
+            await customMediaSigner0.fetchCurrentAsk(customMediaAddress, 0);
 
           expect(parseInt(onChainAskRemoved.amount.toString())).to.equal(0);
           expect(onChainAskRemoved.currency).to.equal(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1808,12 +1808,12 @@ describe("ZapMedia", () => {
             );
         });
 
-        it("Should throw an error if the tokenId exists but an ask was not set", async () => {
-          await ownerConnected.removeAsk(0).catch((err) => {
-            expect(err.message).to.equal(
+        it("Should throw an error if the tokenId exists but an ask was not set on the main media", async () => {
+          await ownerConnected
+            .removeAsk(0)
+            .should.be.rejectedWith(
               "Invariant failed: ZapMedia (removeAsk): Ask was never set."
             );
-          });
         });
 
         it("Should remove an ask", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1798,7 +1798,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#removeAsk", () => {
+      describe("#removeAsk", () => {
         it("Should reject if the tokenId does not exist on the main media", async () => {
           ask = constructAsk(zapMedia.address, 100);
           await ownerConnected

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1798,7 +1798,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#removeAsk", () => {
+      describe.only("#removeAsk", () => {
         it("Should throw an error if the removeAsk tokenId does not exist", async () => {
           ask = constructAsk(zapMedia.address, 100);
           await ownerConnected.removeAsk(400).catch((err) => {


### PR DESCRIPTION
## Summary
Closes #417 

## Implementation
- [x] Refactored the ```Should reject if the tokenId does not exist on the main media``` test and assertion syntax
- [x] Added the ```Should reject if the tokenId does not exist on a custom media``` test
- [x] Refactored the ```Should reject if the ask was never set on the main media``` test and assertion syntax
- [x] Added the ```Should reject if the ask was never set on a custom media``` test
- [x] Refactored the ```Should remove an ask on the main media``` test and assertion syntax
- [x] Added the ```Should remove an ask on a custom media``` test
- [x] Unit tests for ```removeAsk``` function are passing for main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="912" alt="Screen Shot 2022-02-14 at 9 32 50 AM" src="https://user-images.githubusercontent.com/42893948/153883512-8989c51c-532d-4a38-ba95-4c93b7a5ae89.png">

