### PR TITLE
NFT Smart Contracts: Issues 460 & 461

### DIFF
--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -325,8 +325,8 @@ contract Media1155 is
         external
         override
         nonReentrant
-        onlyApprovedOrOwner(owner, msg.sender, tokenId)
         onlyExistingToken(tokenId)
+        onlyApprovedOrOwner(owner, msg.sender, tokenId)
     {
         IMarketV2(access.marketContract).removeAsk(tokenId);
     }

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -206,8 +206,10 @@ contract Media1155 is
 
         require(
             _tokenId.length == _amount.length &&
-                _amount.length == bidShares.length
+                _amount.length == bidShares.length,
+            'Media: The tokenId, amount, and bidShares lengths are mismatched'
         );
+
         for (uint256 i = 0; i < bidShares.length; i++) {
             require(
                 bidShares[i].collaborators.length ==

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -296,8 +296,8 @@ contract Media1155 is
         external
         override
         nonReentrant
-        onlyApprovedOrOwner(owner, msg.sender, tokenId)
         onlyExistingToken(tokenId)
+        onlyApprovedOrOwner(owner, msg.sender, tokenId)
     {
         IMarketV2(access.marketContract).setAsk(tokenId, ask);
     }

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -85,7 +85,6 @@ contract Media1155 is
         if (owner != spender) {
             require(
                 ERC1155Upgradeable.isApprovedForAll(owner, spender),
-                // remove revert string before deployment to mainnet
                 'Media: Only approved or owner'
             );
         }

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -80,7 +80,7 @@ contract Media1155 is
         address spender,
         uint256 tokenId
     ) {
-        require(balanceOf(owner, tokenId) > 0);
+        require(balanceOf(owner, tokenId) > 0, 'Media: Token balance is zero');
 
         if (owner != spender) {
             require(
@@ -414,8 +414,8 @@ contract Media1155 is
     {
         require(
             access._creatorTokens[msg.sender].contains(tokenId) &&
-            msg.sender == owner, 
-            "Media: Must be creator of token to burn"
+                msg.sender == owner,
+            'Media: Must be creator of token to burn'
         );
         _burn(msg.sender, tokenId, amount);
     }

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -499,10 +499,12 @@ describe('Media1155 Test', async () => {
     });
 
     describe.only('#removeAsk', () => {
-      it('Should remove the ask', async () => {
+      beforeEach(async () => {
         // Signer[1] sets an ask on tokenId 1
         await media1.setAsk(1, ask, signers[1].address);
+      });
 
+      it('Should remove the ask', async () => {
         // Returns the ask set on tokenId 1
         let postAsk = await zapMarketV2.currentAskForToken(media1.address, 1);
 
@@ -526,6 +528,10 @@ describe('Media1155 Test', async () => {
 
         // The returned currency post removal should equal a zero address
         expect(postRemoveAsk.currency).to.equal(ethers.constants.AddressZero);
+      });
+
+      it('Should reject if the tokenId does not exist', async () => {
+        await media1.removeAsk(4, signers[1].address);
       });
     });
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -427,39 +427,51 @@ describe('Media1155 Test', async () => {
 
     describe('#setAsk', () => {
       it('Should set the ask', async () => {
+        // Signer[1] sets an ask on tokenId 1
         await media1.setAsk(1, ask, signers[1].address);
 
+        // Returns the ask details on tokenId 1
         let currentAsk = await zapMarketV2.currentAskForToken(
           media1.address,
           1
         );
 
+        // The returned ask amount should equal the amount set
         expect(currentAsk.amount.toNumber() == ask.amount);
+
+        // The returned ask currency should equal the currency set
         expect(currentAsk.currency == ask.currency);
       });
 
       it('Should reject if the ask is 0', async () => {
+        // Should reject due to the ask amount not being abe to be equally divided between shares
         await expect(
           media1.setAsk(1, { ...ask, amount: 0 }, signers[1].address)
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
       });
 
       it('Should reject if the ask amount is invalid and cannot be split', async () => {
+        // Cannot set an ask with an invalid amount
         await expect(
           media1.setAsk(1, { ...ask, amount: 7 }, signers[1].address)
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
       });
 
       it('Should reject the ask if the tokenId does not exist', async () => {
+        // Cannot set an ask on a nonexistent tokenId
         await expect(
           media1.setAsk(4, ask, signers[1].address)
         ).to.be.revertedWith('Media: nonexistent token');
       });
 
       it('Should reject the ask if the tokenId exists but the owner does not have a balance of that tokenId', async () => {
+        // Returns signers[1] balance of tokenId 1 before transferring
         const ownerBalance = await media1.balanceOf(signers[1].address, 1);
+
+        // The returned balance should equal 1
         expect(ownerBalance.toNumber()).to.equal(1);
 
+        // Signers[1] transfers tokenId 1 to signers[19] and will no longer have a balance of this token
         await media1.transferFrom(
           signers[1].address,
           signers[19].address,
@@ -467,12 +479,19 @@ describe('Media1155 Test', async () => {
           1
         );
 
+        // Returns signers[1] balance of tokenId 1 after transferring
         const oldOwnerBalance = await media1.balanceOf(signers[1].address, 1);
+
+        // The returned balance should equal 0
         expect(oldOwnerBalance.toNumber()).to.equal(0);
 
+        // Returns signers[19] balance of tokenId 1 after transferring
         const newOwnerBalance = await media1.balanceOf(signers[19].address, 1);
+
+        // The returned balance should equal 1
         expect(newOwnerBalance.toNumber()).to.equal(1);
 
+        // Should reject due to an attempt to set an ask on an existing token with a balance of 0
         await expect(
           media1.setAsk(1, ask, signers[1].address)
         ).to.be.revertedWith('Media: Token balance is zero');

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -425,7 +425,7 @@ describe('Media1155 Test', async () => {
       });
     });
 
-    describe('#setAsk', () => {
+    describe.only('#setAsk', () => {
       it('Should set the ask', async () => {
         await media1.setAsk(1, ask, signers[1].address);
 
@@ -448,6 +448,10 @@ describe('Media1155 Test', async () => {
         await expect(
           media1.setAsk(1, { ...ask, amount: 7 }, signers[1].address)
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
+      });
+
+      it.only('Should reject ', async () => {
+        await media1.setAsk(4, ask, signers[1].address);
       });
     });
 
@@ -725,7 +729,6 @@ describe('Media1155 Test', async () => {
         const balance = await zapTokenBsc.balanceOf(signers[4].address);
         expect(balance.toNumber()).eq(prevBalance.toNumber() - 100);
       });
-    
 
       it('Should not be able to remove a bid twice', async () => {
         await media1.connect(signers[6]).removeBid(1);

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -425,7 +425,7 @@ describe('Media1155 Test', async () => {
       });
     });
 
-    describe.only('#setAsk', () => {
+    describe('#setAsk', () => {
       it('Should set the ask', async () => {
         await media1.setAsk(1, ask, signers[1].address);
 
@@ -450,10 +450,10 @@ describe('Media1155 Test', async () => {
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
       });
 
-      it('Should reject if the owners tokenId balance is zero', async () => {
+      it.only('Should reject the ask if the tokenId does not exist', async () => {
         await expect(
           media1.setAsk(4, ask, signers[1].address)
-        ).to.be.revertedWith('Media: Token balance is zero');
+        ).to.be.revertedWith('Media: nonexistent token');
       });
     });
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -499,7 +499,7 @@ describe('Media1155 Test', async () => {
       });
     });
 
-    describe.only('#removeAsk', () => {
+    describe('#removeAsk', () => {
       beforeEach(async () => {
         // Signer[1] sets an ask on tokenId 1
         await media1.setAsk(1, ask, signers[1].address);
@@ -532,46 +532,64 @@ describe('Media1155 Test', async () => {
       });
 
       it('Should remove ask by the approved', async () => {
+        // Return the pre approve for all status
         const preApprovedStatus = await media1.isApprovedForAll(
           signers[1].address,
           signers[17].address
         );
+
+        // The returned status should equal false
         expect(preApprovedStatus).to.be.false;
 
+        // Return the pre remove ask
         const preRemoveAsk = await zapMarketV2.currentAskForToken(
           media1.address,
           1
         );
 
+        // The returned amount should equal the amount set on ask
         expect(preRemoveAsk.amount).to.equal(ask.amount);
+
+        // The returned amount should equal the currenct set on ask
         expect(preRemoveAsk.currency).to.equal(ask.currency);
 
+        // Signers[1] approves signers[17] for all assets
         await media1.setApprovalForAll(signers[17].address, true);
 
+        // Return the post approval for all status
         const postApprovedStatus = await media1.isApprovedForAll(
           signers[1].address,
           signers[17].address
         );
+
+        // The returned status should equal true
         expect(postApprovedStatus).to.be.true;
 
+        // Signers[17] is approved and able to remove an ask on the behalf of signers[1]
         await media1.connect(signers[17]).removeAsk(1, signers[1].address);
 
+        // Returns the ask post removal
         const postRemoveAsk = await zapMarketV2.currentAskForToken(
           media1.address,
           1
         );
 
+        // The returned amount should equal 0
         expect(postRemoveAsk.amount).to.equal(0);
+
+        // The returned currency should equal a zero address
         expect(postRemoveAsk.currency).to.equal(ethers.constants.AddressZero);
       });
 
       it('Should reject if the tokenId does not exist', async () => {
+        // Cannot remove an ask on a nonexistent tokenId
         await expect(
           media1.removeAsk(4, signers[1].address)
         ).to.be.revertedWith('Media: nonexistent token');
       });
 
       it('Should reject if the caller is not approved or the owner', async () => {
+        // Only the owner or approved can remove an ask
         await expect(
           media1.connect(signers[17]).removeAsk(1, signers[1].address)
         ).to.be.revertedWith('Media: Only approved or owner');

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -17,6 +17,7 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
 import { formatBytes32String } from 'ethers/lib/utils';
 import { DeployResult } from 'hardhat-deploy/dist/types';
+import { execPath } from 'process';
 
 const { BigNumber } = ethers;
 
@@ -534,6 +535,12 @@ describe('Media1155 Test', async () => {
         await expect(
           media1.removeAsk(4, signers[1].address)
         ).to.be.revertedWith('Media: nonexistent token');
+      });
+
+      it('Should reject if the caller is not approved or the owner', async () => {
+        await expect(
+          media1.connect(signers[17]).removeAsk(1, signers[1].address)
+        ).to.be.revertedWith('Media: Only approved or owner');
       });
     });
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -1025,6 +1025,14 @@ describe('Media1155 Test', async () => {
             .acceptBid(1, invalidBid, signers[4].address)
         ).revertedWith('Market: Bid invalid for share splitting');
       });
+
+      it.only('Should reject if the  tokenId exists, but the owner does not have a balance', async () => {
+        await media1.connect(signers[5]).setBid(1, bid, signers[4].address);
+
+        await expect(
+          media1.connect(signers[4]).acceptBid(2, bid, signers[4].address)
+        ).to.be.revertedWith('Media: Token balance is zero');
+      });
     });
 
     describe('#burn', () => {

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -455,6 +455,28 @@ describe('Media1155 Test', async () => {
           media1.setAsk(4, ask, signers[1].address)
         ).to.be.revertedWith('Media: nonexistent token');
       });
+
+      it.only('Should reject the ask if the tokenId exists but the owner does not have a balance of that tokenId', async () => {
+        const ownerBalance = await media1.balanceOf(signers[1].address, 1);
+        expect(ownerBalance.toNumber()).to.equal(1);
+
+        await media1.transferFrom(
+          signers[1].address,
+          signers[19].address,
+          1,
+          1
+        );
+
+        const oldOwnerBalance = await media1.balanceOf(signers[1].address, 1);
+        expect(oldOwnerBalance.toNumber()).to.equal(0);
+
+        const newOwnerBalance = await media1.balanceOf(signers[19].address, 1);
+        expect(newOwnerBalance.toNumber()).to.equal(1);
+
+        await expect(
+          media1.setAsk(1, ask, signers[1].address)
+        ).to.be.revertedWith('Media: Token balance is zero');
+      });
     });
 
     describe('#setAskBatch', () => {

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -531,7 +531,9 @@ describe('Media1155 Test', async () => {
       });
 
       it('Should reject if the tokenId does not exist', async () => {
-        await media1.removeAsk(4, signers[1].address);
+        await expect(
+          media1.removeAsk(4, signers[1].address)
+        ).to.be.revertedWith('Media: nonexistent token');
       });
     });
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -498,6 +498,37 @@ describe('Media1155 Test', async () => {
       });
     });
 
+    describe.only('#removeAsk', () => {
+      it('Should remove the ask', async () => {
+        // Signer[1] sets an ask on tokenId 1
+        await media1.setAsk(1, ask, signers[1].address);
+
+        // Returns the ask set on tokenId 1
+        let postAsk = await zapMarketV2.currentAskForToken(media1.address, 1);
+
+        // The returned amount post ask should equal the amount set
+        expect(postAsk.amount.toNumber()).to.equal(ask.amount);
+
+        // The returned currency post ask should equal the currency set
+        expect(postAsk.currency).to.equal(ask.currency);
+
+        // Signers[1] removes the ask on tokenId 1
+        await media1.removeAsk(1, signers[1].address);
+
+        // Returns the ask set on tokenId 1 after removal
+        let postRemoveAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          1
+        );
+
+        // The returned amount post removal should equal the 0
+        expect(postRemoveAsk.amount.toNumber()).to.equal(0);
+
+        // The returned currency post removal should equal a zero address
+        expect(postRemoveAsk.currency).to.equal(ethers.constants.AddressZero);
+      });
+    });
+
     describe('#setAskBatch', () => {
       it('Should set the ask of batch', async () => {
         await media1.setAskBatch(

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -531,6 +531,40 @@ describe('Media1155 Test', async () => {
         expect(postRemoveAsk.currency).to.equal(ethers.constants.AddressZero);
       });
 
+      it('Should remove ask by the approved', async () => {
+        const preApprovedStatus = await media1.isApprovedForAll(
+          signers[1].address,
+          signers[17].address
+        );
+        expect(preApprovedStatus).to.be.false;
+
+        const preRemoveAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          1
+        );
+
+        expect(preRemoveAsk.amount).to.equal(ask.amount);
+        expect(preRemoveAsk.currency).to.equal(ask.currency);
+
+        await media1.setApprovalForAll(signers[17].address, true);
+
+        const postApprovedStatus = await media1.isApprovedForAll(
+          signers[1].address,
+          signers[17].address
+        );
+        expect(postApprovedStatus).to.be.true;
+
+        await media1.connect(signers[17]).removeAsk(1, signers[1].address);
+
+        const postRemoveAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          1
+        );
+
+        expect(postRemoveAsk.amount).to.equal(0);
+        expect(postRemoveAsk.currency).to.equal(ethers.constants.AddressZero);
+      });
+
       it('Should reject if the tokenId does not exist', async () => {
         await expect(
           media1.removeAsk(4, signers[1].address)

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -450,7 +450,7 @@ describe('Media1155 Test', async () => {
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
       });
 
-      it.only('Should reject if the owners tokenId balance is zero', async () => {
+      it('Should reject if the owners tokenId balance is zero', async () => {
         await expect(
           media1.setAsk(4, ask, signers[1].address)
         ).to.be.revertedWith('Media: Token balance is zero');

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -450,13 +450,13 @@ describe('Media1155 Test', async () => {
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
       });
 
-      it.only('Should reject the ask if the tokenId does not exist', async () => {
+      it('Should reject the ask if the tokenId does not exist', async () => {
         await expect(
           media1.setAsk(4, ask, signers[1].address)
         ).to.be.revertedWith('Media: nonexistent token');
       });
 
-      it.only('Should reject the ask if the tokenId exists but the owner does not have a balance of that tokenId', async () => {
+      it('Should reject the ask if the tokenId exists but the owner does not have a balance of that tokenId', async () => {
         const ownerBalance = await media1.balanceOf(signers[1].address, 1);
         expect(ownerBalance.toNumber()).to.equal(1);
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -450,8 +450,10 @@ describe('Media1155 Test', async () => {
         ).to.be.revertedWith('Market: Ask invalid for share splitting');
       });
 
-      it.only('Should reject ', async () => {
-        await media1.setAsk(4, ask, signers[1].address);
+      it.only('Should reject if the owners tokenId balance is zero', async () => {
+        await expect(
+          media1.setAsk(4, ask, signers[1].address)
+        ).to.be.revertedWith('Media: Token balance is zero');
       });
     });
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -373,6 +373,21 @@ describe('Media1155 Test', async () => {
         expect(balance.eq(1));
       });
 
+      it('Should revert if the tokenId, amount, and bidShares lengths are mismatched', async () => {
+        await expect(
+          media1
+            .connect(signers[4])
+            .mintBatch(
+              signers[4].address,
+              [4, 5, 6],
+              [1],
+              [bidShares, bidShares]
+            )
+        ).to.be.revertedWith(
+          'Media: The tokenId, amount, and bidShares lengths are mismatched'
+        );
+      });
+
       it('Should mint token', async () => {
         await media1
           .connect(signers[5])

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -465,7 +465,7 @@ describe('Media1155 Test', async () => {
         ).to.be.revertedWith('Media: nonexistent token');
       });
 
-      it('Should reject the ask if the tokenId exists but the owner does not have a balance of that tokenId', async () => {
+      it('Should reject if the  tokenId exists, but the owner does not have a balance', async () => {
         // Returns signers[1] balance of tokenId 1 before transferring
         const ownerBalance = await media1.balanceOf(signers[1].address, 1);
 
@@ -1068,6 +1068,31 @@ describe('Media1155 Test', async () => {
         await expect(
           media3.connect(signers[5]).burn(1, 1, signers[3].address)
         ).revertedWith('Media: Only approved or owner');
+      });
+
+      it('Should reject if the  tokenId exists, but the owner does not have a balance', async () => {
+        const ownerPreBal = await media3.balanceOf(signers[3].address, 1);
+        expect(ownerPreBal.toNumber()).to.equal(1);
+
+        const newOwnerPreBal = await media3.balanceOf(signers[17].address, 1);
+        expect(newOwnerPreBal.toNumber()).to.equal(0);
+
+        await media3.transferFrom(
+          signers[3].address,
+          signers[17].address,
+          1,
+          1
+        );
+
+        const ownerPostBal = await media3.balanceOf(signers[3].address, 1);
+        expect(ownerPostBal.toNumber()).to.equal(0);
+
+        const newOwnerBal = await media3.balanceOf(signers[17].address, 1);
+        expect(newOwnerBal.toNumber()).to.equal(1);
+
+        await expect(media3.burn(1, 1, signers[3].address)).to.be.revertedWith(
+          'Media: Token balance is zero'
+        );
       });
 
       it('should burn a token', async () => {

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -1026,7 +1026,7 @@ describe('Media1155 Test', async () => {
         ).revertedWith('Market: Bid invalid for share splitting');
       });
 
-      it.only('Should reject if the  tokenId exists, but the owner does not have a balance', async () => {
+      it('Should reject if the  tokenId exists, but the owner does not have a balance', async () => {
         await media1.connect(signers[5]).setBid(1, bid, signers[4].address);
 
         await expect(


### PR DESCRIPTION
## Description
Closes #460 & #461

## Implementation
 - [x] Added the error string `'Media: Token balance is zero'` to the `require` in the `onlyApprovedOrOwner` modifier
 - [x] Added the `Should reject if the tokenId exists, but the owner does not have a balance` test to the `#setAsk`, `acceptBid`, `burn` functions due to utilizing the modifier. The tests targeted the error string by attempting to set an ask on the tokenId the caller did not have a balance for.
 - [x] Added the `#removeAsk` test section with passing unit tests
 - [x] Added the error string `Media: The tokenId, amount, and bidShares lengths are mismatched` to the require in the `mintBatch` function 

## Files
```hardhat/test/Media1155Test.ts```
```hardhat/contracts/nft/Media1155.sol```

## Visual Preview

The `onlyApprovedOrOwner` modifier now has a `require` with an error string when the token exists but the caller has no balance

<img width="690" alt="Screen Shot 2022-02-28 at 1 38 41 PM" src="https://user-images.githubusercontent.com/42893948/156039323-d4aa8eb6-91c1-47a6-9244-1bd28ccde894.png">


The `mintBatch` function now has a `require` with an error string when the tokenId, amounts, and bidShares arrays are mismatched.

<img width="758" alt="Screen Shot 2022-02-28 at 1 39 32 PM" src="https://user-images.githubusercontent.com/42893948/156039430-42fe1972-066c-4a29-8fdf-be99417aee54.png">
