### PR TITLE
NFT SDK: Custom Media FetchMediaByIndex Functionality

### DIFF
--- a/sdk/nft/src/zapMedia.ts
+++ b/sdk/nft/src/zapMedia.ts
@@ -259,10 +259,10 @@ class ZapMedia {
   }
 
   public async fetchMediaByIndex(index: BigNumberish): Promise<BigNumber> {
-    let totalMedia = await this.fetchTotalMedia();
+    let totalMedia: BigNumberish = await this.fetchTotalMedia();
 
     if (index > parseInt(totalMedia._hex) - 1) {
-      invariant(false, "ZapMedia (tokenByIndex): Index out of range.");
+      invariant(false, "ZapMedia (fetchMediaByIndex): Index out of range.");
     }
 
     return this.media.tokenByIndex(index);

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -3309,18 +3309,20 @@ describe("ZapMedia", () => {
       });
 
       describe.only("#fetchMediaByIndex", () => {
-        it("Should get media instance by index in the media contract", async () => {
-          const tokenId = await ownerConnected.fetchMediaByIndex(0);
-
-          expect(parseInt(tokenId._hex)).to.equal(0);
+        it("Should reject if the index is out of range on the main media", async () => {
+          await ownerConnected
+            .fetchMediaByIndex(2)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchMediaByIndex): Index out of range."
+            );
         });
 
-        it("Should throw an error index out of range", async () => {
-          await ownerConnected.fetchMediaByIndex(1).catch((err) => {
-            expect(err.message).to.equal(
-              "Invariant failed: ZapMedia (tokenByIndex): Index out of range."
+        it("Should reject if the index is out of range on a custom media", async () => {
+          await customMediaSigner0
+            .fetchMediaByIndex(1)
+            .should.be.rejectedWith(
+              "Invariant failed: ZapMedia (fetchMediaByIndex): Index out of range."
             );
-          });
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -3308,7 +3308,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe.only("#fetchMediaByIndex", () => {
+      describe("#fetchMediaByIndex", () => {
         it("Should reject if the index is out of range on the main media", async () => {
           await ownerConnected
             .fetchMediaByIndex(2)
@@ -3323,6 +3323,37 @@ describe("ZapMedia", () => {
             .should.be.rejectedWith(
               "Invariant failed: ZapMedia (fetchMediaByIndex): Index out of range."
             );
+        });
+
+        it("Should fetch the token by index on the main media", async () => {
+          const firstToken: BigNumberish =
+            await ownerConnected.fetchMediaByIndex(0);
+          expect(parseInt(firstToken._hex)).to.equal(0);
+
+          const firstTokenOwner: string = await ownerConnected.fetchOwnerOf(
+            parseInt(firstToken._hex)
+          );
+          expect(firstTokenOwner).to.equal(await signer.getAddress());
+
+          const secondToken: BigNumberish =
+            await ownerConnected.fetchMediaByIndex(1);
+          expect(parseInt(secondToken._hex)).to.equal(1);
+
+          const secondTokenOwner: string = await ownerConnected.fetchOwnerOf(
+            parseInt(secondToken._hex)
+          );
+          expect(secondTokenOwner).to.equal(await signerOne.getAddress());
+        });
+
+        it("Should fetch the token by index on a custom media", async () => {
+          const firstToken: BigNumberish =
+            await customMediaSigner0.fetchMediaByIndex(0);
+          expect(parseInt(firstToken._hex)).to.equal(0);
+
+          const firstTokenOwner: string = await customMediaSigner0.fetchOwnerOf(
+            parseInt(firstToken._hex)
+          );
+          expect(firstTokenOwner).to.equal(await signerOne.getAddress());
         });
       });
 

--- a/sdk/nft/test/zapMedia.test.ts
+++ b/sdk/nft/test/zapMedia.test.ts
@@ -3308,7 +3308,7 @@ describe("ZapMedia", () => {
         });
       });
 
-      describe("#fetchMedia", () => {
+      describe.only("#fetchMediaByIndex", () => {
         it("Should get media instance by index in the media contract", async () => {
           const tokenId = await ownerConnected.fetchMediaByIndex(0);
 


### PR DESCRIPTION
## Summary
Closes #430 

## Implementation
 - [x] Added the ```Should reject if the index is out of range on the main media``` test
 - [x] Added the ```Should reject if the index is out of range on a custom media``` test
 - [x] Added the ```Should fetch the token by index on the main media``` test
 - [x] Added the ```Should fetch the token by index on a custom media``` test
 - [x] Unit tests for the ```fetchMediaByIndex``` function are passing for main & custom medias

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```

## Visual Preview
<img width="899" alt="Screen Shot 2022-02-15 at 1 48 44 PM" src="https://user-images.githubusercontent.com/42893948/154128722-58f729ef-12ce-460b-a4bf-9a4a0769cf9b.png">

