### PR TITLE
NFT SDK: Custom Media FetchCurrentAsk Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -201,7 +201,7 @@ class ZapMedia {
 
   /**
    * Fetches the current ask for the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
    */
   public async fetchCurrentAsk(
     mediaAddress: string,

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -207,6 +207,12 @@ class ZapMedia {
     mediaAddress: string,
     mediaId: BigNumberish
   ): Promise<Ask> {
+    if (mediaAddress == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (fetchCurrentAsk): The (customMediaAddress) cannot be a zero address."
+      );
+    }
     return this.market.currentAskForToken(mediaAddress, mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -207,12 +207,6 @@ class ZapMedia {
     mediaAddress: string,
     mediaId: BigNumberish
   ): Promise<Ask> {
-    if (mediaAddress == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "ZapMedia (fetchCurrentAsk): The (customMediaAddress) cannot be a zero address."
-      );
-    }
     return this.market.currentAskForToken(mediaAddress, mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1901,7 +1901,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should remove an ask on a custom media", async () => {
-          ask = constructAsk(customMediaAddress, 100);
+          ask = constructAsk(token.address, 100);
 
           const owner: string = await customMediaSigner0.fetchOwnerOf(0);
           expect(owner).to.equal(await signerOne.getAddress());
@@ -1917,7 +1917,7 @@ describe("ZapMedia", () => {
           );
 
           expect(parseInt(onChainAsk.amount.toString())).to.equal(ask.amount);
-          expect(onChainAsk.currency).to.equal(customMediaAddress);
+          expect(onChainAsk.currency).to.equal(token.address);
 
           await customMediaSigner1.removeAsk(0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1707,7 +1707,7 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
-        describe.only("#fetchCurrentAsk", () => {
+        describe("#fetchCurrentAsk", () => {
           it("Should return null values if the media is a zero address with a valid token id", async () => {
             const fetchAsk: Ask = await ownerConnected.fetchCurrentAsk(
               ethers.constants.AddressZero,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1708,14 +1708,6 @@ describe("ZapMedia", () => {
         });
 
         describe.only("#fetchCurrentAsk", () => {
-          it.only("Should reject if the media is a zero address", async () => {
-            await ownerConnected
-              .fetchCurrentAsk(ethers.constants.AddressZero, 0)
-              .should.be.rejectedWith(
-                "Invariant failed: ZapMedia (fetchCurrentAsk): The (customMediaAddress) cannot be a zero address."
-              );
-          });
-
           it("Should return null values if the media is a zero address with a valid token id", async () => {
             const fetchAddress = await ownerConnected.fetchCurrentAsk(
               ethers.constants.AddressZero,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1709,29 +1709,36 @@ describe("ZapMedia", () => {
 
         describe.only("#fetchCurrentAsk", () => {
           it("Should return null values if the media is a zero address with a valid token id", async () => {
-            const fetchAddress = await ownerConnected.fetchCurrentAsk(
+            const fetchAsk: Ask = await ownerConnected.fetchCurrentAsk(
               ethers.constants.AddressZero,
               0
             );
 
-            expect(fetchAddress.currency).to.equal(
-              ethers.constants.AddressZero
-            );
+            expect(fetchAsk.currency).to.equal(ethers.constants.AddressZero);
 
-            expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
+            expect(parseInt(fetchAsk.amount.toString())).to.equal(0);
           });
 
-          it("Should return null values if the token id does not exist", async () => {
-            const fetchAddress = await ownerConnected.fetchCurrentAsk(
+          it("Should return null values if the token id does not exist on the main media", async () => {
+            const fetchAsk: Ask = await ownerConnected.fetchCurrentAsk(
               zapMedia.address,
               10
             );
 
-            expect(fetchAddress.currency).to.equal(
-              ethers.constants.AddressZero
+            expect(fetchAsk.currency).to.equal(ethers.constants.AddressZero);
+
+            expect(parseInt(fetchAsk.amount.toString())).to.equal(0);
+          });
+
+          it("Should return null values if the token id does not exist on a custom media", async () => {
+            const fetchAsk: Ask = await customMediaSigner1.fetchCurrentAsk(
+              customMediaAddress,
+              10
             );
 
-            expect(parseInt(fetchAddress.amount.toString())).to.equal(0);
+            expect(fetchAsk.currency).to.equal(ethers.constants.AddressZero);
+
+            expect(parseInt(fetchAsk.amount.toString())).to.equal(0);
           });
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1708,6 +1708,14 @@ describe("ZapMedia", () => {
         });
 
         describe.only("#fetchCurrentAsk", () => {
+          it.only("Should reject if the media is a zero address", async () => {
+            await ownerConnected
+              .fetchCurrentAsk(ethers.constants.AddressZero, 0)
+              .should.be.rejectedWith(
+                "Invariant failed: ZapMedia (fetchCurrentAsk): The (customMediaAddress) cannot be a zero address."
+              );
+          });
+
           it("Should return null values if the media is a zero address with a valid token id", async () => {
             const fetchAddress = await ownerConnected.fetchCurrentAsk(
               ethers.constants.AddressZero,

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1740,6 +1740,34 @@ describe("ZapMedia", () => {
 
             expect(parseInt(fetchAsk.amount.toString())).to.equal(0);
           });
+
+          it("Should fetch the current ask on the main media", async () => {
+            ask = constructAsk(token.address, 100);
+
+            await ownerConnected.setAsk(0, ask);
+
+            const fetchAsk = await ownerConnected.fetchCurrentAsk(
+              zapMedia.address,
+              0
+            );
+
+            expect(parseInt(fetchAsk.amount.toString())).to.equal(ask.amount);
+            expect(fetchAsk.currency).to.equal(token.address);
+          });
+
+          it("Should fetch the current ask on a custom media", async () => {
+            ask = constructAsk(token.address, 100);
+
+            await customMediaSigner1.setAsk(0, ask);
+
+            const fetchAsk = await ownerConnected.fetchCurrentAsk(
+              customMediaAddress,
+              0
+            );
+
+            expect(parseInt(fetchAsk.amount.toString())).to.equal(ask.amount);
+            expect(fetchAsk.currency).to.equal(token.address);
+          });
         });
 
         describe("#fetchCurrentBidForBidder", () => {
@@ -1807,7 +1835,7 @@ describe("ZapMedia", () => {
 
       describe("#removeAsk", () => {
         it("Should reject if the tokenId does not exist on the main media", async () => {
-          ask = constructAsk(zapMedia.address, 100);
+          ask = constructAsk(token.address, 100);
           await ownerConnected
             .removeAsk(400)
             .should.be.rejectedWith(
@@ -1841,7 +1869,7 @@ describe("ZapMedia", () => {
         });
 
         it("Should remove an ask on the main media", async () => {
-          ask = constructAsk(zapMedia.address, 100);
+          ask = constructAsk(token.address, 100);
 
           const owner: string = await ownerConnected.fetchOwnerOf(0);
           expect(owner).to.equal(await signer.getAddress());
@@ -1857,7 +1885,7 @@ describe("ZapMedia", () => {
           );
 
           expect(parseInt(onChainAsk.amount.toString())).to.equal(ask.amount);
-          expect(onChainAsk.currency).to.equal(zapMedia.address);
+          expect(onChainAsk.currency).to.equal(token.address);
 
           await ownerConnected.removeAsk(0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -1707,7 +1707,7 @@ describe("ZapMedia", () => {
           expect(parseInt(bidderPostBal._hex)).to.equal(600);
         });
 
-        describe("#fetchCurrentAsk", () => {
+        describe.only("#fetchCurrentAsk", () => {
           it("Should return null values if the media is a zero address with a valid token id", async () => {
             const fetchAddress = await ownerConnected.fetchCurrentAsk(
               ethers.constants.AddressZero,


### PR DESCRIPTION
## Summary
Closes #419 

## Implementation
 - [x] Refactored the ```Should return null values if the token id does not exist on the main media```
 - [x] Added the ```Should return null values if the token id does not exist on a custom media``` test
 - [x] Added the ```Should fetch the current ask on the main media``` test
 - [x] Added the ```Should fetch the current ask on a custom media``` test
 - [x]  Unit tests for ```fetchCurrentAsk``` function are passing for main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="907" alt="Screen Shot 2022-02-14 at 11 25 27 AM" src="https://user-images.githubusercontent.com/42893948/153904273-96dc46ba-4eb7-4441-aa66-37c725c56e3b.png">