### PR TITLE
NFT SDK: CancelAuction Functionality

### DIFF
--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -44,15 +44,7 @@ class AuctionHouse {
   }
 
   public async fetchAuction(auctionId: BigNumberish): Promise<any> {
-    const auctionInfo = await this.auctionHouse.auctions(auctionId);
-    if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
-      invariant(
-        false,
-        "AuctionHouse (fetchAuction): AuctionId does not exist."
-      );
-    } else {
-      return auctionInfo;
-    }
+    return auctionId;
   }
 
   public async fetchAuctionFromTransactionReceipt(
@@ -234,7 +226,7 @@ class AuctionHouse {
   }
 
   public async cancelAuction(auctionId: BigNumberish) {
-    const auctionInfo: Auction = await this.fetchAuction(auctionId);
+    const auctionInfo = await this.fetchAuction(auctionId);
 
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
       invariant(
@@ -242,7 +234,7 @@ class AuctionHouse {
         "AuctionHouse (cancelAuction): AuctionId does not exist."
       );
     }
-    // Only the auction creator and curator can cancel the auction
+
     if (
       (await this.signer.getAddress()) !== auctionInfo.curator &&
       (await this.signer.getAddress()) !== auctionInfo.tokenOwner
@@ -250,6 +242,13 @@ class AuctionHouse {
       invariant(
         false,
         "AuctionHouse (cancelAuction): Caller is not the auction creator or curator."
+      );
+    }
+
+    if (parseInt(auctionInfo.amount._hex) > 0) {
+      invariant(
+        false,
+        "AuctionHouse (cancelAuction): You can't cancel an auction that has a bid."
       );
     }
 

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -103,21 +103,21 @@ class AuctionHouse {
       );
     }
     // If the caller is the tokenId owner and the auctionHouse address is not approved throw an error
-    else if (signerAddress == owner && this.auctionHouse.address !== approved) {
+    if (signerAddress == owner && this.auctionHouse.address !== approved) {
       invariant(
         false,
         "AuctionHouse (createAuction): Transfer caller is not owner nor approved."
       );
     }
     // If the caller is not the tokenId owner and the auctionHouse is approved throw an error
-    else if (signerAddress !== owner && this.auctionHouse.address == approved) {
+    if (signerAddress !== owner && this.auctionHouse.address == approved) {
       invariant(
         false,
         "AuctionHouse (createAuction): Caller is not approved or token owner."
       );
     }
     // If the media adddress is a zero address throw an error
-    else if (tokenAddress == ethers.constants.AddressZero) {
+    if (tokenAddress == ethers.constants.AddressZero) {
       invariant(
         false,
         "AuctionHouse (createAuction): Media cannot be a zero address."
@@ -242,6 +242,8 @@ class AuctionHouse {
         false,
         "AuctionHouse (fetchAuction): AuctionId does not exist."
       );
+
+      // Only the auction creator and curator can cancel the auction
     }
 
     return this.auctionHouse.cancelAuction(auctionId);

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -237,12 +237,9 @@ class AuctionHouse {
     const auctionInfo = await this.fetchAuction(auctionId);
 
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
-      invariant(false, "If auction Id does not exist");
-    } else {
-      // Step 1 - Figure out a way to check if an auction id exists or not. If it doesnt exist
-      // throw an error
+      invariant(false, "AuctionHouse (fetchAuction): AuctionId does not exist.");
+    } 
       return this.auctionHouse.cancelAuction(auctionId);
-    }
   }
 }
 

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -234,9 +234,15 @@ class AuctionHouse {
   }
 
   public async cancelAuction(auctionId: BigNumberish) {
-    // Step 1 - Figure out a way to check if an auction id exists or not. If it doesnt exist
-    // throw an error
-    return this.auctionHouse.cancelAuction(auctionId);
+    const auctionInfo = await this.fetchAuction(auctionId);
+
+    if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
+      invariant(false, "If auction Id does not exist");
+    } else {
+      // Step 1 - Figure out a way to check if an auction id exists or not. If it doesnt exist
+      // throw an error
+      return this.auctionHouse.cancelAuction(auctionId);
+    }
   }
 }
 

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -54,7 +54,7 @@ class AuctionHouse {
       if (log.address === this.auctionHouse.address) {
         let description = this.auctionHouse.interface.parseLog(log);
         if (description.args.auctionId) {
-          return this.fetchAuction(description.args.auctionId);
+          return this.auctionHouse.auctions(description.args.auctionId);
         }
       }
     }
@@ -131,7 +131,7 @@ class AuctionHouse {
 
   public async startAuction(auctionId: BigNumberish, approved: boolean) {
     // Fetches the auction details
-    const auctionInfo = await this.fetchAuction(auctionId);
+    const auctionInfo = await this.auctionHouse.auctions(auctionId);
 
     // If the fetched media returns a zero address this means the auction does not exist and throw an error
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
@@ -164,7 +164,7 @@ class AuctionHouse {
     reservePrice: BigNumberish
   ) {
     // Fetches the auction details
-    const auctionInfo = await this.fetchAuction(auctionId);
+    const auctionInfo = await this.auctionHouse.auctions(auctionId);
 
     // If the fetched media returns a zero address this means the auction does not exist and throw an error
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
@@ -199,7 +199,10 @@ class AuctionHouse {
     amount: BigNumberish,
     mediaContract: string
   ) {
-    const auctionInfo = await this.fetchAuction(auctionId);
+    const auctionInfo = await this.auctionHouse.auctions(auctionId);
+    if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
+      invariant(false, "AuctionHouse (createBid): AuctionId does not exist.");
+    }
 
     if (mediaContract == ethers.constants.AddressZero) {
       invariant(
@@ -226,9 +229,9 @@ class AuctionHouse {
   }
 
   public async cancelAuction(auctionId: BigNumberish) {
-    const auctionInfo = await this.fetchAuction(auctionId);
+    const auctionInfo = await this.auctionHouse.auctions(auctionId);
 
-    if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
+    if (auctionInfo.token.meBidiaContract == ethers.constants.AddressZero) {
       invariant(
         false,
         "AuctionHouse (cancelAuction): AuctionId does not exist."

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -231,7 +231,10 @@ class AuctionHouse {
     } else {
       return this.auctionHouse.createBid(auctionId, amount, mediaContract);
     }
+
+    public async cancelAuction(auctionId: BigNumberish) {
+      return this.auctionHouse.cancelAuction(auctionId)
+    }
   }
-}
 
 export default AuctionHouse;

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -231,10 +231,11 @@ class AuctionHouse {
     } else {
       return this.auctionHouse.createBid(auctionId, amount, mediaContract);
     }
-
-    public async cancelAuction(auctionId: BigNumberish) {
-      return this.auctionHouse.cancelAuction(auctionId)
-    }
   }
+
+  public async cancelAuction(auctionId: BigNumberish) {
+    return this.auctionHouse.cancelAuction(auctionId);
+  }
+}
 
 export default AuctionHouse;

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -235,15 +235,22 @@ class AuctionHouse {
 
   public async cancelAuction(auctionId: BigNumberish) {
     const auctionInfo: Auction = await this.fetchAuction(auctionId);
-    console.log(auctionInfo);
 
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
       invariant(
         false,
-        "AuctionHouse (fetchAuction): AuctionId does not exist."
+        "AuctionHouse (cancelAuction): AuctionId does not exist."
       );
-
-      // Only the auction creator and curator can cancel the auction
+    }
+    // Only the auction creator and curator can cancel the auction
+    if (
+      (await this.signer.getAddress()) !== auctionInfo.curator &&
+      (await this.signer.getAddress()) !== auctionInfo.tokenOwner
+    ) {
+      invariant(
+        false,
+        "AuctionHouse (cancelAuction): Caller is not the auction creator or curator."
+      );
     }
 
     return this.auctionHouse.cancelAuction(auctionId);

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -235,6 +235,7 @@ class AuctionHouse {
 
   public async cancelAuction(auctionId: BigNumberish) {
     const auctionInfo: Auction = await this.fetchAuction(auctionId);
+    console.log(auctionInfo);
 
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
       invariant(
@@ -242,6 +243,7 @@ class AuctionHouse {
         "AuctionHouse (fetchAuction): AuctionId does not exist."
       );
     }
+
     return this.auctionHouse.cancelAuction(auctionId);
   }
 }

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -234,6 +234,8 @@ class AuctionHouse {
   }
 
   public async cancelAuction(auctionId: BigNumberish) {
+    // Step 1 - Figure out a way to check if an auction id exists or not. If it doesnt exist
+    // throw an error
     return this.auctionHouse.cancelAuction(auctionId);
   }
 }

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -234,12 +234,15 @@ class AuctionHouse {
   }
 
   public async cancelAuction(auctionId: BigNumberish) {
-    const auctionInfo = await this.fetchAuction(auctionId);
+    const auctionInfo: Auction = await this.fetchAuction(auctionId);
 
     if (auctionInfo.token.mediaContract == ethers.constants.AddressZero) {
-      invariant(false, "AuctionHouse (fetchAuction): AuctionId does not exist.");
-    } 
-      return this.auctionHouse.cancelAuction(auctionId);
+      invariant(
+        false,
+        "AuctionHouse (fetchAuction): AuctionId does not exist."
+      );
+    }
+    return this.auctionHouse.cancelAuction(auctionId);
   }
 }
 

--- a/sdk/nft/src/auctionHouse.ts
+++ b/sdk/nft/src/auctionHouse.ts
@@ -44,7 +44,7 @@ class AuctionHouse {
   }
 
   public async fetchAuction(auctionId: BigNumberish): Promise<any> {
-    return auctionId;
+    return await this.auctionHouse.auctions(auctionId);
   }
 
   public async fetchAuctionFromTransactionReceipt(

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -602,7 +602,7 @@ describe("AuctionHouse", () => {
             );
         });
 
-        it.only("Should cancel the auction by the curator on the main media", async () => {
+        it("Should cancel the auction by the curator on the main media", async () => {
           const preCancelAuction = await curatorMainConnected.fetchAuction(0);
 
           expect(parseInt(preCancelAuction.token.tokenId._hex)).to.equal(0);
@@ -650,7 +650,28 @@ describe("AuctionHouse", () => {
           );
         });
 
-        it("Should cancel the auction by the owner on the main media", async () => {});
+        it.only("Should cancel the auction by the owner on the main media", async () => {
+          const cancelAuction = await ownerAuctionConnected.fetchAuction(0);
+
+          expect(parseInt(cancelAuction.token.tokenId._hex)).to.equal(0);
+          expect(cancelAuction.token.mediaContract).to.equal(mediaAddress);
+          expect(cancelAuction.approved).to.be.true;
+          expect(parseInt(cancelAuction.amount._hex)).to.equal(0);
+          expect(parseInt(cancelAuction.duration._hex)).to.equal(duration);
+
+          expect(parseInt(cancelAuction.reservePrice._hex)).to.equal(
+            reservePrice
+          );
+          expect(curatorFeePercentage).to.equal(0);
+          expect(cancelAuction.tokenOwner).to.equal(await signer.getAddress());
+          expect(cancelAuction.bidder).to.equal(await signer.getAddress());
+          expect(cancelAuction.curator).to.equal(await curator.getAddress());
+          expect(cancelAuction.auctionCurrency).to.equal(token.address);
+
+          await ownerAuctionConnected.cancelAuction(0);
+
+          console.log(cancelAuction, 200);
+        });
       });
     });
 

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -380,8 +380,10 @@ describe("AuctionHouse", () => {
 
       describe("#setAuctionReservePrice", () => {
         let invalidSigner: AuctionHouse;
+
         beforeEach(async () => {
           invalidSigner = new AuctionHouse(1337, signers[8]);
+
           await ownerMediaConnected.approve(
             ownerAuctionConnected.auctionHouse.address,
             0
@@ -426,41 +428,42 @@ describe("AuctionHouse", () => {
             );
         });
 
-        it("Should set the auction reserve price when called by the token owner", async () => {
-          // The owner(signer[0]) connected to the AuctionHouse class
-          // The owner invokes the setAuctionReservePrice
-          await auctionHouse.setAuctionReservePrice(0, 200);
+        it("Should set the auction reserve price when called by the token owner on the main media", async () => {
+          await ownerAuctionConnected.setAuctionReservePrice(0, 200);
 
-          // // The curator invokes startAuction
-          // await curatorConnected.startAuction(0, true);
+          await curatorMainConnected.startAuction(0, true);
+
+          const createdAuction: Auction =
+            await curatorMainConnected.fetchAuction(0);
+
+          expect(parseInt(createdAuction.token.tokenId.toString())).to.equal(0);
+          expect(createdAuction.token.mediaContract).to.equal(mediaAddress);
+          expect(createdAuction.approved).to.be.true;
+          expect(parseInt(createdAuction.duration._hex)).to.equal(duration);
+          expect(createdAuction.curatorFeePercentage).to.equal(0);
+          expect(parseInt(createdAuction.reservePrice._hex)).to.equal(200);
+          expect(createdAuction.tokenOwner).to.equal(await signer.getAddress());
+          expect(createdAuction.curator).to.equal(await curator.getAddress());
+          expect(createdAuction.auctionCurrency).to.equal(token.address);
         });
 
-        it("Should set the auction reserve price when called by the curator", async () => {
-          // // The curator(signer[4]) connected to the AuctionHouse class
-          // // The curator invokes the setAuctionReservePrice
-          // await curatorConnected.setAuctionReservePrice(0, 200);
-          // // The curator invokes startAuction
-          // await curatorConnected.startAuction(0, true);
-          // // Fetches the details from auction id 0
-          // const createdAuction = await curatorConnected.fetchAuction(0);
-          // The returned tokenId should equal 0
-          // expect(parseInt(createdAuction.token.tokenId.toString())).to.equal(0);
-          // // The returned mediaContract address should equal the address the tokenId belongs to
-          // expect(createdAuction.token.mediaContract).to.equal(mediaAddress);
-          // // The returned auction approval status should equal true after the curator invokes startAuction
-          // expect(createdAuction.approved).to.be.true;
-          // // The returned duration should equal the duration set on createAuction
-          // expect(parseInt(createdAuction.duration._hex)).to.equal(duration);
-          // // The returned curatorFeePercentage should equal the fee set on createAuction
-          // expect(createdAuction.curatorFeePercentage).to.equal(0);
-          // // The returned reservePrice should equal the amount the curator set on setAuctionReservePrice
-          // expect(parseInt(createdAuction.reservePrice._hex)).to.equal(200);
-          // // The returned tokenId owner should equal the address who minted
-          // expect(createdAuction.tokenOwner).to.equal(await signer.getAddress());
-          // // The returned curator should equal the address set on createAuction
-          // expect(createdAuction.curator).to.equal(await curator.getAddress());
-          // // The returned currency should equal the currency set on createAuction
-          // expect(createdAuction.auctionCurrency).to.equal(token.address);
+        it("Should set the auction reserve price when called by the curator on the main media", async () => {
+          await curatorMainConnected.setAuctionReservePrice(0, 200);
+
+          await curatorMainConnected.startAuction(0, true);
+
+          const createdAuction: Auction =
+            await curatorMainConnected.fetchAuction(0);
+
+          expect(parseInt(createdAuction.token.tokenId.toString())).to.equal(0);
+          expect(createdAuction.token.mediaContract).to.equal(mediaAddress);
+          expect(createdAuction.approved).to.be.true;
+          expect(parseInt(createdAuction.duration._hex)).to.equal(duration);
+          expect(createdAuction.curatorFeePercentage).to.equal(0);
+          expect(parseInt(createdAuction.reservePrice._hex)).to.equal(200);
+          expect(createdAuction.tokenOwner).to.equal(await signer.getAddress());
+          expect(createdAuction.curator).to.equal(await curator.getAddress());
+          expect(createdAuction.auctionCurrency).to.equal(token.address);
         });
       });
 

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -643,6 +643,10 @@ describe("AuctionHouse", () => {
           );
         });
       });
+
+      describe("#cancelAuction", () => {
+        it("Should reject if the auction id does not exist", async () => {});
+      });
     });
 
     describe("View Functions", () => {

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -1,4 +1,6 @@
-import { expect } from "chai";
+import chai, { expect } from "chai";
+
+import chaiAsPromised from "chai-as-promised";
 
 import { BigNumber, Contract, ethers, Signer } from "ethers";
 
@@ -29,7 +31,9 @@ import ZapMedia from "../src/zapMedia";
 import { getSigners } from "./test_utils";
 
 const provider = new ethers.providers.JsonRpcProvider("http://localhost:8545");
+chai.use(chaiAsPromised);
 
+chai.should();
 describe("AuctionHouse", () => {
   let token: Contract;
   let zapVault: Contract;
@@ -40,7 +44,8 @@ describe("AuctionHouse", () => {
   let auctionHouse: Contract;
   let signer: Signer;
   let mediaData: MediaData;
-  let ownerConnected: ZapMedia;
+  let ownerMediaConnected: ZapMedia;
+  let ownerAuctionConnected: AuctionHouse;
   let mediaAddress: string;
   let bidShares: BidShares;
 
@@ -102,9 +107,10 @@ describe("AuctionHouse", () => {
       35
     );
 
-    ownerConnected = new ZapMedia(1337, signer);
+    ownerMediaConnected = new ZapMedia(1337, signer);
+    ownerAuctionConnected = new AuctionHouse(1337, signer);
 
-    await ownerConnected.mint(mediaData, bidShares);
+    await ownerMediaConnected.mint(mediaData, bidShares);
   });
 
   describe("Contract Functions", () => {
@@ -118,10 +124,8 @@ describe("AuctionHouse", () => {
 
     describe("Write Functions", () => {
       describe("#createAuction", () => {
-        it("Should reject if the auctionHouse is not approved", async () => {
-          const auctionHouse = new AuctionHouse(1337, signer);
-
-          await auctionHouse
+        it.only("Should reject if the auctionHouse is not approved", async () => {
+          await ownerAuctionConnected
             .createAuction(
               0,
               mediaAddress,
@@ -131,11 +135,9 @@ describe("AuctionHouse", () => {
               0,
               token.address
             )
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: AuctionHouse (createAuction): Transfer caller is not owner nor approved."
-              );
-            });
+            .should.be.rejectedWith(
+              "Invariant failed: AuctionHouse (createAuction): Transfer caller is not owner nor approved."
+            );
         });
 
         it("Should reject if the caller is not approved", async () => {
@@ -147,7 +149,7 @@ describe("AuctionHouse", () => {
 
           const auctionHouse = new AuctionHouse(1337, unapprovedSigner);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          // await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse
             .createAuction(
@@ -172,7 +174,7 @@ describe("AuctionHouse", () => {
 
           const auctionHouse = new AuctionHouse(1337, signer);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          // await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse
             .createAuction(
@@ -197,7 +199,7 @@ describe("AuctionHouse", () => {
 
           const auctionHouse = new AuctionHouse(1337, signer);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse
             .createAuction(
@@ -222,7 +224,7 @@ describe("AuctionHouse", () => {
 
           const auctionHouse = new AuctionHouse(1337, signer);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse
             .createAuction(
@@ -247,7 +249,7 @@ describe("AuctionHouse", () => {
 
           const auctionHouse = new AuctionHouse(1337, signer);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse.createAuction(
             0,
@@ -286,7 +288,7 @@ describe("AuctionHouse", () => {
           auctionHouse = new AuctionHouse(1337, signer);
           curatorConnected = new AuctionHouse(1337, curator);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
         });
 
         it("Should reject if the auctionId does not exist", async () => {
@@ -403,7 +405,7 @@ describe("AuctionHouse", () => {
           curatorConnected = new AuctionHouse(1337, curator);
 
           // The owner(signer[0]) of tokenId 0 approves the auctionHouse
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           // The owner(signer[0]) creates the auction
           // The curator is neither a zero address or token owner so the curator has to invoke startAuction
@@ -533,7 +535,7 @@ describe("AuctionHouse", () => {
           bidderOneConnected = new AuctionHouse(1337, bidderOne);
           bidderTwoConnected = new AuctionHouse(1337, bidderTwo);
 
-          await media.approve(ownerConnected.auctionHouse.address, 0);
+          //await media.approve(ownerConnected.auctionHouse.address, 0);
 
           await ownerConnected.createAuction(
             0,
@@ -645,14 +647,14 @@ describe("AuctionHouse", () => {
         });
       });
 
-      describe.only("#cancelAuction", () => {
+      describe("#cancelAuction", () => {
         it("Should reject if the auctionId does not exist on the main media", async () => {
           const duration = 60 * 60 * 24;
           const reservePrice = BigNumber.from(10).pow(18).div(2);
 
           const auctionHouse = new AuctionHouse(1337, signer);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse.createAuction(
             0,
@@ -733,7 +735,7 @@ describe("AuctionHouse", () => {
 
           let auctionHouse = new AuctionHouse(1337, signer);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           const tx = await auctionHouse.createAuction(
             0,
@@ -767,7 +769,7 @@ describe("AuctionHouse", () => {
           let curator = signers[9];
           let auctionHouse = new AuctionHouse(1337, signer);
           let curatorConnected = new AuctionHouse(1337, curator);
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse.createAuction(
             0,
@@ -801,9 +803,8 @@ describe("AuctionHouse", () => {
 
           let auctionHouse = new AuctionHouse(1337, signer);
 
-          const tx = await media.approve(auctionHouse.auctionHouse.address, 0);
-
-          await auctionHouse.createAuction(
+          const tx = await auctionHouse.createAuction(
+            //await media.approve(auctionHouse.auctionHouse.address, 0);
             0,
             mediaAddress,
             duration,
@@ -830,7 +831,7 @@ describe("AuctionHouse", () => {
 
           let curatorConnected = new AuctionHouse(1337, curator);
 
-          await media.approve(auctionHouse.auctionHouse.address, 0);
+          //await media.approve(auctionHouse.auctionHouse.address, 0);
 
           await auctionHouse.createAuction(
             0,

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -36,7 +36,7 @@ chai.use(chaiAsPromised);
 
 chai.should();
 
-describe.only("AuctionHouse", () => {
+describe("AuctionHouse", () => {
   let token: Contract;
   let zapVault: Contract;
   let zapMarket: Contract;

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -538,11 +538,14 @@ describe("AuctionHouse", () => {
       });
 
       describe.only("#cancelAuction", () => {
+        let invalidSigner: AuctionHouse;
         beforeEach(async () => {
           await ownerMediaConnected.approve(
             ownerAuctionConnected.auctionHouse.address,
             0
           );
+
+          invalidSigner = new AuctionHouse(1337, signers[5]);
         });
 
         it("Should reject if the auctionId does not exist on the main media", async () => {
@@ -561,6 +564,20 @@ describe("AuctionHouse", () => {
             .should.be.rejectedWith(
               "Invariant failed: AuctionHouse (fetchAuction): AuctionId does not exist."
             );
+        });
+
+        it.only("Should reject if the caller is not the auction creator or curator on the main media ", async () => {
+          await ownerAuctionConnected.createAuction(
+            0,
+            mediaAddress,
+            duration,
+            reservePrice,
+            ethers.constants.AddressZero,
+            0,
+            token.address
+          );
+
+          await invalidSigner.cancelAuction(0);
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -537,7 +537,7 @@ describe("AuctionHouse", () => {
         });
       });
 
-      describe("#cancelAuction", () => {
+      describe.only("#cancelAuction", () => {
         it("Should reject if the auctionId does not exist on the main media", async () => {
           const duration = 60 * 60 * 24;
           const reservePrice = BigNumber.from(10).pow(18).div(2);

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -4,6 +4,8 @@ import { BigNumber, Contract, ethers, Signer } from "ethers";
 
 import { constructBidShares, constructMediaData } from "../src/utils";
 
+import { BidShares, MediaData } from "../src/types";
+
 import {
   zapMarketAddresses,
   mediaFactoryAddresses,
@@ -34,11 +36,24 @@ describe("AuctionHouse", () => {
   let zapMarket: Contract;
   let zapMediaImpl: Contract;
   let mediaFactory: Contract;
-  let signer: Signer;
   let zapMedia: Contract;
   let auctionHouse: Contract;
+  let signer: Signer;
+  let mediaData: MediaData;
+  let ownerConnected: ZapMedia;
+  let mediaAddress: string;
+  let bidShares: BidShares;
 
   const signers = getSigners(provider);
+
+  const duration = 60 * 60 * 24;
+
+  const reservePrice = BigNumber.from(10).pow(18).div(2);
+
+  let tokenURI =
+    "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
+  let metadataURI =
+    "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
 
   beforeEach(async () => {
     signer = signers[0];
@@ -55,6 +70,41 @@ describe("AuctionHouse", () => {
     mediaFactoryAddresses["1337"] = mediaFactory.address;
     zapMediaAddresses["1337"] = zapMedia.address;
     zapAuctionAddresses["1337"] = auctionHouse.address;
+
+    mediaAddress = zapMediaAddresses["1337"];
+
+    let metadataHex = ethers.utils.formatBytes32String("Test");
+    let metadataHashRaw = ethers.utils.keccak256(metadataHex);
+    let metadataHashBytes = ethers.utils.arrayify(metadataHashRaw);
+
+    let contentHex = ethers.utils.formatBytes32String("Test Car");
+    let contentHashRaw = ethers.utils.keccak256(contentHex);
+    let contentHashBytes = ethers.utils.arrayify(contentHashRaw);
+
+    let contentHash = contentHashBytes;
+    let metadataHash = metadataHashBytes;
+
+    mediaData = constructMediaData(
+      tokenURI,
+      metadataURI,
+      contentHash,
+      metadataHash
+    );
+
+    bidShares = constructBidShares(
+      [
+        await provider.getSigner(2).getAddress(),
+        await provider.getSigner(3).getAddress(),
+        await provider.getSigner(4).getAddress(),
+      ],
+      [15, 15, 15],
+      15,
+      35
+    );
+
+    ownerConnected = new ZapMedia(1337, signer);
+
+    await ownerConnected.mint(mediaData, bidShares);
   });
 
   describe("Contract Functions", () => {
@@ -65,59 +115,10 @@ describe("AuctionHouse", () => {
         }).to.throw("Constructor: Network Id is not supported.");
       });
     });
+
     describe("Write Functions", () => {
-      let media: any;
-      let mediaAddress: any;
-      let mediaData: any;
-      let bidShares: any;
-
-      let tokenURI =
-        "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
-      let metadataURI =
-        "https://bafkreihhu7xo7knc3vn42jj26gz3jkvh3uu3rwurkb4djsoo5ayqs2s25a.ipfs.dweb.link/";
-
-      beforeEach(async () => {
-        let metadataHex = ethers.utils.formatBytes32String("Test");
-        let metadataHashRaw = ethers.utils.keccak256(metadataHex);
-        let metadataHashBytes = ethers.utils.arrayify(metadataHashRaw);
-
-        let contentHex = ethers.utils.formatBytes32String("Test Car");
-        let contentHashRaw = ethers.utils.keccak256(contentHex);
-        let contentHashBytes = ethers.utils.arrayify(contentHashRaw);
-
-        let contentHash = contentHashBytes;
-        let metadataHash = metadataHashBytes;
-
-        media = new ZapMedia(1337, signer);
-        mediaAddress = zapMediaAddresses["1337"];
-
-        bidShares = constructBidShares(
-          [
-            await provider.getSigner(1).getAddress(),
-            await provider.getSigner(2).getAddress(),
-            await provider.getSigner(3).getAddress(),
-          ],
-          [15, 15, 15],
-          15,
-          35
-        );
-
-        mediaData = constructMediaData(
-          tokenURI,
-          metadataURI,
-          contentHash,
-          metadataHash
-        );
-
-        await media.mint(mediaData, bidShares);
-      });
-
       describe("#createAuction", () => {
         it("Should reject if the auctionHouse is not approved", async () => {
-          const duration = 60 * 60 * 24;
-
-          const reservePrice = BigNumber.from(10).pow(18).div(2);
-
           const auctionHouse = new AuctionHouse(1337, signer);
 
           await auctionHouse
@@ -646,9 +647,6 @@ describe("AuctionHouse", () => {
 
       describe.only("#cancelAuction", () => {
         it("Should reject if the auctionId does not exist on the main media", async () => {
-          expect(() => {
-            new AuctionHouse(300, signer);
-          }).to.throw("Constructor: auctionId does not exist on main media.");
           const duration = 60 * 60 * 24;
           const reservePrice = BigNumber.from(10).pow(18).div(2);
 
@@ -665,9 +663,6 @@ describe("AuctionHouse", () => {
             0,
             token.address
           );
-          it("should throw an error if auctionId does not exist", async () => {
-            new AuctionHouse(300, signer);
-          }).should.be.rejectedWith("AuctionHouse (Constructor): the (mainmediaaddress) auctionId is not supported.");
           //Step 1 create an auction
           //step 2 allow the cancelAuction to throw an error if the auctionId does not exist
           //Step 3 add in assertion that it should throw error

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -519,7 +519,7 @@ describe("AuctionHouse", () => {
             );
         });
 
-        it.only("Should reject if the media contract is a zero address on the main media", async () => {
+        it("Should reject if the media contract is a zero address on the main media", async () => {
           await bidderOneMainConnected
             .createBid(0, bidAmtOne, ethers.constants.AddressZero)
             .should.be.rejectedWith(
@@ -527,14 +527,12 @@ describe("AuctionHouse", () => {
             );
         });
 
-        it("Should reject if the bid does not meet the reserve price", async () => {
+        it.only("Should reject if the bid does not meet the reserve price on the main media", async () => {
           await bidderOneMainConnected
             .createBid(0, reservePrice - 1, mediaAddress)
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: AuctionHouse (createBid): Must send at least reserve price."
-              );
-            });
+            .should.be.rejectedWith(
+              "Invariant failed: AuctionHouse (createBid): Must send at least reserve price."
+            );
         });
 
         it("Should create a bid", async () => {

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -617,9 +617,9 @@ describe("AuctionHouse", () => {
           expect(fetchAuction.tokenOwner).to.equal(await signer.getAddress());
           expect(fetchAuction.bidder).to.equal(ethers.constants.AddressZero);
           expect(fetchAuction.curator).to.equal(await curator.getAddress());
-          expect(fetchAuction.fetchCurrency).to.equal(token.address);
+          expect(fetchAuction.auctionCurrency).to.equal(token.address);
 
-          console.log(fetchAuction);
+          // Cancel the auction by the curator
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -644,7 +644,7 @@ describe("AuctionHouse", () => {
         });
       });
 
-      describe("#cancelAuction", () => {
+      describe.only("#cancelAuction", () => {
         it("Should reject if the auction id does not exist", async () => {});
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -538,14 +538,21 @@ describe("AuctionHouse", () => {
       });
 
       describe.only("#cancelAuction", () => {
-        let invalidSigner: AuctionHouse;
+        let invalidSigner: Signer;
+        let curator: Signer;
+        let invalidSignerConnected: AuctionHouse;
+        let curatorMainConnected: AuctionHouse;
+
         beforeEach(async () => {
+          curator = signers[4];
+          invalidSigner = signers[5];
+
           await ownerMediaConnected.approve(
             ownerAuctionConnected.auctionHouse.address,
             0
           );
 
-          invalidSigner = new AuctionHouse(1337, signers[5]);
+          invalidSignerConnected = new AuctionHouse(1337, invalidSigner);
         });
 
         it("Should reject if the auctionId does not exist on the main media", async () => {
@@ -572,12 +579,10 @@ describe("AuctionHouse", () => {
             mediaAddress,
             duration,
             reservePrice,
-            ethers.constants.AddressZero,
+            await curator.getAddress(),
             0,
             token.address
           );
-
-          await invalidSigner.cancelAuction(0);
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -619,6 +619,7 @@ describe("AuctionHouse", () => {
           expect(fetchAuction.curator).to.equal(await curator.getAddress());
           expect(fetchAuction.auctionCurrency).to.equal(token.address);
 
+          await curatorMainConnected.cancelAuction(0);
           // Cancel the auction by the curator
         });
       });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -603,24 +603,51 @@ describe("AuctionHouse", () => {
         });
 
         it.only("Should cancel the auction by the curator on the main media", async () => {
-          const fetchAuction = await curatorMainConnected.fetchAuction(0);
+          const preCancelAuction = await curatorMainConnected.fetchAuction(0);
 
-          expect(parseInt(fetchAuction.token.tokenId._hex)).to.equal(0);
-          expect(fetchAuction.token.mediaContract).to.equal(mediaAddress);
-          expect(fetchAuction.approved).to.be.true;
-          expect(parseInt(fetchAuction.amount._hex)).to.equal(0);
-          expect(parseInt(fetchAuction.duration._hex)).to.equal(duration);
-          expect(parseInt(fetchAuction.reservePrice._hex)).to.equal(
+          expect(parseInt(preCancelAuction.token.tokenId._hex)).to.equal(0);
+          expect(preCancelAuction.token.mediaContract).to.equal(mediaAddress);
+          expect(preCancelAuction.approved).to.be.true;
+          expect(parseInt(preCancelAuction.amount._hex)).to.equal(0);
+          expect(parseInt(preCancelAuction.duration._hex)).to.equal(duration);
+          expect(parseInt(preCancelAuction.reservePrice._hex)).to.equal(
             reservePrice
           );
           expect(curatorFeePercentage).to.equal(0);
-          expect(fetchAuction.tokenOwner).to.equal(await signer.getAddress());
-          expect(fetchAuction.bidder).to.equal(ethers.constants.AddressZero);
-          expect(fetchAuction.curator).to.equal(await curator.getAddress());
-          expect(fetchAuction.auctionCurrency).to.equal(token.address);
+          expect(preCancelAuction.tokenOwner).to.equal(
+            await signer.getAddress()
+          );
+          expect(preCancelAuction.bidder).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(preCancelAuction.curator).to.equal(await curator.getAddress());
+          expect(preCancelAuction.auctionCurrency).to.equal(token.address);
 
           await curatorMainConnected.cancelAuction(0);
-          // Cancel the auction by the curator
+
+          const postCancelAuction = await curatorMainConnected.fetchAuction(0);
+
+          expect(parseInt(postCancelAuction.token.tokenId._hex)).to.equal(0);
+          expect(postCancelAuction.token.mediaContract).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.approved).to.be.false;
+          expect(parseInt(postCancelAuction.amount._hex)).to.equal(0);
+          expect(parseInt(postCancelAuction.duration._hex)).to.equal(0);
+          expect(parseInt(postCancelAuction.reservePrice._hex)).to.equal(0);
+          expect(curatorFeePercentage).to.equal(0);
+          expect(postCancelAuction.tokenOwner).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.bidder).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.curator).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.auctionCurrency).to.equal(
+            ethers.constants.AddressZero
+          );
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -650,7 +650,7 @@ describe("AuctionHouse", () => {
           );
         });
 
-        it.only("Should cancel the auction by the owner on the main media", async () => {
+        it("Should cancel the auction by the owner on the main media", async () => {
           const preCancelAuction = await ownerAuctionConnected.fetchAuction(0);
 
           expect(parseInt(preCancelAuction.token.tokenId._hex)).to.equal(0);

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -538,7 +538,7 @@ describe("AuctionHouse", () => {
         });
       });
 
-      describe.only("#cancelAuction", () => {
+      describe("#cancelAuction", () => {
         let invalidSigner: Signer;
         let curator: Signer;
         let bidder: Signer;
@@ -651,26 +651,54 @@ describe("AuctionHouse", () => {
         });
 
         it.only("Should cancel the auction by the owner on the main media", async () => {
-          const cancelAuction = await ownerAuctionConnected.fetchAuction(0);
+          const preCancelAuction = await ownerAuctionConnected.fetchAuction(0);
 
-          expect(parseInt(cancelAuction.token.tokenId._hex)).to.equal(0);
-          expect(cancelAuction.token.mediaContract).to.equal(mediaAddress);
-          expect(cancelAuction.approved).to.be.true;
-          expect(parseInt(cancelAuction.amount._hex)).to.equal(0);
-          expect(parseInt(cancelAuction.duration._hex)).to.equal(duration);
-
-          expect(parseInt(cancelAuction.reservePrice._hex)).to.equal(
+          expect(parseInt(preCancelAuction.token.tokenId._hex)).to.equal(0);
+          expect(preCancelAuction.token.mediaContract).to.equal(mediaAddress);
+          expect(preCancelAuction.approved).to.be.true;
+          expect(parseInt(preCancelAuction.amount._hex)).to.equal(0);
+          expect(parseInt(preCancelAuction.duration._hex)).to.equal(duration);
+          expect(parseInt(preCancelAuction.reservePrice._hex)).to.equal(
             reservePrice
           );
-          expect(curatorFeePercentage).to.equal(0);
-          expect(cancelAuction.tokenOwner).to.equal(await signer.getAddress());
-          expect(cancelAuction.bidder).to.equal(await signer.getAddress());
-          expect(cancelAuction.curator).to.equal(await curator.getAddress());
-          expect(cancelAuction.auctionCurrency).to.equal(token.address);
+
+          expect(parseInt(preCancelAuction.curatorFeePercentage)).to.equal(0);
+
+          expect(preCancelAuction.tokenOwner).to.equal(
+            await signer.getAddress()
+          );
+          expect(preCancelAuction.bidder).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(preCancelAuction.curator).to.equal(await curator.getAddress());
+          expect(preCancelAuction.auctionCurrency).to.equal(token.address);
 
           await ownerAuctionConnected.cancelAuction(0);
 
-          console.log(cancelAuction, 200);
+          const postCancelAuction = await ownerAuctionConnected.fetchAuction(0);
+
+          expect(parseInt(postCancelAuction.token.tokenId._hex)).to.equal(0);
+          expect(postCancelAuction.token.mediaContract).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.approved).to.be.false;
+          expect(parseInt(postCancelAuction.amount._hex)).to.equal(0);
+          expect(parseInt(postCancelAuction.duration._hex)).to.equal(0);
+
+          expect(parseInt(postCancelAuction.reservePrice._hex)).to.equal(0);
+          expect(parseInt(postCancelAuction.curatorFeePercentage)).to.equal(0);
+          expect(postCancelAuction.tokenOwner).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.bidder).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.curator).to.equal(
+            ethers.constants.AddressZero
+          );
+          expect(postCancelAuction.auctionCurrency).to.equal(
+            ethers.constants.AddressZero
+          );
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -573,7 +573,7 @@ describe("AuctionHouse", () => {
             );
         });
 
-        it.only("Should reject if the caller is not the auction creator or curator on the main media ", async () => {
+        it("Should reject if the caller is not the auction creator or curator on the main media", async () => {
           await ownerAuctionConnected.createAuction(
             0,
             mediaAddress,
@@ -583,6 +583,12 @@ describe("AuctionHouse", () => {
             0,
             token.address
           );
+
+          await invalidSignerConnected
+            .cancelAuction(0)
+            .should.be.rejectedWith(
+              "Invariant failed: AuctionHouse (cancelAuction): Caller is not the auction creator or curator."
+            );
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -649,6 +649,8 @@ describe("AuctionHouse", () => {
             ethers.constants.AddressZero
           );
         });
+
+        it("Should cancel the auction by the owner on the main media", async () => {});
       });
     });
 

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -538,26 +538,29 @@ describe("AuctionHouse", () => {
       });
 
       describe.only("#cancelAuction", () => {
+        beforeEach(async () => {
+          await ownerMediaConnected.approve(
+            ownerAuctionConnected.auctionHouse.address,
+            0
+          );
+        });
+
         it("Should reject if the auctionId does not exist on the main media", async () => {
-          const duration = 60 * 60 * 24;
-          const reservePrice = BigNumber.from(10).pow(18).div(2);
-
-          const auctionHouse = new AuctionHouse(1337, signer);
-
-          //await media.approve(auctionHouse.auctionHouse.address, 0);
-
-          await auctionHouse.createAuction(
+          await ownerAuctionConnected.createAuction(
             0,
             mediaAddress,
             duration,
             reservePrice,
-            "0x0000000000000000000000000000000000000000",
+            ethers.constants.AddressZero,
             0,
             token.address
           );
-          //Step 1 create an auction
-          //step 2 allow the cancelAuction to throw an error if the auctionId does not exist
-          //Step 3 add in assertion that it should throw error
+
+          await ownerAuctionConnected
+            .cancelAuction(53)
+            .should.be.rejectedWith(
+              "Invariant failed: AuctionHouse (fetchAuction): AuctionId does not exist."
+            );
         });
       });
     });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -57,6 +57,8 @@ describe("AuctionHouse", () => {
 
   const reservePrice = 200;
 
+  const curatorFeePercentage = 0;
+
   let tokenURI =
     "https://bafkreievpmtbofalpowrcbr5oaok33e6xivii62r6fxh6fontaglngme2m.ipfs.dweb.link/";
   let metadataURI =
@@ -545,6 +547,8 @@ describe("AuctionHouse", () => {
         let curatorMainConnected: AuctionHouse;
 
         beforeEach(async () => {
+          const mintAmt = 300;
+          const bidAmt = 200;
           curator = signers[4];
           invalidSigner = signers[5];
           bidder = signers[5];
@@ -568,8 +572,8 @@ describe("AuctionHouse", () => {
           invalidSignerConnected = new AuctionHouse(1337, invalidSigner);
           bidderMainConnected = new AuctionHouse(1337, bidder);
 
-          await token.mint(await bidder.getAddress(), 200);
-          await token.connect(bidder).approve(auctionHouse.address, 300);
+          await token.mint(await bidder.getAddress(), mintAmt);
+          await token.connect(bidder).approve(auctionHouse.address, bidAmt);
         });
 
         it("Should reject if the auctionId does not exist on the main media", async () => {
@@ -599,9 +603,21 @@ describe("AuctionHouse", () => {
         });
 
         it.only("Should cancel the auction by the curator on the main media", async () => {
-          await curatorMainConnected.cancelAuction(0);
-
           const fetchAuction = await curatorMainConnected.fetchAuction(0);
+
+          expect(parseInt(fetchAuction.token.tokenId._hex)).to.equal(0);
+          expect(fetchAuction.token.mediaContract).to.equal(mediaAddress);
+          expect(fetchAuction.approved).to.be.true;
+          expect(parseInt(fetchAuction.amount._hex)).to.equal(0);
+          expect(parseInt(fetchAuction.duration._hex)).to.equal(duration);
+          expect(parseInt(fetchAuction.reservePrice._hex)).to.equal(
+            reservePrice
+          );
+          expect(curatorFeePercentage).to.equal(0);
+          expect(fetchAuction.tokenOwner).to.equal(await signer.getAddress());
+          expect(fetchAuction.bidder).to.equal(ethers.constants.AddressZero);
+          expect(fetchAuction.curator).to.equal(await curator.getAddress());
+          expect(fetchAuction.fetchCurrency).to.equal(token.address);
 
           console.log(fetchAuction);
         });

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -511,7 +511,7 @@ describe("AuctionHouse", () => {
             .approve(ownerAuctionConnected.auctionHouse.address, 1000);
         });
 
-        it.only("Should reject if the auction id does not exist on the main media", async () => {
+        it("Should reject if the auction id does not exist on the main media", async () => {
           await bidderOneMainConnected
             .createBid(12, bidAmtOne, mediaAddress)
             .should.be.rejectedWith(
@@ -519,14 +519,12 @@ describe("AuctionHouse", () => {
             );
         });
 
-        it("Should reject if the media contract is a zero address", async () => {
+        it.only("Should reject if the media contract is a zero address on the main media", async () => {
           await bidderOneMainConnected
             .createBid(0, bidAmtOne, ethers.constants.AddressZero)
-            .catch((err) => {
-              expect(err.message).to.equal(
-                "Invariant failed: AuctionHouse (createBid): Media cannot be a zero address."
-              );
-            });
+            .should.be.rejectedWith(
+              "Invariant failed: AuctionHouse (createBid): Media cannot be a zero address."
+            );
         });
 
         it("Should reject if the bid does not meet the reserve price", async () => {

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -667,7 +667,7 @@ describe("AuctionHouse", () => {
           );
           it("should throw an error if auctionId does not exist", async () => {
             new AuctionHouse(300, signer);
-          }).to.throw("AuctionHouse (Constructor): the (mainmediaaddress) auctionId is not supported.");
+          }).should.be.rejectedWith("AuctionHouse (Constructor): the (mainmediaaddress) auctionId is not supported.");
           //Step 1 create an auction
           //step 2 allow the cancelAuction to throw an error if the auctionId does not exist
           //Step 3 add in assertion that it should throw error

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -645,7 +645,33 @@ describe("AuctionHouse", () => {
       });
 
       describe.only("#cancelAuction", () => {
-        it("Should reject if the auction id does not exist", async () => {});
+        it("Should reject if the auctionId does not exist on the main media", async () => {
+          expect(() => {
+            new AuctionHouse(300, signer);
+          }).to.throw("Constructor: auctionId does not exist on main media.");
+          const duration = 60 * 60 * 24;
+          const reservePrice = BigNumber.from(10).pow(18).div(2);
+
+          const auctionHouse = new AuctionHouse(1337, signer);
+
+          await media.approve(auctionHouse.auctionHouse.address, 0);
+
+          await auctionHouse.createAuction(
+            0,
+            mediaAddress,
+            duration,
+            reservePrice,
+            "0x0000000000000000000000000000000000000000",
+            0,
+            token.address
+          );
+          it("should throw an error if auctionId does not exist", async () => {
+            new AuctionHouse(300, signer);
+          }).to.throw("AuctionHouse (Constructor): the (mainmediaaddress) auctionId is not supported.");
+          //Step 1 create an auction
+          //step 2 allow the cancelAuction to throw an error if the auctionId does not exist
+          //Step 3 add in assertion that it should throw error
+        });
       });
     });
 


### PR DESCRIPTION
## Summary
Closes #323 

## Implementation
- [x] Added the ```cancelAuction``` function to the ```AuctionHouse``` class
- [x] Added error handling that checks if the auction id exists or not
- [x] Added error handling to check if the caller is approved or not
- [x]  Added error handling to prevent the cancelling the auction when there is already a bid
- [x] Added the ```Should reject if the auctionId does not exist on the main media``` test
- [x] Added the ```Should reject if the caller is not the auction creator or curator on the main media``` test
- [x] Added the ```Should reject if the auction has a bid on the main media``` test 
- [x] Added the ```Should cancel the auction by the curator on the main media``` test 
- [x] Added the ```Should cancel the auction by the owner on the main media``` test
- [x] Unit tests for the ```cancelAuction``` function are passing on the main media

## Files
```sdk/nft/src/zapMedia.ts```
```sdk/nft/test/zapMedia.test.ts```