### PR TITLE
NFT SDK: Custom Media UpdateMetadataURI Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -621,19 +621,46 @@ class ZapMedia {
     mediaId: BigNumberish,
     metadataURI: string
   ): Promise<ContractTransaction> {
+    // Will store the address of the token owner if the tokenId exists
+    let owner: string;
+
     try {
       validateURI(metadataURI);
     } catch (err: any) {
       return Promise.reject(err.message);
     }
 
-    const gasEstimate = await this.media.estimateGas.updateTokenMetadataURI(
-      mediaId,
-      metadataURI
-    );
-    return this.media.updateTokenMetadataURI(mediaId, metadataURI, {
-      gasLimit: gasEstimate,
-    });
+    // // Checks if the tokenId exists. If the tokenId exists store the owner
+    // // address in the variable and if it doesnt throw an error
+    // try {
+    //   owner = await this.media.ownerOf(mediaId);
+    // } catch {
+    //   invariant(false, "ZapMedia (updateMetadataURI): TokenId does not exist.");
+    // }
+
+    // // Returns the address approved for the tokenId by the owner
+    // const approveAddr: string = await this.media.getApproved(mediaId);
+
+    // // Returns true/false if the operator was approved for all by the owner
+    // const approveForAllStatus: boolean = await this.media.isApprovedForAll(
+    //   owner,
+    //   await this.signer.getAddress()
+    // );
+
+    // // Checks if the caller is not approved, not approved for all, and not the owner.
+    // // If the caller meets the three conditions throw an error
+    // if (
+    //   approveAddr == ethers.constants.AddressZero &&
+    //   approveForAllStatus == false &&
+    //   owner !== (await this.signer.getAddress())
+    // ) {
+    //   invariant(
+    //     false,
+    //     "ZapMedia (updateMetadataURI): Caller is not approved nor the owner."
+    //   );
+    // }
+
+    return this.media.updateTokenMetadataURI(mediaId, metadataURI);
   }
 
   /**

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -630,13 +630,13 @@ class ZapMedia {
       return Promise.reject(err.message);
     }
 
-    // // Checks if the tokenId exists. If the tokenId exists store the owner
-    // // address in the variable and if it doesnt throw an error
-    // try {
-    //   owner = await this.media.ownerOf(mediaId);
-    // } catch {
-    //   invariant(false, "ZapMedia (updateMetadataURI): TokenId does not exist.");
-    // }
+    // Checks if the tokenId exists. If the tokenId exists store the owner
+    // address in the variable and if it doesnt throw an error
+    try {
+      owner = await this.media.ownerOf(mediaId);
+    } catch {
+      invariant(false, "ZapMedia (updateMetadataURI): TokenId does not exist.");
+    }
 
     // // Returns the address approved for the tokenId by the owner
     // const approveAddr: string = await this.media.getApproved(mediaId);

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -638,27 +638,27 @@ class ZapMedia {
       invariant(false, "ZapMedia (updateMetadataURI): TokenId does not exist.");
     }
 
-    // // Returns the address approved for the tokenId by the owner
-    // const approveAddr: string = await this.media.getApproved(mediaId);
+    // Returns the address approved for the tokenId by the owner
+    const approveAddr: string = await this.media.getApproved(mediaId);
 
-    // // Returns true/false if the operator was approved for all by the owner
-    // const approveForAllStatus: boolean = await this.media.isApprovedForAll(
-    //   owner,
-    //   await this.signer.getAddress()
-    // );
+    // Returns true/false if the operator was approved for all by the owner
+    const approveForAllStatus: boolean = await this.media.isApprovedForAll(
+      owner,
+      await this.signer.getAddress()
+    );
 
-    // // Checks if the caller is not approved, not approved for all, and not the owner.
-    // // If the caller meets the three conditions throw an error
-    // if (
-    //   approveAddr == ethers.constants.AddressZero &&
-    //   approveForAllStatus == false &&
-    //   owner !== (await this.signer.getAddress())
-    // ) {
-    //   invariant(
-    //     false,
-    //     "ZapMedia (updateMetadataURI): Caller is not approved nor the owner."
-    //   );
-    // }
+    // Checks if the caller is not approved, not approved for all, and not the owner.
+    // If the caller meets the three conditions throw an error
+    if (
+      approveAddr == ethers.constants.AddressZero &&
+      approveForAllStatus == false &&
+      owner !== (await this.signer.getAddress())
+    ) {
+      invariant(
+        false,
+        "ZapMedia (updateMetadataURI): Caller is not approved nor the owner."
+      );
+    }
 
     return this.media.updateTokenMetadataURI(mediaId, metadataURI);
   }

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -967,16 +967,15 @@ describe("ZapMedia", () => {
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });
 
-        it("Should update the metadata uri", async () => {
-          const fetchMetadataURI = await ownerConnected.fetchMetadataURI(0);
-          expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);
-
+        it.only("Should update the metadata uri by the owner on the main media", async () => {
           await ownerConnected.updateMetadataURI(
             0,
             "https://newMetadataURI.com"
           );
 
-          const newMetadataURI = await ownerConnected.fetchMetadataURI(0);
+          const newMetadataURI: string = await ownerConnected.fetchMetadataURI(
+            0
+          );
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -890,8 +890,16 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the token id does not exist on the main media", async () => {
+        it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
+            .updateMetadataURI(1001, "https://newMetadataURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (updateMetadataURI): TokenId does not exist."
+            );
+        });
+
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await customMediaSigner1
             .updateMetadataURI(1001, "https://newMetadataURI.com")
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (updateMetadataURI): TokenId does not exist."

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -922,7 +922,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should update the metadata uri by the approved on the main media", async () => {
+        it("Should update the metadata uri by the approved on the main media", async () => {
           const preApproveAddr: string = await ownerConnected.fetchApproved(0);
           expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
 
@@ -939,6 +939,30 @@ describe("ZapMedia", () => {
           const newMetadataURI: string = await ownerConnected.fetchMetadataURI(
             0
           );
+
+          expect(newMetadataURI).to.equal("https://newMetadataURI.com");
+        });
+
+        it("Should update the metadata uri by the approved on a custom media", async () => {
+          const preApproveAddr: string = await customMediaSigner1.fetchApproved(
+            0
+          );
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await customMediaSigner1.approve(await signer.getAddress(), 0);
+
+          const postApproveAddr: string =
+            await customMediaSigner1.fetchApproved(0);
+
+          expect(postApproveAddr).to.equal(await signer.getAddress());
+
+          await customMediaSigner0.updateMetadataURI(
+            0,
+            "https://newMetadataURI.com"
+          );
+
+          const newMetadataURI: string =
+            await customMediaSigner1.fetchMetadataURI(0);
 
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -967,7 +967,7 @@ describe("ZapMedia", () => {
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });
 
-        it.only("Should update the metadata uri by the owner on the main media", async () => {
+        it("Should update the metadata uri by the owner on the main media", async () => {
           await ownerConnected.updateMetadataURI(
             0,
             "https://newMetadataURI.com"
@@ -976,6 +976,17 @@ describe("ZapMedia", () => {
           const newMetadataURI: string = await ownerConnected.fetchMetadataURI(
             0
           );
+          expect(newMetadataURI).to.equal("https://newMetadataURI.com");
+        });
+
+        it.only("Should update the metadata uri by the owner on a custom media", async () => {
+          await customMediaSigner1.updateMetadataURI(
+            0,
+            "https://newMetadataURI.com"
+          );
+
+          const newMetadataURI: string =
+            await customMediaSigner0.fetchMetadataURI(0);
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });
       });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -906,8 +906,16 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the caller is not approved nor the owner on the main media", async () => {
+        it("Should reject if the caller is not approved nor the owner on the main media", async () => {
           await signerOneConnected
+            .updateMetadataURI(0, "https://newMetadataURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (updateMetadataURI): Caller is not approved nor the owner."
+            );
+        });
+
+        it("Should reject if the caller is not approved nor the owner on a custom media", async () => {
+          await customMediaSigner0
             .updateMetadataURI(0, "https://newMetadataURI.com")
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (updateMetadataURI): Caller is not approved nor the owner."

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -890,6 +890,14 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should reject if the token id does not exist on the main media", async () => {
+          await ownerConnected
+            .updateMetadataURI(1001, "https://newMetadataURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (updateMetadataURI): TokenId does not exist."
+            );
+        });
+
         it("Should update the metadata uri", async () => {
           const fetchMetadataURI = await ownerConnected.fetchMetadataURI(0);
           expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -922,6 +922,27 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should update the metadata uri by the approved on the main media", async () => {
+          const preApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
+
+          const postApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signerOne.getAddress());
+
+          await signerOneConnected.updateMetadataURI(
+            0,
+            "https://newMetadataURI.com"
+          );
+
+          const newMetadataURI: string = await ownerConnected.fetchMetadataURI(
+            0
+          );
+
+          expect(newMetadataURI).to.equal("https://newMetadataURI.com");
+        });
+
         it("Should update the metadata uri", async () => {
           const fetchMetadataURI = await ownerConnected.fetchMetadataURI(0);
           expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -873,7 +873,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#updateMetadataURI", () => {
+      describe("#updateMetadataURI", () => {
         it("Should reject if the metadataURI does not begin with `https://` on the main media", async () => {
           await ownerConnected
             .updateMetadataURI(0, "http://newMetadataURI.com")

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -874,14 +874,12 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#updateMetadataURI", () => {
-        it("Should thrown an error if the metadataURI does not begin with `https://`", async () => {
-          mediaDataOne.metadataURI = "http://example.com";
-
-          await ownerConnected.mint(mediaDataOne, bidShares).catch((err) => {
-            expect(err).to.equal(
-              "Invariant failed: http://example.com must begin with `https://`"
+        it("Should reject if the metadataURI does not begin with `https://` on the main media", async () => {
+          await ownerConnected
+            .updateMetadataURI(0, "http://newMetadataURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: http://newMetadataURI.com must begin with `https://`"
             );
-          });
         });
 
         it("Should update the metadata uri", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -979,7 +979,7 @@ describe("ZapMedia", () => {
           expect(newMetadataURI).to.equal("https://newMetadataURI.com");
         });
 
-        it.only("Should update the metadata uri by the owner on a custom media", async () => {
+        it("Should update the metadata uri by the owner on a custom media", async () => {
           await customMediaSigner1.updateMetadataURI(
             0,
             "https://newMetadataURI.com"

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -906,6 +906,14 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should reject if the caller is not approved nor the owner on the main media", async () => {
+          await signerOneConnected
+            .updateMetadataURI(0, "https://newMetadataURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (updateMetadataURI): Caller is not approved nor the owner."
+            );
+        });
+
         it("Should update the metadata uri", async () => {
           const fetchMetadataURI = await ownerConnected.fetchMetadataURI(0);
           expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -873,7 +873,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#updateMetadataURI", () => {
+      describe.only("#updateMetadataURI", () => {
         it("Should thrown an error if the metadataURI does not begin with `https://`", async () => {
           mediaDataOne.metadataURI = "http://example.com";
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -882,6 +882,14 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should reject if the metadataURI does not begin with `https://` on a custom media", async () => {
+          await customMediaSigner1
+            .updateMetadataURI(0, "http://newMetadataURI.com")
+            .should.be.rejectedWith(
+              "Invariant failed: http://newMetadataURI.com must begin with `https://`"
+            );
+        });
+
         it("Should update the metadata uri", async () => {
           const fetchMetadataURI = await ownerConnected.fetchMetadataURI(0);
           expect(fetchMetadataURI).to.equal(mediaDataOne.metadataURI);


### PR DESCRIPTION
## Summary
Closes #418 

## Implementation
 - [x] Added error handling checking if the token id exists for the ```updateMetadataURI``` function
 - [x] Added error handling checking if the caller is the token and owner and approved for the token
 - [x] Refactored the ```Should reject if the metadataURI does not begin with `https://` on the main media``` test
 - [x] Added the ```Should reject if the metadataURI does not begin with `https://` on a custom media``` test
 - [x] Added the ```Should reject if the token id does not exist on the main media``` test
 - [x] Added the ```Should reject if the token id does not exist on a custom media``` test
 - [x] Added the ```Should reject if the caller is not approved nor the owner on the main media``` test
 - [x] Added the ```Should reject if the caller is not approved nor the owner on a custom media``` test
 - [x] Adde the ```Should update the metadata uri by the approved on the main media``` test
 - [x] Added the ```Should update the metadata uri by the approved on a custom media``` test
 - [x] Added the ```Should update the metadata uri by the owner on the main media``` test
 - [x] Added the ```Should update the metadata uri by the owner on a custom media``` test
 - [x]  Unit tests for the ```updateMetadataURI`` `function are passing for main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="895" alt="Screen Shot 2022-02-14 at 1 18 44 PM" src="https://user-images.githubusercontent.com/42893948/153922888-ac081a0d-0c2d-4cd1-8bd2-eb6b8998eb99.png">


