### PR TITLE
NFT Smart Contracts: burnBatch functionality

### DIFF
--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -458,6 +458,11 @@ contract Media1155 is
         onlyExistingTokenBatch(tokenId)
         onlyApprovedOrOwnerBatch(owner, msg.sender, tokenId)
     {
+        require(
+            access._creatorTokens[msg.sender].contains(tokenId) &&
+                msg.sender == owner,
+            'Media: Must be creator of token to burn batch'
+        );
         _burnBatch(msg.sender, tokenId, amount);
     }
 

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -101,8 +101,11 @@ contract Media1155 is
         address spender,
         uint256[] calldata tokenId
     ) {
-        for (uint i = 0; i < tokenId.length; i++){
-            require(balanceOf(owner, tokenId[i]) > 0, 'Media: Token balance is zero');
+        for (uint256 i = 0; i < tokenId.length; i++) {
+            require(
+                balanceOf(owner, tokenId[i]) > 0,
+                'Media: Token balance is zero'
+            );
         }
 
         if (owner != spender) {
@@ -200,7 +203,7 @@ contract Media1155 is
         uint256[] memory amounts,
         bytes memory data
     ) internal virtual override {
-        for (uint i = 0; i < ids.length; i++) {
+        for (uint256 i = 0; i < ids.length; i++) {
             IMarketV2(access.marketContract).removeAsk(from, ids[i]);
         }
     }
@@ -448,9 +451,9 @@ contract Media1155 is
      * @param tokenId the list of IDs of the tokens to burn
      */
     function burnBatch(
+        address owner,
         uint256[] calldata tokenId,
-        uint256[] calldata amount,
-        address owner
+        uint256[] calldata amount
     )
         external
         override

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -457,7 +457,9 @@ contract Media1155 is
         nonReentrant
         onlyExistingTokenBatch(tokenId)
         onlyApprovedOrOwnerBatch(owner, msg.sender, tokenId)
-    {}
+    {
+        _burnBatch(msg.sender, tokenId, amount);
+    }
 
     function transferFrom(
         address from,

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -451,7 +451,7 @@ contract Media1155 is
      * @param tokenId the list of IDs of the tokens to burn
      */
     function burnBatch(
-        address owner,
+        address owner, // public address 123
         uint256[] calldata tokenId,
         uint256[] calldata amount
     )
@@ -466,7 +466,7 @@ contract Media1155 is
                 msg.sender == owner,
             'Media: Must be creator of token to burn batch'
         );
-        _burnBatch(msg.sender, tokenId, amount);
+        _burnBatch(owner, tokenId, amount); // Whoever is connected = 456
     }
 
     function transferFrom(

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -451,9 +451,9 @@ contract Media1155 is
      * @param tokenId the list of IDs of the tokens to burn
      */
     function burnBatch(
-        address owner, // public address 123
         uint256[] calldata tokenId,
-        uint256[] calldata amount
+        uint256[] calldata amount,
+        address owner
     )
         external
         override
@@ -461,12 +461,14 @@ contract Media1155 is
         onlyExistingTokenBatch(tokenId)
         onlyApprovedOrOwnerBatch(owner, msg.sender, tokenId)
     {
-        require(
-            access._creatorTokens[msg.sender].contains(tokenId) &&
-                msg.sender == owner,
-            'Media: Must be creator of token to burn batch'
-        );
-        _burnBatch(owner, tokenId, amount); // Whoever is connected = 456
+        for (uint256 i = 0; i < tokenId.length; i++) {
+            require(
+                access._creatorTokens[msg.sender].contains(tokenId[i]),
+                'Media: Must be creator of token to burn batch'
+            );
+
+            _burnBatch(msg.sender, tokenId, amount);
+        }
     }
 
     function transferFrom(

--- a/hardhat/contracts/nft/Media1155.sol
+++ b/hardhat/contracts/nft/Media1155.sol
@@ -463,12 +463,12 @@ contract Media1155 is
     {
         for (uint256 i = 0; i < tokenId.length; i++) {
             require(
-                access._creatorTokens[msg.sender].contains(tokenId[i]),
+                access._creatorTokens[msg.sender].contains(tokenId[i]) &&
+                    msg.sender == owner,
                 'Media: Must be creator of token to burn batch'
             );
-
-            _burnBatch(msg.sender, tokenId, amount);
         }
+        _burnBatch(msg.sender, tokenId, amount);
     }
 
     function transferFrom(

--- a/hardhat/contracts/nft/interfaces/IMedia1155.sol
+++ b/hardhat/contracts/nft/interfaces/IMedia1155.sol
@@ -3,7 +3,6 @@ pragma experimental ABIEncoderV2;
 
 import {IMarketV2} from '../v2/IMarketV2.sol';
 
-
 interface IMedia1155 {
     event URIUpdated(address owner, string _uri);
 
@@ -17,36 +16,63 @@ interface IMedia1155 {
     /**
      * @notice Mint new media for msg.sender.
      */
-    function mint(address to, uint256 tokenId, uint256 amount, IMarketV2.BidShares calldata bidShares)
-        external;
+    function mint(
+        address to,
+        uint256 tokenId,
+        uint256 amount,
+        IMarketV2.BidShares calldata bidShares
+    ) external;
 
     /**
      * @notice Batch mint medias with given IDs and amounts for msg.sender
      */
-    function mintBatch(address _to, uint256[] calldata _tokenId, uint256[] calldata _amount, IMarketV2.BidShares[] calldata bidShares) external;
+    function mintBatch(
+        address _to,
+        uint256[] calldata _tokenId,
+        uint256[] calldata _amount,
+        IMarketV2.BidShares[] calldata bidShares
+    ) external;
 
     /**
      * @notice Transfer the token with the given ID to a given address.
      * Save the previous owner before the transfer, in case there is a sell-on fee.
      * @dev This can only be called by the auction contract specified at deployment
      */
-    function auctionTransfer(uint256 tokenId, uint256 amount, address recipient, address owner) external;
+    function auctionTransfer(
+        uint256 tokenId,
+        uint256 amount,
+        address recipient,
+        address owner
+    ) external;
 
     /**
      * @notice Transfer the tokens with the given IDs and amount to a given address.
      * Save the previous owners before the transfer, in case there is a sell-on fee.
      */
-    function batchAuctionTransfer(uint256[] calldata tokenId, uint256[] calldata amount, address recipient, address owner) external;
+    function batchAuctionTransfer(
+        uint256[] calldata tokenId,
+        uint256[] calldata amount,
+        address recipient,
+        address owner
+    ) external;
 
     /**
      * @notice Set the ask on a piece of media
      */
-    function setAsk(uint256 tokenId, IMarketV2.Ask calldata ask, address owner) external;
+    function setAsk(
+        uint256 tokenId,
+        IMarketV2.Ask calldata ask,
+        address owner
+    ) external;
 
     /**
      * @notice Set the ask on the medias of given IDs
      */
-    function setAskBatch(uint256[] calldata tokenId, IMarketV2.Ask[] calldata ask, address owner) external;
+    function setAskBatch(
+        uint256[] calldata tokenId,
+        IMarketV2.Ask[] calldata ask,
+        address owner
+    ) external;
 
     /**
      * @notice Remove the ask on a piece of media
@@ -61,22 +87,38 @@ interface IMedia1155 {
     /**
      * @notice Set the bid on a piece of media
      */
-    function setBid(uint256 tokenId, IMarketV2.Bid calldata bid, address owner) external;
+    function setBid(
+        uint256 tokenId,
+        IMarketV2.Bid calldata bid,
+        address owner
+    ) external;
 
     /**
      * @notice Remove the bid on a piece of media
      */
     function removeBid(uint256 tokenId) external;
 
-    function acceptBid(uint256 tokenId, IMarketV2.Bid calldata bid, address owner) external;
+    function acceptBid(
+        uint256 tokenId,
+        IMarketV2.Bid calldata bid,
+        address owner
+    ) external;
 
     /**
      * @notice Burn a piece of media
      */
-    function burn(uint256 tokenId, uint256 amount, address owner) external;
+    function burn(
+        uint256 tokenId,
+        uint256 amount,
+        address owner
+    ) external;
 
     /**
      * @notice Burn a batch of media
      */
-    function burnBatch(uint256[] calldata tokenId, uint256[] calldata amount, address owner) external;
+    function burnBatch(
+        uint256[] calldata tokenId,
+        uint256[] calldata amount,
+        address owner
+    ) external;
 }

--- a/hardhat/test/Media1155Factory.test.ts
+++ b/hardhat/test/Media1155Factory.test.ts
@@ -160,30 +160,6 @@ describe('Media1155Factory', () => {
       expect(registeredStatus).to.be.true;
     });
 
-    it('Should emit the MediaContractCreated on ZapMarketV2 with 0x0 values in place of the name & symbol', async () => {
-      //   Creates a filter for the Media1155Deployed event on the Media1155Factory contract
-      const filter = zapMarketV2.filters.MediaContractCreated(
-        mediaAddress,
-        null,
-        null
-      );
-      // Returns the event log for the Media1155Deployed event on the Media1155Factory contract
-      let eventLog = (await zapMarketV2.queryFilter(filter))[0];
-
-      // The emitted address from ZapMarketV2 should equal the emitted address from Media1155Factory
-      expect(eventLog.args?.mediaContract).to.equal(mediaAddress);
-
-      // The emitted name from ZapMarketV2 should be an empty string due to the ERC1155
-      // not supporting a symbol() function in its interface
-      expect(ethers.utils.parseBytes32String(eventLog.args?.name)).to.equal('');
-
-      // The emitted name from ZapMarketV2 should be an empty string due to the ERC1155
-      // not supporting a name() function in its interface
-      expect(ethers.utils.parseBytes32String(eventLog.args?.symbol)).to.equal(
-        ''
-      );
-    });
-
     it('Should deploy a Media1155 contract through the Media1155Factory and create an instance', async () => {
       // Creates the Media115 contract instance
       const media1155 = (await ethers.getContractAt(

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -1361,7 +1361,13 @@ describe('Media1155 Test', async () => {
 
     describe('#burnBatch', () => {
       beforeEach(async () => {
-        await media3.mintBatch(signers[3].address, [1], [10], [bidShares]);
+        // Signers[3] mints a batch tokenId's
+        await media3.mintBatch(
+          signers[3].address,
+          [1, 2],
+          [10, 4],
+          [bidShares, bidShares]
+        );
       });
 
       it.only('should revert when the caller is the owner, but not creator', async () => {
@@ -1371,13 +1377,29 @@ describe('Media1155 Test', async () => {
           .connect(signers[3])
           .transferFrom(signers[3].address, signers[4].address, 1, 10);
 
-        await expect(
-          media3.connect(signers[4]).burnBatch([1], [10], signers[4].address)
-        ).to.be.revertedWith('Media: Must be creator of token to burn batch');
+        await media3
+          .connect(signers[3])
+          .transferFrom(signers[3].address, signers[4].address, 2, 4);
 
+        // Signers[4] is the current owner of the tokenId but cannot burn them due to not being
+        // the original minter
         // await expect(
-        //   media3.connect(signers[4]).burnBatch([1], [1], signers[4].address)
-        // ).revertedWith('Media: Must be creator of token to burn batch');
+        media3
+          .connect(signers[3])
+          .burnBatch([1, 2], [10, 4], signers[4].address);
+        // ).to.be.revertedWith('Media: Must be creator of token to burn batch');
+      });
+
+      it('should revert when the caller is approved, but the owner is not the creator', async () => {
+        await media3
+          .connect(signers[3])
+          .transferFrom(signers[3].address, signers[4].address, 1, 10);
+
+        await media3
+          .connect(signers[4])
+          .setApprovalForAll(signers[5].address, true);
+
+        media3.connect(signers[5]).burnBatch([1], [10], signers[4].address);
       });
     });
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -1227,8 +1227,14 @@ describe('Media1155 Test', async () => {
       });
     });
 
-    describe.only('#burnBatch', () => {
+    describe('#burnBatch', () => {
+      beforeEach(async () => {
+        await media3.mint(signers[3].address, 1, 1, bidShares);
+      });
 
+      it.only('should revert when the caller is the owner, but not creator', async () => {
+
+  
     });
 
     describe('#burn', () => {

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -548,7 +548,7 @@ describe('Media1155 Test', async () => {
         let balance2 = await media1.balanceOf(owner2, 1);
 
         expect(balance2).eq(1);
-        
+
         // Signer[1] sets an ask on tokenId 1
         await media1.setAsk(1, ask, owner1);
 
@@ -566,9 +566,9 @@ describe('Media1155 Test', async () => {
         expect(currentAsk1.currency == ask.currency);
 
         let currentAsk2 = await zapMarketV2.currentAskForToken(
-            media1.address,
-            owner2,
-            1
+          media1.address,
+          owner2,
+          1
         );
 
         // The returned ask amount should equal the amount set
@@ -576,15 +576,17 @@ describe('Media1155 Test', async () => {
 
         // The returned ask currency should equal the currency set
         expect(currentAsk2.currency == '');
-        
+
         // Set a new ask for owner 2
-        await media1.connect(signers[2]).setAsk(1, {...ask, amount: 300}, owner2);
+        await media1
+          .connect(signers[2])
+          .setAsk(1, { ...ask, amount: 300 }, owner2);
 
         // confirm if the correct ask was set
         currentAsk2 = await zapMarketV2.currentAskForToken(
-            media1.address,
-            owner2,
-            1
+          media1.address,
+          owner2,
+          1
         );
 
         // The returned ask amount should equal the amount set
@@ -595,9 +597,9 @@ describe('Media1155 Test', async () => {
 
         // confirm owner1's ask remains the same
         currentAsk1 = await zapMarketV2.currentAskForToken(
-            media1.address,
-            owner1,
-            1
+          media1.address,
+          owner1,
+          1
         );
 
         // The returned ask amount should equal the amount set
@@ -616,7 +618,11 @@ describe('Media1155 Test', async () => {
 
       it('Should remove the ask', async () => {
         // Returns the ask set on tokenId 1
-        let postAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 1);
+        let postAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          1
+        );
 
         // The returned amount post ask should equal the amount set
         expect(postAsk.amount.toNumber()).to.equal(ask.amount);
@@ -709,119 +715,146 @@ describe('Media1155 Test', async () => {
     });
 
     describe('#removeAskBatch', () => {
-        beforeEach(async () => {
-            await media1.setAskBatch(
-                [1, 2, 3],
-                [ask, ask, ask],
-                signers[1].address
-            );
-    
-            let currentAsk = await zapMarketV2.currentAskForToken(
-                media1.address,
-                signers[1].address,
-                1
-            );
-    
-            expect(currentAsk.amount.toNumber() == ask.amount);
-            expect(currentAsk.currency == ask.currency);
-    
-            currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 2);
-            expect(currentAsk.amount.toNumber() == ask.amount);
-            expect(currentAsk.currency == ask.currency);
-    
-            currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 3);
-            expect(currentAsk.amount.toNumber() == ask.amount);
-            expect(currentAsk.currency == ask.currency);
-        });
+      beforeEach(async () => {
+        await media1.setAskBatch(
+          [1, 2, 3],
+          [ask, ask, ask],
+          signers[1].address
+        );
 
-        it('Should remove a batch of asks', async () => {
-            await media1.removeAskBatch(
-                [1,2,3],
-                signers[1].address
-            );
+        let currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          1
+        );
 
-            let currentAsk = await zapMarketV2.currentAskForToken(
-                media1.address,
-                signers[1].address,
-                1
-            );
-    
-            expect(currentAsk.amount.toNumber() == 0);
-            expect(currentAsk.currency == '');
-    
-            currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 2);
-            expect(currentAsk.amount.toNumber() == 0);
-            expect(currentAsk.currency == '');
-    
-            currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 3);
-            expect(currentAsk.amount.toNumber() == 0);
-            expect(currentAsk.currency == '');
+        expect(currentAsk.amount.toNumber() == ask.amount);
+        expect(currentAsk.currency == ask.currency);
 
-            // event listening
-            const zapMarketFilter: EventFilter = zapMarketV2.filters.AskRemovedBatch(
-                null,
-                null,
-                null
-            );
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          2
+        );
+        expect(currentAsk.amount.toNumber() == ask.amount);
+        expect(currentAsk.currency == ask.currency);
 
-            const event: Event = (
-            await zapMarketV2.queryFilter(zapMarketFilter)
-            ).slice(-1)[0];
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          3
+        );
+        expect(currentAsk.amount.toNumber() == ask.amount);
+        expect(currentAsk.currency == ask.currency);
+      });
 
-            const logDescription = zapMarketV2.interface.parseLog(event);
+      it('Should remove a batch of asks', async () => {
+        await media1.removeAskBatch([1, 2, 3], signers[1].address);
 
-            expect(logDescription.args.mediaContract).to.eq(media1.address);
-            
-            expect(logDescription.args.tokenId[0].toNumber()).to.eq(1);
+        let currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          1
+        );
 
-            expect(logDescription.args.tokenId[1].toNumber()).to.eq(2);
+        expect(currentAsk.amount.toNumber() == 0);
+        expect(currentAsk.currency == '');
 
-            expect(logDescription.args.tokenId[2].toNumber()).to.eq(3);
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          2
+        );
+        expect(currentAsk.amount.toNumber() == 0);
+        expect(currentAsk.currency == '');
 
-            expect(logDescription.args.ask[0].amount.toNumber()).to.eq(ask.amount);
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          3
+        );
+        expect(currentAsk.amount.toNumber() == 0);
+        expect(currentAsk.currency == '');
 
-            expect(logDescription.args.ask[1].amount.toNumber()).to.eq(ask.amount);
+        // event listening
+        const zapMarketFilter: EventFilter =
+          zapMarketV2.filters.AskRemovedBatch(null, null, null);
 
-            expect(logDescription.args.ask[2].amount.toNumber()).to.eq(ask.amount);
-        });
+        const event: Event = (
+          await zapMarketV2.queryFilter(zapMarketFilter)
+        ).slice(-1)[0];
 
-        it('Should remove a batch of asks as approved', async () => {
-            await media1.connect(signers[1]).setApprovalForAll(signers[7].address, true);
+        const logDescription = zapMarketV2.interface.parseLog(event);
 
-            await media1.connect(signers[7]).removeAskBatch(
-                [1,2,3],
-                signers[1].address
-            );
+        expect(logDescription.args.mediaContract).to.eq(media1.address);
 
-            let currentAsk = await zapMarketV2.currentAskForToken(
-                media1.address,
-                signers[1].address,
-                1
-            );
-    
-            expect(currentAsk.amount.toNumber() == 0);
-            expect(currentAsk.currency == '');
-    
-            currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 2);
-            expect(currentAsk.amount.toNumber() == 0);
-            expect(currentAsk.currency == '');
-    
-            currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 3);
-            expect(currentAsk.amount.toNumber() == 0);
-            expect(currentAsk.currency == '');
-        });
+        expect(logDescription.args.tokenId[0].toNumber()).to.eq(1);
 
-        it('Should revert if caller is not owner or approved', async () => {
-            await expect(media1.connect(signers[5]).removeAskBatch([1,2,3], signers[1].address)).to.be.revertedWith("Media: Only approved or owner");
-        });
+        expect(logDescription.args.tokenId[1].toNumber()).to.eq(2);
 
-        it('Should revert if owner does not have a balance', async () => {
-            await expect(media1.removeAskBatch([1,2,3], signers[3].address)).to.be.revertedWith("Media: Token balance is zero");
-        });
+        expect(logDescription.args.tokenId[2].toNumber()).to.eq(3);
 
-        it ('Should revert if token does not exist', async () => {
-            await expect(media1.removeAskBatch([7], signers[1].address)).to.be.revertedWith("Media: nonexistent token");
-        });
+        expect(logDescription.args.ask[0].amount.toNumber()).to.eq(ask.amount);
+
+        expect(logDescription.args.ask[1].amount.toNumber()).to.eq(ask.amount);
+
+        expect(logDescription.args.ask[2].amount.toNumber()).to.eq(ask.amount);
+      });
+
+      it('Should remove a batch of asks as approved', async () => {
+        await media1
+          .connect(signers[1])
+          .setApprovalForAll(signers[7].address, true);
+
+        await media1
+          .connect(signers[7])
+          .removeAskBatch([1, 2, 3], signers[1].address);
+
+        let currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          1
+        );
+
+        expect(currentAsk.amount.toNumber() == 0);
+        expect(currentAsk.currency == '');
+
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          2
+        );
+        expect(currentAsk.amount.toNumber() == 0);
+        expect(currentAsk.currency == '');
+
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          3
+        );
+        expect(currentAsk.amount.toNumber() == 0);
+        expect(currentAsk.currency == '');
+      });
+
+      it('Should revert if caller is not owner or approved', async () => {
+        await expect(
+          media1
+            .connect(signers[5])
+            .removeAskBatch([1, 2, 3], signers[1].address)
+        ).to.be.revertedWith('Media: Only approved or owner');
+      });
+
+      it('Should revert if owner does not have a balance', async () => {
+        await expect(
+          media1.removeAskBatch([1, 2, 3], signers[3].address)
+        ).to.be.revertedWith('Media: Token balance is zero');
+      });
+
+      it('Should revert if token does not exist', async () => {
+        await expect(
+          media1.removeAskBatch([7], signers[1].address)
+        ).to.be.revertedWith('Media: nonexistent token');
+      });
     });
 
     describe('#setAskBatch', () => {
@@ -841,29 +874,34 @@ describe('Media1155 Test', async () => {
         expect(currentAsk.amount.toNumber() == ask.amount);
         expect(currentAsk.currency == ask.currency);
 
-        currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 2);
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          2
+        );
         expect(currentAsk.amount.toNumber() == ask.amount);
         expect(currentAsk.currency == ask.currency);
 
-        currentAsk = await zapMarketV2.currentAskForToken(media1.address, signers[1].address, 3);
+        currentAsk = await zapMarketV2.currentAskForToken(
+          media1.address,
+          signers[1].address,
+          3
+        );
         expect(currentAsk.amount.toNumber() == ask.amount);
         expect(currentAsk.currency == ask.currency);
 
         // event listening
-        const zapMarketFilter: EventFilter = zapMarketV2.filters.AskCreatedBatch(
-            null,
-            null,
-            null
-        );
+        const zapMarketFilter: EventFilter =
+          zapMarketV2.filters.AskCreatedBatch(null, null, null);
 
         const event: Event = (
-        await zapMarketV2.queryFilter(zapMarketFilter)
+          await zapMarketV2.queryFilter(zapMarketFilter)
         ).slice(-1)[0];
 
         const logDescription = zapMarketV2.interface.parseLog(event);
 
         expect(logDescription.args.mediaContract).to.eq(media1.address);
-        
+
         expect(logDescription.args.tokenId[0].toNumber()).to.eq(1);
 
         expect(logDescription.args.tokenId[1].toNumber()).to.eq(2);
@@ -1323,17 +1361,23 @@ describe('Media1155 Test', async () => {
 
     describe('#burnBatch', () => {
       beforeEach(async () => {
-        await media3.mint(signers[3].address, 1, 1, bidShares);
+        await media3.mintBatch(signers[3].address, [1], [10], [bidShares]);
       });
 
       it.only('should revert when the caller is the owner, but not creator', async () => {
+        // Signers[3] transfers all 10 of tokenId 1 to signers[4]
+        // Signers[4] is the now the owner of the 10 tokenId's
         await media3
           .connect(signers[3])
-          .transferFrom(signers[3].address, signers[4].address, 1, 1);
+          .transferFrom(signers[3].address, signers[4].address, 1, 10);
 
         await expect(
-          media3.connect(signers[4]).burnBatch([1], [1], signers[4].address)
-        ).revertedWith('Media: Must be creator of token to burn batch');
+          media3.connect(signers[4]).burnBatch([1], [10], signers[4].address)
+        ).to.be.revertedWith('Media: Must be creator of token to burn batch');
+
+        // await expect(
+        //   media3.connect(signers[4]).burnBatch([1], [1], signers[4].address)
+        // ).revertedWith('Media: Must be creator of token to burn batch');
       });
     });
 
@@ -1419,7 +1463,11 @@ describe('Media1155 Test', async () => {
             .transferFrom(signers[4].address, signers[5].address, 1, 1)
         );
 
-        const askB = await zapMarketV2.currentAskForToken(media2.address, signers[4].address, 1);
+        const askB = await zapMarketV2.currentAskForToken(
+          media2.address,
+          signers[4].address,
+          1
+        );
 
         expect(await askB.amount.toNumber()).eq(0);
 

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -1227,6 +1227,10 @@ describe('Media1155 Test', async () => {
       });
     });
 
+    describe.only('#burnBatch', () => {
+
+    });
+
     describe('#burn', () => {
       beforeEach(async () => {
         await media3.mint(signers[3].address, 1, 1, bidShares);

--- a/hardhat/test/Media1155Test.ts
+++ b/hardhat/test/Media1155Test.ts
@@ -1233,8 +1233,14 @@ describe('Media1155 Test', async () => {
       });
 
       it.only('should revert when the caller is the owner, but not creator', async () => {
+        await media3
+          .connect(signers[3])
+          .transferFrom(signers[3].address, signers[4].address, 1, 1);
 
-  
+        await expect(
+          media3.connect(signers[4]).burnBatch([1], [1], signers[4].address)
+        ).revertedWith('Media: Must be creator of token to burn batch');
+      });
     });
 
     describe('#burn', () => {


### PR DESCRIPTION
## Summary
@aidnii @kimanikelly 
Closes #453 

## Implementation
  - [x] caller must be creator
  - [x] only existing tokens
  - [x] caller must have the correct balance of tokens
  - [x] burn the correct amount of tokens
  - [x] Added passing unit tests to reflect the `burnBatch` changes

## Files
`hardhat/contracts/nft/Media1155.sol`
`hardhat/test/Media1155Test.ts`

## Visual Preview

<img width="903" alt="Screen Shot 2022-03-03 at 6 01 49 PM" src="https://user-images.githubusercontent.com/42893948/156667400-3106a591-519b-49dd-b7a1-139dd8fe72e4.png">

