### PR TITLE
NFT SDK: Test AuctionHouse Custom Media Functionality

### DIFF
--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -129,7 +129,7 @@ describe("AuctionHouse", () => {
         }).to.throw("Constructor: Network Id is not supported.");
       });
 
-      it.only("Should reject if the customMediaAddress is a zero address", async () => {
+      it("Should reject if the customMediaAddress is a zero address", async () => {
         expect(() => {
           new AuctionHouse(1337, signer, ethers.constants.AddressZero);
         }).to.throw(

--- a/sdk/nft/test/auctionHouse.test.ts
+++ b/sdk/nft/test/auctionHouse.test.ts
@@ -128,6 +128,14 @@ describe("AuctionHouse", () => {
           new AuctionHouse(300, signer);
         }).to.throw("Constructor: Network Id is not supported.");
       });
+
+      it.only("Should reject if the customMediaAddress is a zero address", async () => {
+        expect(() => {
+          new AuctionHouse(1337, signer, ethers.constants.AddressZero);
+        }).to.throw(
+          "Invariant failed: AuctionHouse (constructor): The (customMediaAddress) cannot be a zero address."
+        );
+      });
     });
 
     describe("Write Functions", () => {


### PR DESCRIPTION
## Summary 
Closes #437 

## Implementation
 - [x] Added the ```Should reject if the customMediaAddress is a zero address``` inside the ```#constructor``` describe block

## Files
```sdk/nft/test/auctionHouse.test.ts```

## Visual Preview
<img width="949" alt="Screen Shot 2022-02-16 at 10 31 29 PM" src="https://user-images.githubusercontent.com/42893948/154399895-f39b0862-7790-43f2-ae3f-40a657ec3850.png">

