### PR TITLE
NFT SDK: Custom Media TransferFrom Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -417,6 +417,13 @@ class ZapMedia {
         "ZapMedia (transferFrom): The (from) address cannot be a zero address."
       );
     }
+
+    if (to == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (transferFrom): The (to) address cannot be a zero address."
+      );
+    }
     return this.media.transferFrom(from, to, mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -411,6 +411,12 @@ class ZapMedia {
     to: string,
     mediaId: BigNumberish
   ): Promise<ContractTransaction> {
+    if (from == ethers.constants.AddressZero) {
+      invariant(
+        false,
+        "ZapMedia (transferFrom): The (from) address cannot be a zero address."
+      );
+    }
     return this.media.transferFrom(from, to, mediaId);
   }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -402,9 +402,9 @@ class ZapMedia {
 
   /**
    * Transfers the specified media to the specified to address on an instance of the Zap Media Contract
-   * @param from
-   * @param to
-   * @param mediaId
+   * @param from The address of the owner who is transferring the token
+   * @param to The receiving address
+   * @param mediaId Numerical identifier for a minted token
    */
   public async transferFrom(
     from: string,

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -411,6 +411,7 @@ class ZapMedia {
     to: string,
     mediaId: BigNumberish
   ): Promise<ContractTransaction> {
+    let owner: string;
     if (from == ethers.constants.AddressZero) {
       invariant(
         false,
@@ -426,9 +427,31 @@ class ZapMedia {
     }
 
     try {
-      await this.media.ownerOf(mediaId);
+      owner = await this.media.ownerOf(mediaId);
     } catch {
       invariant(false, "ZapMedia (transferFrom): TokenId does not exist.");
+    }
+
+    // Returns the address approved for the tokenId by the owner
+    const approveAddr: string = await this.media.getApproved(mediaId);
+
+    // Returns true/false if the operator was approved for all by the owner
+    const approveForAllStatus: boolean = await this.media.isApprovedForAll(
+      owner,
+      await this.signer.getAddress()
+    );
+
+    // Checks if the caller is not approved, not approved for all, and not the owner.
+    // If the caller meets the three conditions throw an error
+    if (
+      approveAddr == ethers.constants.AddressZero &&
+      approveForAllStatus == false &&
+      owner !== (await this.signer.getAddress())
+    ) {
+      invariant(
+        false,
+        "ZapMedia (updateContentURI): Caller is not approved nor the owner."
+      );
     }
 
     return this.media.transferFrom(from, to, mediaId);

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -450,7 +450,7 @@ class ZapMedia {
     ) {
       invariant(
         false,
-        "ZapMedia (updateContentURI): Caller is not approved nor the owner."
+        "ZapMedia (transferFrom): Caller is not approved nor the owner."
       );
     }
 

--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -424,6 +424,13 @@ class ZapMedia {
         "ZapMedia (transferFrom): The (to) address cannot be a zero address."
       );
     }
+
+    try {
+      await this.media.ownerOf(mediaId);
+    } catch {
+      invariant(false, "ZapMedia (transferFrom): TokenId does not exist.");
+    }
+
     return this.media.transferFrom(from, to, mediaId);
   }
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2660,7 +2660,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#transferFrom", () => {
+      describe.only("#transferFrom", () => {
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2685,6 +2685,18 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should reject if the (to) is a zero address on the main media", async () => {
+          await ownerConnected
+            .transferFrom(
+              await signer.getAddress(),
+              ethers.constants.AddressZero,
+              0
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): The (to) address cannot be a zero address."
+            );
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2745,7 +2745,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the caller is not the owner or approved on a custom media", async () => {
+        it("Should reject if the caller is not the owner or approved on a custom media", async () => {
           await customMediaSigner0
             .transferFrom(
               await signerOne.getAddress(),
@@ -2755,6 +2755,25 @@ describe("ZapMedia", () => {
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (transferFrom): Caller is not approved nor the owner."
             );
+        });
+
+        it.only("Should transfer a token by the approved on the main media", async () => {
+          const preApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await ownerConnected.approve(await signerOne.getAddress(), 0);
+
+          const postApproveAddr: string = await ownerConnected.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signerOne.getAddress());
+
+          await signerOneConnected.transferFrom(
+            await signer.getAddress(),
+            await signerOne.getAddress(),
+            0
+          );
+
+          const newTokenOwner: string = await ownerConnected.fetchOwnerOf(0);
+          expect(newTokenOwner).to.equal(await signerOne.getAddress());
         });
 
         it("Should transfer token to another address", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2709,6 +2709,18 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should reject if the token id does not exist on the main media", async () => {
+          await ownerConnected
+            .transferFrom(
+              await signer.getAddress(),
+              await signerOne.getAddress(),
+              300
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): TokenId does not exist"
+            );
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2661,6 +2661,18 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#transferFrom", () => {
+        it("Should reject if the (from) is a zero address on the main media", async () => {
+          await ownerConnected
+            .transferFrom(
+              ethers.constants.AddressZero,
+              await signerOne.getAddress(),
+              0
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): The (from) address cannot be a zero address."
+            );
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2697,6 +2697,18 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should reject if the (to) is a zero address on a custom media", async () => {
+          await customMediaSigner1
+            .transferFrom(
+              await signerOne.getAddress(),
+              ethers.constants.AddressZero,
+              0
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): The (to) address cannot be a zero address."
+            );
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2660,7 +2660,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#transferFrom", () => {
+      describe("#transferFrom", () => {
         it("Should reject if the (from) is a zero address on the main media", async () => {
           await ownerConnected
             .transferFrom(

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2673,6 +2673,18 @@ describe("ZapMedia", () => {
             );
         });
 
+        it("Should reject if the (from) is a zero address on a custom media", async () => {
+          await customMediaSigner1
+            .transferFrom(
+              ethers.constants.AddressZero,
+              await signer.getAddress(),
+              0
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): The (from) address cannot be a zero address."
+            );
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2776,6 +2776,30 @@ describe("ZapMedia", () => {
           expect(newTokenOwner).to.equal(await signerOne.getAddress());
         });
 
+        it.only("Should transfer a token by the approved on a custom media", async () => {
+          const preApproveAddr: string = await customMediaSigner0.fetchApproved(
+            0
+          );
+          expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
+
+          await customMediaSigner1.approve(await signer.getAddress(), 0);
+
+          const postApproveAddr: string =
+            await customMediaSigner0.fetchApproved(0);
+          expect(postApproveAddr).to.equal(await signer.getAddress());
+
+          await customMediaSigner0.transferFrom(
+            await signerOne.getAddress(),
+            await signer.getAddress(),
+            0
+          );
+
+          const newTokenOwner: string = await customMediaSigner0.fetchOwnerOf(
+            0
+          );
+          expect(newTokenOwner).to.equal(await signer.getAddress());
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2709,12 +2709,24 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the token id does not exist on the main media", async () => {
+        it("Should reject if the token id does not exist on the main media", async () => {
           await ownerConnected
             .transferFrom(
               await signer.getAddress(),
               await signerOne.getAddress(),
               300
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): TokenId does not exist"
+            );
+        });
+
+        it("Should reject if the token id does not exist on a custom media", async () => {
+          await customMediaSigner1
+            .transferFrom(
+              await signerOne.getAddress(),
+              await signer.getAddress(),
+              1
             )
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (transferFrom): TokenId does not exist"

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2734,11 +2734,15 @@ describe("ZapMedia", () => {
         });
 
         it.only("Should reject if the caller is not the owner or approved on the main media", async () => {
-          await signerOneConnected.transferFrom(
-            await signer.getAddress(),
-            await signerOne.getAddress(),
-            0
-          );
+          await signerOneConnected
+            .transferFrom(
+              await signer.getAddress(),
+              await signerOne.getAddress(),
+              0
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): Caller is not approved nor the owner."
+            );
         });
 
         it("Should transfer token to another address", async () => {

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2757,7 +2757,7 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should transfer a token by the approved on the main media", async () => {
+        it("Should transfer a token by the approved on the main media", async () => {
           const preApproveAddr: string = await ownerConnected.fetchApproved(0);
           expect(preApproveAddr).to.equal(ethers.constants.AddressZero);
 
@@ -2776,7 +2776,7 @@ describe("ZapMedia", () => {
           expect(newTokenOwner).to.equal(await signerOne.getAddress());
         });
 
-        it.only("Should transfer a token by the approved on a custom media", async () => {
+        it("Should transfer a token by the approved on a custom media", async () => {
           const preApproveAddr: string = await customMediaSigner0.fetchApproved(
             0
           );
@@ -2800,18 +2800,15 @@ describe("ZapMedia", () => {
           expect(newTokenOwner).to.equal(await signer.getAddress());
         });
 
-        it("Should transfer token to another address", async () => {
-          const recipient = await signerOne.getAddress();
+        it.only("Should transfer a token by the owner on the main media", async () => {
+          await ownerConnected.transferFrom(
+            await signer.getAddress(),
+            await signerOne.getAddress(),
+            0
+          );
 
-          const owner = await ownerConnected.fetchOwnerOf(0);
-
-          expect(owner).to.equal(await signer.getAddress());
-
-          await ownerConnected.transferFrom(owner, recipient, 0);
-
-          const newOwner = await ownerConnected.fetchOwnerOf(0);
-
-          expect(newOwner).to.equal(recipient);
+          const newTokenOwner: string = await ownerConnected.fetchOwnerOf(0);
+          expect(newTokenOwner).to.equal(await signerOne.getAddress());
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2800,7 +2800,7 @@ describe("ZapMedia", () => {
           expect(newTokenOwner).to.equal(await signer.getAddress());
         });
 
-        it.only("Should transfer a token by the owner on the main media", async () => {
+        it("Should transfer a token by the owner on the main media", async () => {
           await ownerConnected.transferFrom(
             await signer.getAddress(),
             await signerOne.getAddress(),
@@ -2809,6 +2809,19 @@ describe("ZapMedia", () => {
 
           const newTokenOwner: string = await ownerConnected.fetchOwnerOf(0);
           expect(newTokenOwner).to.equal(await signerOne.getAddress());
+        });
+
+        it("Should transfer a token by the owner on a custom media", async () => {
+          await customMediaSigner1.transferFrom(
+            await signerOne.getAddress(),
+            await signer.getAddress(),
+            0
+          );
+
+          const newTokenOwner: string = await customMediaSigner0.fetchOwnerOf(
+            0
+          );
+          expect(newTokenOwner).to.equal(await signer.getAddress());
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2733,6 +2733,14 @@ describe("ZapMedia", () => {
             );
         });
 
+        it.only("Should reject if the caller is not the owner or approved on the main media", async () => {
+          await signerOneConnected.transferFrom(
+            await signer.getAddress(),
+            await signerOne.getAddress(),
+            0
+          );
+        });
+
         it("Should transfer token to another address", async () => {
           const recipient = await signerOne.getAddress();
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -2733,11 +2733,23 @@ describe("ZapMedia", () => {
             );
         });
 
-        it.only("Should reject if the caller is not the owner or approved on the main media", async () => {
+        it("Should reject if the caller is not the owner or approved on the main media", async () => {
           await signerOneConnected
             .transferFrom(
               await signer.getAddress(),
               await signerOne.getAddress(),
+              0
+            )
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (transferFrom): Caller is not approved nor the owner."
+            );
+        });
+
+        it.only("Should reject if the caller is not the owner or approved on a custom media", async () => {
+          await customMediaSigner0
+            .transferFrom(
+              await signerOne.getAddress(),
+              await signer.getAddress(),
               0
             )
             .should.be.rejectedWith(


### PR DESCRIPTION
## Summary
Closes #428 

## Implementation
 - [x] Added  error handling that checks if the ``` from``` argument is not a zero address
 - [x] Added error handling that checks if the ```to``` argument is not zero address
 - [x] Added error handling that checks if the ```mediaId``` argument exsits
 - [x] Added error handling to the ````transferFrom``` function checking if the caller is the owner or approved
 - [x]  Unit tests for the ```transferFrom``` function are passing for main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```