### PR TITLE
NFT Smart Contracts: Media1155Factory Testing

### DIFF
--- a/hardhat/test/Media1155Factory.test.ts
+++ b/hardhat/test/Media1155Factory.test.ts
@@ -1,0 +1,94 @@
+import { ethers, deployments } from 'hardhat';
+
+import { solidity } from 'ethereum-waffle';
+
+import chai, { expect } from 'chai';
+
+import { Media1155Factory, ZapMarket, ZapMarketV2 } from '../typechain';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { DeployResult } from 'hardhat-deploy/dist/types';
+
+chai.use(solidity);
+
+describe.only('Media1155Factory', () => {
+  let signers: SignerWithAddress[];
+  let zapMarket: ZapMarket;
+  let zapMarketV2: ZapMarketV2;
+  let media1155Factory: Media1155Factory;
+
+  beforeEach(async () => {
+    signers = await ethers.getSigners();
+    await deployments.fixture();
+
+    const zapMarketFixture = await deployments.get('ZapMarket');
+
+    // Creates an instance of ZapMarket
+    zapMarket = (await ethers.getContractAt(
+      'ZapMarket',
+      zapMarketFixture.address,
+      signers[0]
+    )) as ZapMarket;
+
+    // Upgrade ZapMarket to ZapMarketV2
+    const marketUpgradeTx = await deployments.deploy('ZapMarket', {
+      from: signers[0].address,
+      contract: 'ZapMarketV2',
+      proxy: {
+        proxyContract: 'OpenZeppelinTransparentProxy'
+      },
+      log: true
+    });
+
+    // Fetch the address of ZapMarketV2 from the transaction receipt
+    const zapMarketV2Address: string | any =
+      marketUpgradeTx.receipt?.contractAddress;
+
+    // Create the ZapMarketV2 contract instance
+    zapMarketV2 = (await ethers.getContractAt(
+      'ZapMarketV2',
+      zapMarketV2Address,
+      signers[0]
+    )) as ZapMarketV2;
+
+    // Deploy the Media1155 implementation through hardhat-deploy
+    const deployMedia1155ImpTx: DeployResult = await deployments.deploy(
+      'Media1155',
+      {
+        from: signers[0].address,
+        args: []
+      }
+    );
+
+    // Fetch the address of Media1155 implementation from the transaction receipt
+    const media1155ImpAddress: string | any =
+      deployMedia1155ImpTx.receipt?.contractAddress;
+
+    // Deploy the Media1155Factory through hardhat-deploy
+    const deployMedia1155Factory: DeployResult = await deployments.deploy(
+      'Media1155Factory',
+      {
+        from: signers[0].address,
+        proxy: {
+          proxyContract: 'OpenZeppelinTransparentProxy',
+          execute: {
+            methodName: 'initialize',
+            args: [zapMarketV2.address, media1155ImpAddress]
+          }
+        }
+      }
+    );
+
+    // Fetch the Media1155Factory address from the transaction receipt
+    const media1155FactoryAddress: string | any =
+      deployMedia1155Factory.receipt?.contractAddress;
+
+    // Creates the Media1155 contract instance
+    media1155Factory = (await ethers.getContractAt(
+      'Media1155Factory',
+      media1155FactoryAddress,
+      signers[0]
+    )) as Media1155Factory;
+  });
+
+  it('', async () => {});
+});

--- a/hardhat/test/Media1155Factory.test.ts
+++ b/hardhat/test/Media1155Factory.test.ts
@@ -130,6 +130,14 @@ describe.only('Media1155Factory', () => {
       expect(registeredStatus).to.be.true;
     });
 
+    it('Should be configured to ZapMarketV2 after deployment', async () => {
+      const registeredStatus: boolean = await zapMarketV2.isConfigured(
+        mediaAddress
+      );
+
+      expect(registeredStatus).to.be.true;
+    });
+
     it('Should deploy a Media1155 contract through the Media1155Factory and create an instance', async () => {
       // Creates the Media115 contract instance
       const media1155 = (await ethers.getContractAt(

--- a/hardhat/test/Media1155Factory.test.ts
+++ b/hardhat/test/Media1155Factory.test.ts
@@ -16,7 +16,7 @@ import { DeployResult } from 'hardhat-deploy/dist/types';
 
 chai.use(solidity);
 
-describe.only('Media1155Factory', () => {
+describe('Media1155Factory', () => {
   let signers: SignerWithAddress[];
   let zapMarket: ZapMarket;
   let zapMarketV2: ZapMarketV2;
@@ -122,19 +122,41 @@ describe.only('Media1155Factory', () => {
       mediaAddress = eventLog.args?.mediaContract;
     });
 
+    describe('#Ownership', () => {
+      it('Should revert if a caller other than the owner attempts to claim ownership', async () => {
+        // Creates the Media115 contract instance
+        const media1155 = (await ethers.getContractAt(
+          'Media1155',
+          mediaAddress,
+          signers[0]
+        )) as Media1155;
+
+        // Only the deployer of the media
+        await expect(
+          media1155.connect(signers[2]).claimTransferOwnership()
+        ).to.be.revertedWith(
+          'Ownable: Caller is not the appointed owner of this contract'
+        );
+      });
+    });
+
     it('Should be registered to ZapMarketV2 after deployment', async () => {
+      // Returns the registraton status of the deployed media contract
       const registeredStatus: boolean = await zapMarketV2.isRegistered(
         mediaAddress
       );
 
+      // The deployed media contract registration status should equal true
       expect(registeredStatus).to.be.true;
     });
 
     it('Should be configured to ZapMarketV2 after deployment', async () => {
+      // Returns the configure status of the deployed media contract
       const registeredStatus: boolean = await zapMarketV2.isConfigured(
         mediaAddress
       );
 
+      // The deployed media contract configure status should equal true
       expect(registeredStatus).to.be.true;
     });
 

--- a/hardhat/test/Media1155Factory.test.ts
+++ b/hardhat/test/Media1155Factory.test.ts
@@ -122,6 +122,14 @@ describe.only('Media1155Factory', () => {
       mediaAddress = eventLog.args?.mediaContract;
     });
 
+    it('Should be registered to ZapMarketV2 after deployment', async () => {
+      const registeredStatus: boolean = await zapMarketV2.isRegistered(
+        mediaAddress
+      );
+
+      expect(registeredStatus).to.be.true;
+    });
+
     it('Should deploy a Media1155 contract through the Media1155Factory and create an instance', async () => {
       // Creates the Media115 contract instance
       const media1155 = (await ethers.getContractAt(

--- a/hardhat/test/Media1155Factory.test.ts
+++ b/hardhat/test/Media1155Factory.test.ts
@@ -10,10 +10,9 @@ import {
   ZapMarket,
   ZapMarketV2
 } from '../typechain';
+
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { DeployResult } from 'hardhat-deploy/dist/types';
-import { ContractReceipt, ContractTransaction } from 'ethers';
-import { TypedEventFilter } from '../typechain/commons';
 
 chai.use(solidity);
 


### PR DESCRIPTION
## Summary
Closes #466 & 467

## Implementation
 - [x] Created a test file specifically for the Media1155Factory contract
 - [x] Added the `Should revert if a caller other than the owner attempts to claim ownership` test
 - [x] Added the `Should be registered to ZapMarketV2 after deployment` test
 - [x] Added the `Should be configured to ZapMarketV2 after deployment` test
 - [x] Adde the `Should deploy a Media1155 contract through the Media1155Factory and create an instance` test
 
## Issues Found
 - Found that the deployed `deployMedia` function is unable to set its own collection and symbol. This will have to be addressed in another issue and PR

## Visual Preview
<img width="814" alt="Screen Shot 2022-03-03 at 12 01 58 PM" src="https://user-images.githubusercontent.com/42893948/156613953-ec83f2f2-b36c-432b-b74a-2002bbbb4e6f.png">

