### PR TITLE
NFT SDK: Custom Media RevokeApproval Functionality 

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -691,6 +691,14 @@ class ZapMedia {
   public async revokeApproval(
     mediaId: BigNumberish
   ): Promise<ContractTransaction> {
+    try {
+      return await this.media.ownerOf(mediaId);
+    } catch {
+      invariant(
+        false,
+        "ZapMedia (revokeApproval): The token id does not exist."
+      );
+    }
     return this.media.revokeApproval(mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -691,12 +691,35 @@ class ZapMedia {
   public async revokeApproval(
     mediaId: BigNumberish
   ): Promise<ContractTransaction> {
+    let owner: string;
     try {
-      return await this.media.ownerOf(mediaId);
+      owner = await this.media.ownerOf(mediaId);
     } catch {
       invariant(
         false,
         "ZapMedia (revokeApproval): The token id does not exist."
+      );
+    }
+
+    // Returns the address approved for the tokenId by the owner
+    const approveAddr: string = await this.media.getApproved(mediaId);
+
+    // Returns true/false if the operator was approved for all by the owner
+    const approveForAllStatus: boolean = await this.media.isApprovedForAll(
+      owner,
+      await this.signer.getAddress()
+    );
+
+    // Checks if the caller is not approved, not approved for all, and not the owner.
+    // If the caller meets the three conditions throw an error
+    if (
+      approveAddr == ethers.constants.AddressZero &&
+      approveForAllStatus == false &&
+      owner !== (await this.signer.getAddress())
+    ) {
+      invariant(
+        false,
+        "ZapMedia (revokeApproval): Caller is not approved nor the owner."
       );
     }
     return this.media.revokeApproval(mediaId);

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -686,7 +686,7 @@ class ZapMedia {
 
   /**
    * Revokes the approval of an approved account for the specified media on an instance of the Zap Media Contract
-   * @param mediaId
+   * @param mediaId Numerical identifier for a minted token
    */
   public async revokeApproval(
     mediaId: BigNumberish

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2218,6 +2218,21 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should revoke approval by the approved on the main media", async () => {
+          const preApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
+
+          const postApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signerOne.getAddress());
+
+          await signerOneConnected.revokeApproval(0);
+
+          const postRevokedAddr: string = await ownerConnected.fetchApproved(0);
+          expect(postRevokedAddr).to.equal(ethers.constants.AddressZero);
+        });
+
         it("revokes an addresses approval of another address's media", async () => {
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2218,7 +2218,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should revoke approval by the approved on the main media", async () => {
+        it("Should revoke approval by the approved on the main media", async () => {
           const preApproveAddr: string = await ownerConnected.fetchApproved(0);
           expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
 
@@ -2230,6 +2230,25 @@ describe("ZapMedia", () => {
           await signerOneConnected.revokeApproval(0);
 
           const postRevokedAddr: string = await ownerConnected.fetchApproved(0);
+          expect(postRevokedAddr).to.equal(ethers.constants.AddressZero);
+        });
+
+        it.only("Should revoke approval by the approved on a custom media", async () => {
+          const preApproveAddr: string = await customMediaSigner0.fetchApproved(
+            0
+          );
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await customMediaSigner1.approve(await signer.getAddress(), 0);
+
+          const postApproveAddr: string =
+            await customMediaSigner0.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signer.getAddress());
+
+          await customMediaSigner0.revokeApproval(0);
+
+          const postRevokedAddr: string =
+            await customMediaSigner0.fetchApproved(0);
           expect(postRevokedAddr).to.equal(ethers.constants.AddressZero);
         });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2202,6 +2202,14 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should reject if the caller is not approved nor the owner on the main media", async () => {
+          await signerOneConnected
+            .revokeApproval(0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (revokeApproval): Caller is not approved nor the owner."
+            );
+        });
+
         it("revokes an addresses approval of another address's media", async () => {
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2185,7 +2185,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#revokeApproval", () => {
+      describe("#revokeApproval", () => {
         it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
             .revokeApproval(400)
@@ -2252,7 +2252,7 @@ describe("ZapMedia", () => {
           expect(postRevokedAddr).to.equal(preApproveAddr);
         });
 
-        it.only("Should revoke approval by the owner on the main media", async () => {
+        it("Should revoke approval by the owner on the main media", async () => {
           const preApproveAddr: string = await ownerConnected.fetchApproved(0);
           expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
 
@@ -2266,6 +2266,26 @@ describe("ZapMedia", () => {
           await ownerConnected.revokeApproval(0);
 
           const postRevokedAddr: string = await ownerConnected.fetchApproved(0);
+
+          expect(postRevokedAddr).to.equal(preApproveAddr);
+        });
+
+        it("Should revoke approval by the owner on a custom media", async () => {
+          const preApproveAddr: string = await customMediaSigner0.fetchApproved(
+            0
+          );
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await customMediaSigner1.approve(await signer.getAddress(), 0);
+
+          const postApprovedAddr: string =
+            await customMediaSigner0.fetchApproved(0);
+          expect(postApprovedAddr).to.equal(await signer.getAddress());
+
+          await customMediaSigner1.revokeApproval(0);
+
+          const postRevokedAddr: string =
+            await customMediaSigner0.fetchApproved(0);
 
           expect(postRevokedAddr).to.equal(preApproveAddr);
         });

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2230,10 +2230,10 @@ describe("ZapMedia", () => {
           await signerOneConnected.revokeApproval(0);
 
           const postRevokedAddr: string = await ownerConnected.fetchApproved(0);
-          expect(postRevokedAddr).to.equal(ethers.constants.AddressZero);
+          expect(postRevokedAddr).to.equal(preApproveAddr);
         });
 
-        it.only("Should revoke approval by the approved on a custom media", async () => {
+        it("Should revoke approval by the approved on a custom media", async () => {
           const preApproveAddr: string = await customMediaSigner0.fetchApproved(
             0
           );
@@ -2249,19 +2249,25 @@ describe("ZapMedia", () => {
 
           const postRevokedAddr: string =
             await customMediaSigner0.fetchApproved(0);
-          expect(postRevokedAddr).to.equal(ethers.constants.AddressZero);
+          expect(postRevokedAddr).to.equal(preApproveAddr);
         });
 
-        it("revokes an addresses approval of another address's media", async () => {
+        it.only("Should revoke approval by the owner on the main media", async () => {
+          const preApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 
-          const approved = await ownerConnected.fetchApproved(0);
-          expect(approved).to.equal(await signerOne.getAddress());
+          const postApprovedAddr: string = await ownerConnected.fetchApproved(
+            0
+          );
+          expect(postApprovedAddr).to.equal(await signerOne.getAddress());
 
-          await signerOneConnected.revokeApproval(0);
+          await ownerConnected.revokeApproval(0);
 
-          const revokedStatus = await ownerConnected.fetchApproved(0);
-          expect(revokedStatus).to.equal(ethers.constants.AddressZero);
+          const postRevokedAddr: string = await ownerConnected.fetchApproved(0);
+
+          expect(postRevokedAddr).to.equal(preApproveAddr);
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2186,9 +2186,14 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#revokeApproval", () => {
-        it.only("Should reject if the token id does not exist", async () => {
-          await ownerConnected.revokeApproval(400);
+        it.only("Should reject if the token id does not exist on the main media", async () => {
+          await ownerConnected
+            .revokeApproval(400)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (revokeApproval): The token id does not exist."
+            );
         });
+
         it("revokes an addresses approval of another address's media", async () => {
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2185,7 +2185,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#revokeApproval", () => {
+      describe.only("#revokeApproval", () => {
         it("revokes an addresses approval of another address's media", async () => {
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2186,6 +2186,9 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#revokeApproval", () => {
+        it.only("Should reject if the token id does not exist", async () => {
+          await ownerConnected.revokeApproval(400);
+        });
         it("revokes an addresses approval of another address's media", async () => {
           await ownerConnected.approve(await signerOne.getAddress(), 0);
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2186,8 +2186,16 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#revokeApproval", () => {
-        it.only("Should reject if the token id does not exist on the main media", async () => {
+        it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
+            .revokeApproval(400)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (revokeApproval): The token id does not exist."
+            );
+        });
+
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await customMediaSigner1
             .revokeApproval(400)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (revokeApproval): The token id does not exist."

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2202,8 +2202,16 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the caller is not approved nor the owner on the main media", async () => {
+        it("Should reject if the caller is not approved nor the owner on the main media", async () => {
           await signerOneConnected
+            .revokeApproval(0)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (revokeApproval): Caller is not approved nor the owner."
+            );
+        });
+
+        it("Should reject if the caller is not approved nor the owner on a custom media", async () => {
+          await customMediaSigner0
             .revokeApproval(0)
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (revokeApproval): Caller is not approved nor the owner."


### PR DESCRIPTION
## Summary
Closes #420 

## Implementation
 - [x] Refactored the ```Should reject if the token id does not exist on the main media``` test
 - [x] Added the ```Should reject if the token id does not exist on a custom media``` test
 - [x] Added the ```Should reject if the caller is not approved nor the owner on the main media``` test
 - [x] Added the ```Should reject if the caller is not approved nor the owner on a custom media``` test
 - [x] Added the ```Should revoke approval by the approved on the main media``` test
 - [x] Added the ```Should revoke approval by the approved on a custom media``` test
 - [x] Added the ```Should revoke approval by the owner on the main media``` test
 - [x] Added the ```Should revoke approval by the owner on a custom media``` test
 - [x] Added error handling to the ```revokeApproval``` function checking if the token id exists
 - [x] Added error handling to the ```revokeApproval``` function checking if the caller is the owner or approved
 - [x] Unit tests for the ```revokeApproval``` function are passing for main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="900" alt="Screen Shot 2022-02-14 at 2 41 45 PM" src="https://user-images.githubusercontent.com/42893948/153934688-a60e6cb2-e03b-40d9-a2d6-bf2173b5b279.png">


